### PR TITLE
v0.3.1: Victoria 3 feels right, color picker, Discord release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,6 +108,22 @@ jobs:
           prerelease: true
           generate_release_notes: true
 
+      # Announce the release in the Discord server's #toolkit-updates, pinging
+      # the @Paradox Toolkit role. DISCORD_RELEASE_WEBHOOK is a plain Discord
+      # webhook URL (repo secret). Missing secret = silent skip; a failed post
+      # warns but never fails a release that already shipped.
+      - name: Announce on Discord (tag builds)
+        if: startsWith(github.ref, 'refs/tags/v')
+        env:
+          WEBHOOK: ${{ secrets.DISCORD_RELEASE_WEBHOOK }}
+        run: |
+          [ -z "$WEBHOOK" ] && exit 0
+          jq -n --arg tag "$GITHUB_REF_NAME" --arg repo "$GITHUB_REPOSITORY" \
+            '{content: "<@&1534329963933864079> **Paradox Toolkit \($tag)** is out.\nhttps://github.com/\($repo)/releases/tag/\($tag)",
+              allowed_mentions: {roles: ["1534329963933864079"]}}' \
+            | curl -sf -H "Content-Type: application/json" -d @- "$WEBHOOK" \
+            || echo "::warning::Discord release announcement failed"
+
       - name: Publish to Marketplace
         if: github.event_name == 'workflow_dispatch' && inputs.publish
         working-directory: packages/vscode

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,6 +97,24 @@ jobs:
             px-lsp-server-*.tar.gz
             px-lsp-win-x64-*.zip
 
+      # The human-written notes (docs/release-notes-<version>.md) are the
+      # release body AND the Discord post. The H1 and the trailing "Full
+      # changelog" pointer are dropped: the release page shows the version
+      # already, and the Discord embed appends its own changelog link. A tag
+      # with no notes file falls back to GitHub's generated commit list.
+      - name: Collect release notes (tag builds)
+        if: startsWith(github.ref, 'refs/tags/v')
+        id: notes
+        run: |
+          FILE="docs/release-notes-${GITHUB_REF_NAME#v}.md"
+          if [ -f "$FILE" ]; then
+            sed -e '1{/^# /d}' -e '/^### Full changelog/,$d' "$FILE" | sed -e '/./,$!d' > release-body.md
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::$FILE missing, release body falls back to generated notes"
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: GitHub Release (tag builds)
         if: startsWith(github.ref, 'refs/tags/v')
         uses: softprops/action-gh-release@v2
@@ -106,21 +124,37 @@ jobs:
             px-lsp-server-*.tar.gz
             px-lsp-win-x64-*.zip
           prerelease: true
-          generate_release_notes: true
+          body_path: ${{ steps.notes.outputs.found == 'true' && 'release-body.md' || '' }}
+          generate_release_notes: ${{ steps.notes.outputs.found != 'true' }}
 
       # Announce the release in the Discord server's #toolkit-updates, pinging
       # the @Paradox Toolkit role. DISCORD_RELEASE_WEBHOOK is a plain Discord
-      # webhook URL (repo secret). Missing secret = silent skip; a failed post
-      # warns but never fails a release that already shipped.
+      # webhook URL (repo secret). The notes ride in an embed (4096-char
+      # description cap; longer notes are cut at 3900 on a line boundary), the
+      # ping and the link stay in `content` so they render above the embed.
+      # Missing secret = silent skip; a failed post warns but never fails a
+      # release that already shipped.
       - name: Announce on Discord (tag builds)
         if: startsWith(github.ref, 'refs/tags/v')
         env:
           WEBHOOK: ${{ secrets.DISCORD_RELEASE_WEBHOOK }}
+          NOTES_FOUND: ${{ steps.notes.outputs.found }}
         run: |
           [ -z "$WEBHOOK" ] && exit 0
-          jq -n --arg tag "$GITHUB_REF_NAME" --arg repo "$GITHUB_REPOSITORY" \
-            '{content: "<@&1534329963933864079> **Paradox Toolkit \($tag)** is out.\nhttps://github.com/\($repo)/releases/tag/\($tag)",
-              allowed_mentions: {roles: ["1534329963933864079"]}}' \
+          URL="https://github.com/$GITHUB_REPOSITORY/releases/tag/$GITHUB_REF_NAME"
+          if [ "$NOTES_FOUND" = "true" ]; then
+            NOTES=$(head -c 3900 release-body.md)
+            if [ "$(wc -c < release-body.md)" -gt 3900 ]; then
+              NOTES=$(printf '%s' "$NOTES" | sed '$d')
+            fi
+          else
+            NOTES="See the release page for the changes."
+          fi
+          jq -n --arg tag "$GITHUB_REF_NAME" --arg url "$URL" --arg notes "$NOTES" \
+            '{content: "<@&1534329963933864079> **Paradox Toolkit \($tag)** is out.\n\($url)",
+              allowed_mentions: {roles: ["1534329963933864079"]},
+              embeds: [{title: "What changed in \($tag)", url: $url, color: 7506394,
+                        description: ($notes + "\n\n[Full changelog](https://github.com/JDeffner/paradox-modding-toolkit/blob/main/packages/vscode/CHANGELOG.md)")}]}' \
             | curl -sf -H "Content-Type: application/json" -d @- "$WEBHOOK" \
             || echo "::warning::Discord release announcement failed"
 

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@ docs/*
 # What a workspace costs and how to configure a big one; public, linked from
 # the extension README and the CHANGELOG.
 !docs/PERFORMANCE.md
+# Per-release notes: release.yml reads docs/release-notes-<version>.md as the
+# GitHub Release body and the Discord announcement.
+!docs/release-notes-*.md
 # Machine-specific paths for scripts/tests (copy dev-paths.example.json).
 dev-paths.json
 # Build-time copy of the server bundle data (scripts/copy-server.mjs).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,56 @@
+# CLAUDE.md
+
+## Branch rules (hard, no exceptions)
+
+`main` is the public face of this repo. Treat it as read-only.
+
+- **Never commit on `main`.** Check what branch you are on before the first edit.
+- **Never push to `main`.** Not `git push origin main`, not `--force`, not
+  `--force-with-lease`, not a push that fast-forwards it. If you believe a push
+  to `main` is the only way, stop and ask Joel instead.
+- **Never work in a worktree that has `main` checked out.**
+- `main` changes ONLY through a squash-merged pull request.
+
+This rule exists because the whole 0.3.1 cycle was committed straight onto
+`main` and then pushed: 11 working commits, 103 files, on the public branch
+that is supposed to carry one commit per release. Recovering it needed a
+history rewrite of a public branch.
+
+## How to land work
+
+1. Branch first. Never start from a `main` checkout.
+   ```bash
+   git checkout -b <type>/<short-name>   # feat/, fix/, docs/, chore/
+   ```
+2. Commit on that branch, as many commits as the work needs. Granular history
+   belongs here, not on `main`.
+3. Push the branch, then open the pull request:
+   ```bash
+   git push -u origin <branch>
+   gh pr create --base main --title "<title>" --body "<why, with numbers>"
+   ```
+4. **Stop there and hand Joel the PR link.** Opening the PR is the deliverable.
+   The squash merge is Joel's call, not yours. Merge only if he says so, and
+   then only with:
+   ```bash
+   gh pr merge --squash
+   ```
+
+The squash produces exactly one commit on `main` per landed change, which is
+the same result the release model has always wanted.
+
+## Relationship to AGENTS.md
+
+`AGENTS.md` "Releasing" documents the older recipe: `git read-tree -u --reset
+monorepo` on a `main` checkout, then `git push origin main`. **That recipe is
+superseded.** Do not run it. Cut releases through a squash PR like any other
+change. The rest of AGENTS.md (invariants, repo map, build/test, data
+regeneration) still stands and is required reading.
+
+## Current branches
+
+| Branch | What it is |
+|---|---|
+| `main` | Public face. One squash commit per landed change. Read-only to you. |
+| `dev-0.3.1` | The 0.3.1 working history, moved off `main` on 2026-08-20. Active work branch. |
+| `monorepo` | Older full working history, pushed to `origin/monorepo`. |

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -33,7 +33,7 @@ a client written against 0.3.0 keeps working unchanged.
 - Standard LSP: the server implements completion (+resolve), signatureHelp,
   hover, definition, references, rename (+prepare), documentSymbol,
   workspaceSymbol, codeAction, inlayHint, foldingRange, documentFormatting,
-  semanticTokens (full), publishDiagnostics, and workDoneProgress for the
+  documentColor + colorPresentation, semanticTokens (full), publishDiagnostics, and workDoneProgress for the
   vanilla scan.
 - Document sync: `Incremental`, with `openClose` and `save`. A `didChange`
   content change carrying no `range` (a full-document replacement) is accepted

--- a/docs/release-notes-0.3.0.md
+++ b/docs/release-notes-0.3.0.md
@@ -1,0 +1,30 @@
+## Paradox Modding Toolkit 0.3.0 (beta)
+
+The CK3 Modding Toolkit is now the **Paradox Modding Toolkit**, and it speaks
+three games. This is the first release under the new name, the new extension ID
+and the new monorepo layout, and it is the largest release so far.
+
+> **Moving from the old extension:** this ships as a new listing,
+> `JDeffner.px-toolkit`. Install it and uninstall the old
+> `JDeffner.ck3-modding-toolkit`, which is now deprecated. Your settings move
+> with a rename: every `ck3.*` setting is now `px.*` (`ck3.gamePath` becomes
+> `px.gamePath`), commands are prefixed **Paradox** instead of **CK3**, and the
+> inline suppression comment is `# px:ignore` instead of `# ck3m:ignore`.
+> Nothing about your mod files changes.
+
+### Full changelog
+
+Every change in this release, with the reasoning behind it, is in
+[CHANGELOG.md](https://github.com/JDeffner/paradox-modding-toolkit/blob/main/packages/vscode/CHANGELOG.md).
+The same text is the Changelog tab on the
+[Marketplace listing](https://marketplace.visualstudio.com/items/JDeffner.px-toolkit/changelog).
+
+The short version: Victoria 3 is first-class, Europa Universalis V ships as a
+community-sourced profile, and CK3 users need to change nothing. New since
+0.1.x: a Project panel, an event simulator, a visual GUI editor, a redesigned
+event graph, bundled `script_docs` snapshots per game, full-depth outlines, and
+a standalone language server you can run from neovim, Zed, Helix or your own
+application.
+
+Beta means young, not unusable. It is what I mod with daily. Tell me what
+breaks: [issues](https://github.com/JDeffner/paradox-modding-toolkit/issues).

--- a/docs/release-notes-0.3.1.md
+++ b/docs/release-notes-0.3.1.md
@@ -1,0 +1,68 @@
+# Paradox Modding Toolkit 0.3.1 (beta)
+
+0.3.0 said "three games"; 0.3.1 makes the second one feel like the first.
+This release was driven by an audit of the toolkit against a live Victoria 3
+install and three real workshop mods (including the Community Mod Framework),
+plus the sidebar and hotkey work.
+
+### Victoria 3, actually good now
+
+- **Completion offers the right key.** On 1215 real cursor positions in
+  three workshop mods, the correct key was never offered in 77.1% of them
+  before, 0.2% after. Vic3 now has a structures layer, scope inference no
+  longer assumes a CK3 character root, and 12 reference prefixes resolve 446
+  previously dead sites.
+- The **GUI editor draws Vic3 files**: declared types preview without an
+  instance, and multi-line data functions no longer break the parser (202
+  errors across 23 CMF files, gone).
+- The **error.log watcher fires**: wrong folder and a CK3-only line parser
+  meant it silently never reported anything on Vic3/EU5. In-game script and
+  GUI errors are squiggles again.
+- The **GUI editor opens** (the Vic3 calibration shipped in 0.3.0; a stale
+  gate still refused it).
+- **Real mod names** instead of workshop folder ids, everywhere.
+- **New Content, Create Mod Descriptor and translation mods** produce content
+  Victoria 3 actually loads: `country_event` templates, real vanilla
+  on_actions, `.metadata/metadata.json` descriptors with completion and
+  validation.
+- **129 indexed folders** (naval, mobilization, AI, buy packages, console
+  macros, +2186 vanilla definitions) and `.gui` type/template definitions.
+- **`Paradox: Add Dependency Mod`** turns "hand-edit px.parentMods" into a
+  quick-pick over your declared dependencies and the Steam workshop folder.
+  Dependency mods (frameworks like CMF) now feed every completion layer,
+  including `data_binding` macros.
+
+### EU5
+
+Everything buildable without owning the game: stage-root aware scaffolds,
+metadata descriptors, honest copy, tiger commands hidden (no tiger exists).
+The error.log path and launch flags follow the engine convention but are
+**not yet verified on a live install**; a data-collection pack is out with a
+volunteer and the results land in 0.3.2.
+
+### Panel, hotkeys, icons
+
+- Every tool now has a **row in the Project panel** (new "Open" group), and
+  the rows are **customizable** (`Paradox: Customize Project Panel Rows`).
+- **Five chords**: Ctrl+Alt+G graph, D format docs, W widget tree, S
+  simulate, R mod report. Rebindable; a title-bar button opens the shortcuts
+  UI pre-filtered.
+- **CK3 script files wear the crown again**; Victoria 3 and EU5 get the PX
+  box, and the status bar names the game ("Paradox Script (Victoria 3)").
+  Same language, same server, per-game identity.
+
+### Color picker
+
+Every `rgb { }`, `hsv { }`, `hsv360 { }`, `hex { }` and `color = { }` in
+script and `.gui` gets a swatch; click it for the native picker, click the
+label to cycle formats. Measured against vanilla: Jomini `hsv` hue is 0..1,
+not 0..360, which other tools get wrong. Ships over standard LSP, so every
+editor gets it. (Closes #11.)
+
+### Full changelog
+
+Every change with its reasoning:
+[CHANGELOG.md](https://github.com/JDeffner/paradox-modding-toolkit/blob/main/packages/vscode/CHANGELOG.md).
+
+Beta means young, not unusable. Tell me what breaks:
+[issues](https://github.com/JDeffner/paradox-modding-toolkit/issues).

--- a/packages/server/src/features/colors.ts
+++ b/packages/server/src/features/colors.ts
@@ -30,7 +30,9 @@ import {
 } from "../parser";
 import { getParse } from "../parseCache";
 
-export type ColorFormat = "rgb" | "hsv" | "hsv360" | "hex" | "float" | "int";
+/** `rgbf` is a tagged rgb block written with 0..1 components (vanilla named_colors
+ *  does this); it is offered back in the same notation, never as 0..255. */
+export type ColorFormat = "rgb" | "rgbf" | "hsv" | "hsv360" | "hex" | "float" | "int";
 
 const TAGS: ReadonlySet<string> = new Set(["rgb", "hsv", "hsv360", "hex"]);
 
@@ -114,7 +116,7 @@ function rgbComponents(c: number[], format: ColorFormat): Decoded {
       blue: clamp01(c[2] / k),
       alpha: alpha ? clamp01(c[3] / k) : 1,
     },
-    format: format === "rgb" ? "rgb" : floats ? "float" : "int",
+    format: format === "rgb" ? (floats ? "rgbf" : "rgb") : floats ? "float" : "int",
     alpha,
   };
 }
@@ -126,7 +128,8 @@ function decode(value: ValueNode, keyIsColor: boolean): Decoded | null {
     if (!TAGS.has(tag)) return null;
     if (tag === "hex") {
       const s = value.block.statements;
-      if (s.length !== 1 || s[0].kind !== "value" || s[0].value.kind !== "scalar") return null;
+      if (s.length !== 1 || s[0].kind !== "value" || s[0].value.kind !== "scalar" || s[0].value.quoted)
+        return null;
       const m = /^(?:0x)?([0-9a-fA-F]{6})$/.exec(s[0].value.text);
       if (!m) return null;
       const n = parseInt(m[1], 16);
@@ -192,6 +195,8 @@ export function renderColor(color: Color, format: ColorFormat, alpha: boolean): 
   switch (format) {
     case "rgb":
       return `rgb { ${i(r)} ${i(g)} ${i(b)}${withAlpha ? ` ${i(a)}` : ""} }`;
+    case "rgbf":
+      return `rgb { ${f(r)} ${f(g)} ${f(b)}${withAlpha ? ` ${f(a)}` : ""} }`;
     case "int":
       return `{ ${i(r)} ${i(g)} ${i(b)}${withAlpha ? ` ${i(a)}` : ""} }`;
     case "float":

--- a/packages/server/src/features/colors.ts
+++ b/packages/server/src/features/colors.ts
@@ -1,0 +1,230 @@
+/**
+ * Color swatches and the multi-format picker (issue #11), via the standard
+ * LSP documentColor / colorPresentation pair so the editor's native picker
+ * drives it.
+ *
+ * The recognised forms are the ones measured in vanilla CK3 and Victoria 3
+ * (2026-08), not the HOI4/EU4 habits other tools assume:
+ *   rgb { 174 169 166 }        ints 0..255
+ *   hsv { 0.6 0.5 0.7 }        hue 0..1, NOT 0..360 (998 uses in CK3)
+ *   hsv360 { 358 70 65 }       hue 0..360, s and v 0..100 (179 uses in Vic3)
+ *   hex { 50779b }             six hex digits, no 0x prefix
+ *   { 0.9 0.8 0.2 1 }          untagged floats 0..1, alpha optional (.gui, named colors)
+ *   { 180 75 80 }              untagged ints 0..255
+ * Untagged blocks are only colors when the key says so (`color`, `color1`,
+ * `map_color`, ...) or when they sit inside a `colors = { }` table
+ * (common/named_colors). Tagged blocks are colors wherever they appear.
+ *
+ * The untagged int/float split follows the engine: a component with a `.`
+ * or every component <= 1 means floats, otherwise 0..255. `{ 1 1 1 }` is
+ * therefore white, which is what every vanilla .gui relies on.
+ */
+import type { Color, ColorInformation, ColorPresentation, Range } from "vscode-languageserver/node";
+import type { TextDocument } from "vscode-languageserver-textdocument";
+import {
+  walkStatements,
+  type AssignmentNode,
+  type BlockNode,
+  type Statement,
+  type ValueNode,
+} from "../parser";
+import { getParse } from "../parseCache";
+
+export type ColorFormat = "rgb" | "hsv" | "hsv360" | "hex" | "float" | "int";
+
+const TAGS: ReadonlySet<string> = new Set(["rgb", "hsv", "hsv360", "hex"]);
+
+/** The format rides along in the ColorInformation so the presentation request
+ *  can lead with the author's own notation; the LSP layer passes extra fields
+ *  through as plain object data. */
+export interface ColorSite extends ColorInformation {
+  format: ColorFormat;
+  /** The source spelled a fourth component, so presentations keep it. */
+  alpha: boolean;
+}
+
+interface Decoded {
+  color: Color;
+  format: ColorFormat;
+  alpha: boolean;
+}
+
+function numbers(block: BlockNode): number[] | null {
+  const out: number[] = [];
+  for (const s of block.statements) {
+    if (s.kind !== "value" || s.value.kind !== "scalar" || s.value.quoted) return null;
+    const n = Number(s.value.text);
+    if (!Number.isFinite(n)) return null;
+    out.push(n);
+  }
+  return out.length === 3 || out.length === 4 ? out : null;
+}
+
+function clamp01(n: number): number {
+  return Math.min(1, Math.max(0, n));
+}
+
+function hsvToRgb(h: number, s: number, v: number): [number, number, number] {
+  const i = Math.floor(h * 6);
+  const f = h * 6 - i;
+  const p = v * (1 - s);
+  const q = v * (1 - f * s);
+  const t = v * (1 - (1 - f) * s);
+  switch (((i % 6) + 6) % 6) {
+    case 0:
+      return [v, t, p];
+    case 1:
+      return [q, v, p];
+    case 2:
+      return [p, v, t];
+    case 3:
+      return [p, q, v];
+    case 4:
+      return [t, p, v];
+    default:
+      return [v, p, q];
+  }
+}
+
+function rgbToHsv(r: number, g: number, b: number): [number, number, number] {
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  const d = max - min;
+  const s = max === 0 ? 0 : d / max;
+  let h = 0;
+  if (d > 0) {
+    if (max === r) h = (g - b) / d + (g < b ? 6 : 0);
+    else if (max === g) h = (b - r) / d + 2;
+    else h = (r - g) / d + 4;
+    h /= 6;
+  }
+  return [h, s, max];
+}
+
+/** `{ 1 1 1 }` is white and `{ 255 0 0 }` is red: floats when any component
+ *  carries a fraction or all of them fit in 0..1. */
+function rgbComponents(c: number[], format: ColorFormat): Decoded {
+  const floats = c.some((n) => !Number.isInteger(n)) || c.every((n) => n <= 1);
+  const k = floats ? 1 : 255;
+  const alpha = c.length === 4;
+  return {
+    color: {
+      red: clamp01(c[0] / k),
+      green: clamp01(c[1] / k),
+      blue: clamp01(c[2] / k),
+      alpha: alpha ? clamp01(c[3] / k) : 1,
+    },
+    format: format === "rgb" ? "rgb" : floats ? "float" : "int",
+    alpha,
+  };
+}
+
+/** Decode one value node into a color, or null when it is not a color. */
+function decode(value: ValueNode, keyIsColor: boolean): Decoded | null {
+  if (value.kind === "tagged-block") {
+    const tag = value.tag.text;
+    if (!TAGS.has(tag)) return null;
+    if (tag === "hex") {
+      const s = value.block.statements;
+      if (s.length !== 1 || s[0].kind !== "value" || s[0].value.kind !== "scalar") return null;
+      const m = /^(?:0x)?([0-9a-fA-F]{6})$/.exec(s[0].value.text);
+      if (!m) return null;
+      const n = parseInt(m[1], 16);
+      return {
+        color: { red: (n >> 16) / 255, green: ((n >> 8) & 255) / 255, blue: (n & 255) / 255, alpha: 1 },
+        format: "hex",
+        alpha: false,
+      };
+    }
+    const c = numbers(value.block);
+    if (!c) return null;
+    // Vic3 named_colors spells `rgb { 1 0.4 0.6 }`, so rgb follows the untagged split too.
+    if (tag === "rgb") return rgbComponents(c, "rgb");
+    const alpha = c.length === 4;
+    const format: ColorFormat = tag === "hsv360" ? "hsv360" : "hsv";
+    const [h, s, v] = format === "hsv360" ? [c[0] / 360, c[1] / 100, c[2] / 100] : [c[0], c[1], c[2]];
+    const [r, g, b] = hsvToRgb(((h % 1) + 1) % 1, clamp01(s), clamp01(v));
+    return { color: { red: r, green: g, blue: b, alpha: alpha ? clamp01(c[3]) : 1 }, format, alpha };
+  }
+  if (value.kind === "block" && keyIsColor) {
+    const c = numbers(value);
+    return c ? rgbComponents(c, "float") : null;
+  }
+  return null;
+}
+
+/** Portrait genes: `hair_color = { 32 235 66 229 }` is two palette coordinates
+ *  (x y x y), not RGBA. 766 sites per game in dna_data, ethnicities and
+ *  bookmark_portraits would otherwise show a meaningless swatch. */
+const GENE_KEYS: ReadonlySet<string> = new Set(["hair_color", "skin_color", "eye_color"]);
+
+function keyNamesColor(stmt: Statement, ancestors: readonly (AssignmentNode | BlockNode)[]): boolean {
+  if (stmt.kind === "assignment" && stmt.key.text.includes("color")) return !GENE_KEYS.has(stmt.key.text);
+  // common/named_colors: `colors = { english = { 0.8 0.2 0.2 } }`.
+  const parent = ancestors[ancestors.length - 2];
+  return parent?.kind === "assignment" && parent.key.text === "colors";
+}
+
+export function provideDocumentColors(document: TextDocument): ColorSite[] {
+  const { result, lineIndex } = getParse(document);
+  const out: ColorSite[] = [];
+  walkStatements(result.root, (stmt, ancestors) => {
+    const value = stmt.value;
+    if (!value) return;
+    const hit = decode(value, keyNamesColor(stmt, ancestors));
+    if (!hit) return;
+    const range: Range = {
+      start: lineIndex.positionAt(value.range.start),
+      end: lineIndex.positionAt(value.range.end),
+    };
+    out.push({ range, color: hit.color, format: hit.format, alpha: hit.alpha });
+  });
+  return out;
+}
+
+const FORMATS: readonly ColorFormat[] = ["rgb", "hsv", "hsv360", "hex", "float", "int"];
+
+export function renderColor(color: Color, format: ColorFormat, alpha: boolean): string {
+  const i = (n: number) => Math.round(n * 255);
+  const f = (n: number) => String(Math.round(n * 1000) / 1000);
+  const withAlpha = alpha || color.alpha < 1;
+  const { red: r, green: g, blue: b, alpha: a } = color;
+  switch (format) {
+    case "rgb":
+      return `rgb { ${i(r)} ${i(g)} ${i(b)}${withAlpha ? ` ${i(a)}` : ""} }`;
+    case "int":
+      return `{ ${i(r)} ${i(g)} ${i(b)}${withAlpha ? ` ${i(a)}` : ""} }`;
+    case "float":
+      return `{ ${f(r)} ${f(g)} ${f(b)}${withAlpha ? ` ${f(a)}` : ""} }`;
+    case "hex":
+      return `hex { ${((i(r) << 16) | (i(g) << 8) | i(b)).toString(16).padStart(6, "0")} }`;
+    case "hsv": {
+      const [h, s, v] = rgbToHsv(r, g, b);
+      return `hsv { ${f(h)} ${f(s)} ${f(v)}${withAlpha ? ` ${f(a)}` : ""} }`;
+    }
+    case "hsv360": {
+      const [h, s, v] = rgbToHsv(r, g, b);
+      return `hsv360 { ${Math.round(h * 360)} ${Math.round(s * 100)} ${Math.round(v * 100)}${withAlpha ? ` ${f(a)}` : ""} }`;
+    }
+  }
+}
+
+/**
+ * One presentation per format, the author's own notation first so a nudge in
+ * the picker never silently rewrites `hsv` as `rgb`. The editor cycles through
+ * the rest on click; that is the "multiple format" part of the feature.
+ */
+export function provideColorPresentations(
+  document: TextDocument,
+  color: Color,
+  range: Range
+): ColorPresentation[] {
+  const site = provideDocumentColors(document).find(
+    (s) => s.range.start.line === range.start.line && s.range.start.character === range.start.character
+  );
+  const own = site?.format ?? "rgb";
+  const alpha = site?.alpha ?? false;
+  return [own, ...FORMATS.filter((f) => f !== own)].map((format) => ({
+    label: renderColor(color, format, alpha),
+  }));
+}

--- a/packages/server/src/features/colors.ts
+++ b/packages/server/src/features/colors.ts
@@ -3,11 +3,11 @@
  * LSP documentColor / colorPresentation pair so the editor's native picker
  * drives it.
  *
- * The recognised forms are the ones measured in vanilla CK3 and Victoria 3
- * (2026-08), not the HOI4/EU4 habits other tools assume:
+ * The recognised forms are the ones measured in the vanilla files of the two
+ * calibrated games (2026-08), not the habits older-engine tools assume:
  *   rgb { 174 169 166 }        ints 0..255
- *   hsv { 0.6 0.5 0.7 }        hue 0..1, NOT 0..360 (998 uses in CK3)
- *   hsv360 { 358 70 65 }       hue 0..360, s and v 0..100 (179 uses in Vic3)
+ *   hsv { 0.6 0.5 0.7 }        hue 0..1, NOT 0..360 (998 vanilla uses)
+ *   hsv360 { 358 70 65 }       hue 0..360, s and v 0..100 (179 vanilla uses)
  *   hex { 50779b }             six hex digits, no 0x prefix
  *   { 0.9 0.8 0.2 1 }          untagged floats 0..1, alpha optional (.gui, named colors)
  *   { 180 75 80 }              untagged ints 0..255
@@ -138,7 +138,7 @@ function decode(value: ValueNode, keyIsColor: boolean): Decoded | null {
     }
     const c = numbers(value.block);
     if (!c) return null;
-    // Vic3 named_colors spells `rgb { 1 0.4 0.6 }`, so rgb follows the untagged split too.
+    // Vanilla named_colors spells `rgb { 1 0.4 0.6 }`, so rgb follows the untagged split too.
     if (tag === "rgb") return rgbComponents(c, "rgb");
     const alpha = c.length === 4;
     const format: ColorFormat = tag === "hsv360" ? "hsv360" : "hsv";

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -130,6 +130,7 @@ import { provideCodeActions } from "./features/codeActions";
 import { provideSignatureHelp } from "./features/signatureHelp";
 import { provideDocumentSymbols } from "./features/symbols";
 import { provideFoldingRanges } from "./features/folding";
+import { provideColorPresentations, provideDocumentColors } from "./features/colors";
 import { provideFormattingEdits } from "./features/formatting";
 import {
   computeLocDiagnostics,
@@ -1043,6 +1044,7 @@ connection.onInitialize((params: InitializeParams): InitializeResult => {
       inlayHintProvider: true,
       documentSymbolProvider: true,
       foldingRangeProvider: true,
+      colorProvider: true,
       referencesProvider: true,
       documentFormattingProvider: true,
       renameProvider: { prepareProvider: true },
@@ -1545,6 +1547,22 @@ connection.onFoldingRanges((params) => {
   const doc = documents.get(params.textDocument.uri);
   if (!doc) return [];
   return provideFoldingRanges(doc);
+});
+
+// Color swatches + the native picker (issue #11). Script and .gui only: the
+// descriptor and format-doc languages carry no colors.
+function colorLanguage(languageId: string): boolean {
+  return isScriptLanguage(languageId) || languageId === "paradox-gui";
+}
+connection.onDocumentColor((params) => {
+  const doc = documents.get(params.textDocument.uri);
+  if (!doc || !colorLanguage(doc.languageId)) return [];
+  return provideDocumentColors(doc);
+});
+connection.onColorPresentation((params) => {
+  const doc = documents.get(params.textDocument.uri);
+  if (!doc || !colorLanguage(doc.languageId)) return [];
+  return provideColorPresentations(doc, params.color, params.range);
 });
 
 // ---- structural diagnostics -----------------------------------------------------

--- a/packages/server/test/colors.test.ts
+++ b/packages/server/test/colors.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import { TextDocument } from "vscode-languageserver-textdocument";
+import { provideColorPresentations, provideDocumentColors } from "../src/features/colors";
+
+let n = 0;
+const doc = (text: string, lang = "paradox") =>
+  TextDocument.create(`file:///colors-${n++}.txt`, lang, 1, text);
+const rgb255 = (c: { red: number; green: number; blue: number }) =>
+  [c.red, c.green, c.blue].map((x) => Math.round(x * 255));
+
+describe("documentColor, the vanilla forms", () => {
+  it("rgb is 0..255, hex has no 0x, both carry the whole value as the range", () => {
+    const d = doc("color1 = rgb { 174 169 166 }\nx = hex { 50779b }");
+    const [a, b] = provideDocumentColors(d);
+    expect(rgb255(a.color)).toEqual([174, 169, 166]);
+    expect(d.getText(a.range)).toBe("rgb { 174 169 166 }");
+    expect(rgb255(b.color)).toEqual([0x50, 0x77, 0x9b]);
+    expect(b.format).toBe("hex");
+  });
+
+  it("hsv hue is 0..1 (Jomini), hsv360 is 0..360 with s/v in percent", () => {
+    const d = doc("a = hsv { 0.6 0.5 0.7 }\nb = hsv360 { 216 50 70 }");
+    const [a, b] = provideDocumentColors(d);
+    // Both spell the same blue; a naive h/360 would paint `a` near red.
+    expect(rgb255(a.color)).toEqual([89, 125, 179]);
+    expect(rgb255(b.color)).toEqual(rgb255(a.color));
+  });
+
+  it("untagged blocks need a color key; { 1 1 1 } is white, { 255 0 0 } is red", () => {
+    const d = doc(
+      "color = { 1 1 1 }\nmap_color = { 255 0 0 }\nposition = { 1 1 1 }\ncolor = { .9 .9 .9 1.0 }",
+      "paradox-gui"
+    );
+    const hits = provideDocumentColors(d);
+    expect(hits.map((h) => [h.format, ...rgb255(h.color)])).toEqual([
+      ["float", 255, 255, 255],
+      ["int", 255, 0, 0],
+      ["float", 230, 230, 230],
+    ]);
+    expect(hits[2].alpha).toBe(true);
+  });
+
+  it("portrait genes are palette coordinates, not colors", () => {
+    const d = doc("hair_color = { 32 235 66 229 }\nskin_color={ 0 0 0 0 }\neye_color = { 1 1 1 1 }");
+    expect(provideDocumentColors(d)).toEqual([]);
+  });
+
+  it("a named_colors table makes every entry a color", () => {
+    const d = doc("colors = {\n english = { 0.8 0.2 0.2 }\n todo = rgb { 1 0.4 0.6 }\n}");
+    const hits = provideDocumentColors(d);
+    expect(hits.map((h) => rgb255(h.color))).toEqual([
+      [204, 51, 51],
+      [255, 102, 153],
+    ]);
+  });
+
+  it("ignores blocks that are not three or four numbers", () => {
+    const d = doc('color = { 1 2 }\ncolor = { a b c }\ncolor = { 1 2 3 4 5 }\ncolor = rgb { "1" 2 3 }');
+    expect(provideDocumentColors(d)).toEqual([]);
+  });
+});
+
+describe("colorPresentation, the multi-format cycle", () => {
+  it("leads with the author's notation and offers every other form", () => {
+    const d = doc("color = hsv { 0.6 0.5 0.7 }");
+    const [site] = provideDocumentColors(d);
+    const labels = provideColorPresentations(d, site.color, site.range).map((p) => p.label);
+    expect(labels[0]).toBe("hsv { 0.6 0.5 0.7 }");
+    expect(labels).toContain("rgb { 89 125 179 }");
+    expect(labels).toContain("hsv360 { 216 50 70 }");
+    expect(labels).toContain("hex { 597db3 }");
+    expect(labels).toContain("{ 89 125 179 }");
+    expect(labels).toHaveLength(6);
+  });
+
+  it("keeps a spelled alpha and drops an implicit one", () => {
+    const d = doc("color = { 0.5 0.5 0.5 0.25 }\ncolor = { 128 128 128 }");
+    const [a, b] = provideDocumentColors(d);
+    expect(provideColorPresentations(d, a.color, a.range)[0].label).toBe("{ 0.5 0.5 0.5 0.25 }");
+    expect(provideColorPresentations(d, b.color, b.range)[0].label).toBe("{ 128 128 128 }");
+  });
+});

--- a/packages/server/test/colors.test.ts
+++ b/packages/server/test/colors.test.ts
@@ -54,9 +54,20 @@ describe("documentColor, the vanilla forms", () => {
     ]);
   });
 
-  it("ignores blocks that are not three or four numbers", () => {
-    const d = doc('color = { 1 2 }\ncolor = { a b c }\ncolor = { 1 2 3 4 5 }\ncolor = rgb { "1" 2 3 }');
+  it("ignores blocks that are not three or four numbers, and quoted hex", () => {
+    const d = doc(
+      'color = { 1 2 }\ncolor = { a b c }\ncolor = { 1 2 3 4 5 }\ncolor = rgb { "1" 2 3 }\ncolor = hex { "50779b" }'
+    );
     expect(provideDocumentColors(d)).toEqual([]);
+  });
+
+  it("a normalized rgb block keeps its 0..1 notation as the author's form", () => {
+    const d = doc("todo = rgb { 1 0.4 0.6 }");
+    const [site] = provideDocumentColors(d);
+    expect(site.format).toBe("rgbf");
+    const labels = provideColorPresentations(d, site.color, site.range).map((p) => p.label);
+    expect(labels[0]).toBe("rgb { 1 0.4 0.6 }");
+    expect(labels).toContain("rgb { 255 102 153 }");
   });
 });
 

--- a/packages/server/test/lspSmoke.test.ts
+++ b/packages/server/test/lspSmoke.test.ts
@@ -454,6 +454,32 @@ describe.skipIf(!hasServer)("LSP smoke over node IPC (the client's transport)", 
     expect(tokens.data.length).toBeGreaterThan(0);
   });
 
+  it("documentColor + colorPresentation round-trip over the wire (issue #11)", async () => {
+    expect((initResult as { capabilities: { colorProvider?: boolean } }).capabilities.colorProvider).toBe(
+      true
+    );
+    const uri = "file:///smoke-colors.txt";
+    void conn.sendNotification("textDocument/didOpen", {
+      textDocument: { uri, languageId: "paradox", version: 1, text: "color = hsv { 0.6 0.5 0.7 }\n" },
+    });
+    const colors = (await conn.sendRequest("textDocument/documentColor", {
+      textDocument: { uri },
+    })) as Array<{
+      range: unknown;
+      color: { red: number; green: number; blue: number; alpha: number };
+    }>;
+    expect(colors).toHaveLength(1);
+    expect(Math.round(colors[0].color.blue * 255)).toBe(179);
+    const presentations = (await conn.sendRequest("textDocument/colorPresentation", {
+      textDocument: { uri },
+      color: colors[0].color,
+      range: colors[0].range,
+    })) as Array<{ label: string }>;
+    // The author's notation leads; the other formats follow.
+    expect(presentations[0].label).toBe("hsv { 0.6 0.5 0.7 }");
+    expect(presentations.map((p) => p.label)).toContain("rgb { 89 125 179 }");
+  });
+
   it("paradox/eventDetail answers with loc, options and refs", async () => {
     const detail = (await conn.sendRequest("paradox/eventDetail", { id: "smoke.1" })) as {
       id: string;

--- a/packages/vscode/CHANGELOG.md
+++ b/packages/vscode/CHANGELOG.md
@@ -67,6 +67,20 @@ including the Community Mod Framework.
 
 ### Added
 
+- **Color swatches and a multi-format color picker** (issue #11). Every color
+  in script and `.gui` gets a swatch; click it and the editor's native picker
+  opens. Clicking the notation label cycles the formats, so one color can be
+  written as `rgb { 174 169 166 }`, `hsv { 0.6 0.5 0.7 }`, `hsv360 { 216 50
+  70 }`, `hex { 50779b }`, `{ 0.9 0.8 0.2 1 }` or `{ 180 75 80 }`. Your own
+  notation is offered first, so a nudge never silently rewrites `hsv` as
+  `rgb`. The forms are the ones measured in vanilla CK3 and Victoria 3, which
+  differ from what HOI4/EU4 tools assume: Jomini `hsv` takes hue in 0..1, not
+  0..360, and `hex` has no `0x` prefix. Untagged blocks count only under a
+  `color` key (or inside a `named_colors` table); portrait genes like
+  `hair_color = { 32 235 66 229 }` are palette coordinates and stay
+  swatch-free. Ships on the standard LSP `documentColor` request, so every
+  client gets it, not just VS Code. 20,817 sites in vanilla CK3 `common/` +
+  `gui/`, 3,387 in Victoria 3, zero false positives in the audit.
 - **`Paradox: Add Dependency Mod`** reads the dependencies your mod declares
   (`descriptor.mod` or metadata `relationships`), scans the Steam workshop
   folder of the active game, and writes `px.parentMods` for you. Declared but

--- a/packages/vscode/CHANGELOG.md
+++ b/packages/vscode/CHANGELOG.md
@@ -9,6 +9,25 @@ including the Community Mod Framework.
 
 ### Fixed (Victoria 3 and EU5)
 
+- **Victoria 3 completion offers the right key.** Measured on 1215 cursor
+  positions across three real workshop mods, the correct key was never
+  offered in 77.1 percent of positions before, 0.2 percent after. Three
+  causes: Victoria 3 had no structures layer (its 91 `*.md` docs were
+  dismissed as prose, 71 of them are `key = value # doc` listings and now
+  feed `data/vic3/structures.json`, 116 kinds, 1179 keys); scope inference
+  hardcoded CK3's "event root is a character" rule, so every country effect
+  was demoted (`change_infamy` ranked 3963); and 12 reference prefixes
+  (`unit_type`, `rank_value`, `ship_type`, nine more) were not wired,
+  which left 446 reference sites dead. The CK3 rank-eval confirms no
+  regression.
+- **The GUI editor draws Victoria 3 files.** It laid out top-level
+  instances only, and Vic3 writes 65 percent of vanilla gui (75 percent of
+  the Community Mod Framework) as type declarations with no instance, so
+  the canvas was empty. Declared types are previewed when a file
+  instantiates nothing. The lexer also ended quoted strings at end of line,
+  while Vic3 writes multi-line data functions: 202 parse errors in 23 of
+  CMF's 52 gui files, editor read-only there. A newline now continues a
+  string while a bracket is open, capped at 32 lines.
 - **The error.log watcher works on Victoria 3 and EU5.** It watched a file
   that never exists: those games dump `script_docs` into `docs/` and the
   toolkit joined `error.log` onto that folder, while the engine writes it to
@@ -48,7 +67,7 @@ including the Community Mod Framework.
   `px.parentMods` contributed definitions but not `data_binding` macros or
   text-formatting tags; the Community Mod Framework alone carries 40 macros
   that were invisible. Parent mods are now a full layer between game and mod.
-- **83 Victoria 3 folders indexed** (up from 72): combat units, mobilization,
+- **129 Victoria 3 folders indexed** (up from 72, +2186 vanilla definitions): combat units, mobilization,
   ship types/modifications/names, AI strategies, buy packages, console
   command macros, plus `.gui` `type`/`template` names as definitions for both
   Victoria 3 and EU5 (2371 GUI types on a live install). Each new folder was

--- a/packages/vscode/README.md
+++ b/packages/vscode/README.md
@@ -62,6 +62,9 @@ bottom says exactly where they stop.
   walk a whole chain with a breadcrumb and a Back button. It reads each game's
   own event vocabulary, so a Victoria 3 event shows its `flavor` line and its
   `cancellation_trigger` in place.
+- **Color picker**: a swatch on every `rgb { }`, `hsv { }`, `hsv360 { }`,
+  `hex { }` and `color = { }` value, in script and `.gui`. Click it for the
+  native picker; click the label to cycle between the formats.
 - **DDS and images**: zoomable `.dds` preview, a PNG/JPEG/WebP to DDS converter
   in the explorer right-click menu, and **Show Image Guidelines** with the
   sizes vanilla actually uses.


### PR DESCRIPTION
Lands the 0.3.1 cycle as one squash commit on main.

## What ships
- **Victoria 3 completion offers the right key.** 1215 real cursor positions across three workshop mods: correct key never offered 77.1% before, 0.2% after. Structures layer (116 kinds, 1179 keys), profile-driven scope roots, 12 reference prefixes (446 dead sites resolved). No CK3 regression on the gated rank-eval.
- **GUI editor draws Vic3 files**: declared types preview without an instance; multi-line data functions no longer break the lexer (202 parse errors in 23 CMF files, gone).
- **error.log watcher fires on Vic3/EU5**, real mod names from metadata.json, per-game scaffolds and descriptors, dependency mods feed every completion layer, 129 Vic3 folders indexed (+2186 definitions).
- **Color swatches + multi-format picker** over LSP documentColor (#11). Forms measured in vanilla: Jomini hsv hue is 0..1, hsv360 is 0..360/100/100, hex has no 0x. Portrait genes excluded. 20,817 CK3 sites, 3,387 Vic3, zero false positives.
- Project panel Open group, five chords, per-game icons, Add Dependency Mod, metadata.json schema.
- **Release pipeline**: docs/release-notes-<version>.md is the GitHub Release body and is posted to Discord in an embed with a role ping.
- CLAUDE.md: main is read-only, work lands through squash PRs only.

## Gates
tsc, eslint, prettier clean. 1447 tests passing, lspSmoke 34/34 including the new documentColor wire round-trip. vsix packaged: px-toolkit-0.3.1.vsix (1.67 MB).

Closes #11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Make Victoria 3 a first-class editing experience, add a standard multi-format color picker, and streamline release communication.

New Features:
- Add standard LSP color swatches and multi-format color presentations for Paradox script and GUI files.
- Expand the project panel, keyboard shortcuts, per-game identity, dependency management, and game-specific scaffolding and metadata support.

Bug Fixes:
- Improve Victoria 3 completion accuracy, GUI rendering and parsing, error-log diagnostics, mod naming, and dependency-aware definitions without regressing CK3 behavior.

Enhancements:
- Extend Victoria 3 indexing and reference resolution with broader structures, definitions, scopes, and content support.
- Document the color protocol and expose the color picker in the VS Code user documentation.

CI:
- Publish authored release notes to GitHub Releases and optionally announce tagged releases in Discord.

Documentation:
- Add versioned release notes for 0.3.0 and 0.3.1.
- Document the branch and squash-merge workflow for future contributions.

Tests:
- Add unit coverage for color detection, conversion, formatting preservation, exclusions, and alpha handling.
- Add an LSP smoke test covering documentColor and colorPresentation requests.

Chores:
- Update the changelog and project ignore configuration for the 0.3.1 release.