### PR TITLE
Audit fixes (2026-08)

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,11 @@
   "pnpm": {
     "overrides": {
       "brace-expansion@<5.0.8": ">=5.0.8"
-    }
+    },
+    "onlyBuiltDependencies": [
+      "@vscode/vsce-sign",
+      "esbuild",
+      "keytar"
+    ]
   }
 }

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -18,9 +18,7 @@
     "README.md",
     "LICENSE"
   ],
-  "publishConfig": {
-    "access": "public"
-  },
+  "private": true,
   "exports": {
     "./*": "./src/*.ts"
   }

--- a/packages/protocol/src/fsWalk.ts
+++ b/packages/protocol/src/fsWalk.ts
@@ -5,6 +5,30 @@
 import * as fs from "fs";
 import * as path from "path";
 
+/**
+ * Directory entries between two `null` ticks from `iterFiles`. Measured walk
+ * throughput on a real tree is 4.2k entries/s cold and 29k/s warm, so 500
+ * entries is tens of milliseconds of blocking at worst.
+ */
+export const WALK_TICK = 500;
+
+/**
+ * Every file under `dir` (recursive) with the given extension (lowercase
+ * match), yielded as it is found, plus a `null` every WALK_TICK entries
+ * VISITED.
+ *
+ * The nulls are what lets an async caller pace the listing: a subtree with no
+ * match in it at all (a mod's `gfx/` under a `.txt` scan) still costs one
+ * readdirSync per directory, so a caller handed only paths would have nothing
+ * to pace itself against and would block for the whole traversal.
+ */
+export function* iterFiles(dir: string, ext: string): Generator<string | null> {
+  // One visited-target set per walk: shared across sibling links so two links
+  // to the same tree cannot index it twice. The walk runs once per schema folder
+  // (tens of times per root), never per directory, so the Set is free.
+  yield* walk(dir, ext, new Set<string>(), { count: 0 });
+}
+
 /** All files under `dir` (recursive) with the given extension (lowercase match). */
 export function listFiles(dir: string, ext: string): string[] {
   const out: string[] = [];
@@ -13,13 +37,17 @@ export function listFiles(dir: string, ext: string): string[] {
 }
 
 export function walkDir(dir: string, ext: string, out: string[]): void {
-  // One visited-target set per walk: shared across sibling links so two links
-  // to the same tree cannot index it twice. walkDir runs once per schema folder
-  // (tens of times per root), never per directory, so the Set is free.
-  walk(dir, ext, out, new Set<string>());
+  for (const file of iterFiles(dir, ext)) {
+    if (file !== null) out.push(file);
+  }
 }
 
-function walk(dir: string, ext: string, out: string[], visited: Set<string>): void {
+function* walk(
+  dir: string,
+  ext: string,
+  visited: Set<string>,
+  tick: { count: number }
+): Generator<string | null> {
   let entries: fs.Dirent[];
   try {
     entries = fs.readdirSync(dir, { withFileTypes: true });
@@ -30,11 +58,12 @@ function walk(dir: string, ext: string, out: string[], visited: Set<string>): vo
     // Dot-directories (.git, .claude worktrees, …) are never game content and
     // can hold stale copies of the whole mod — indexing them pollutes results.
     if (entry.name.startsWith(".")) continue;
+    if (++tick.count % WALK_TICK === 0) yield null;
     const full = path.join(dir, entry.name);
-    if (entry.isDirectory()) walk(full, ext, out, visited);
+    if (entry.isDirectory()) yield* walk(full, ext, visited, tick);
     else if (entry.isFile()) {
-      if (entry.name.toLowerCase().endsWith(ext)) out.push(full);
-    } else if (entry.isSymbolicLink()) followLink(full, ext, out, visited);
+      if (entry.name.toLowerCase().endsWith(ext)) yield full;
+    } else if (entry.isSymbolicLink()) yield* followLink(full, ext, visited, tick);
   }
 }
 
@@ -62,7 +91,12 @@ function isSameOrBelow(outer: string, inner: string): boolean {
  * resolving to the directory it sits in (or one of its ancestors) is skipped
  * outright, and every followed target is remembered for the rest of the walk.
  */
-function followLink(full: string, ext: string, out: string[], visited: Set<string>): void {
+function* followLink(
+  full: string,
+  ext: string,
+  visited: Set<string>,
+  tick: { count: number }
+): Generator<string | null> {
   let target: fs.Stats;
   let real: string;
   try {
@@ -72,7 +106,7 @@ function followLink(full: string, ext: string, out: string[], visited: Set<strin
     return; // dangling or unreadable link indexes nothing
   }
   if (target.isFile()) {
-    if (path.basename(full).toLowerCase().endsWith(ext)) out.push(full);
+    if (path.basename(full).toLowerCase().endsWith(ext)) yield full;
     return;
   }
   if (!target.isDirectory()) return;
@@ -88,5 +122,5 @@ function followLink(full: string, ext: string, out: string[], visited: Set<strin
   const key = norm(real);
   if (visited.has(key)) return;
   visited.add(key);
-  walk(full, ext, out, visited);
+  yield* walk(full, ext, visited, tick);
 }

--- a/packages/protocol/test/fsWalk.test.ts
+++ b/packages/protocol/test/fsWalk.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
-import { listFiles } from "../src/fsWalk";
+import { iterFiles, listFiles, WALK_TICK } from "../src/fsWalk";
 
 const dirs: string[] = [];
 
@@ -93,5 +93,22 @@ describe("listFiles", () => {
     const root = tmp();
     fs.writeFileSync(path.join(root, "A.TXT"), "");
     expect(listFiles(root, ".txt")).toEqual([path.join(root, "A.TXT")]);
+  });
+});
+
+describe("iterFiles", () => {
+  it("ticks on entries visited, so a subtree with no match still paces a caller", () => {
+    const root = tmp();
+    fs.mkdirSync(path.join(root, "gfx"));
+    for (let i = 0; i < WALK_TICK * 2; i++) fs.writeFileSync(path.join(root, "gfx", `p${i}.dds`), "");
+
+    let ticks = 0;
+    let files = 0;
+    for (const file of iterFiles(root, ".txt")) {
+      if (file === null) ticks++;
+      else files++;
+    }
+    expect(files).toBe(0);
+    expect(ticks).toBe(2);
   });
 });

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -30,6 +30,10 @@ mirror in the log. Nothing has to be configured for that.
 
 ## Install
 
+The release tarball is the distribution. This package is not on npm: inside the
+repository its `exports` point at TypeScript sources, which the bundler consumes
+directly and a published package could not.
+
 Download `px-lsp-server-<version>.tar.gz` from the
 [GitHub releases](https://github.com/JDeffner/paradox-modding-toolkit/releases)
 and extract it anywhere, e.g. `~/.local/share/px-lsp/`. Layout:

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -28,9 +28,7 @@
     "LICENSE",
     "THIRD-PARTY-NOTICES.md"
   ],
-  "publishConfig": {
-    "access": "public"
-  },
+  "private": true,
   "exports": {
     "./dds": "./src/dds/index.ts",
     "./parser": "./src/parser/index.ts",
@@ -38,8 +36,7 @@
   },
   "scripts": {
     "compile": "esbuild src/server.ts --bundle --outfile=dist/server.js --format=cjs --platform=node --target=node18 --banner:js=\"#!/usr/bin/env node\"",
-    "watch": "esbuild src/server.ts --bundle --outfile=dist/server.js --format=cjs --platform=node --target=node18 --watch",
-    "prepublishOnly": "npm run compile"
+    "watch": "esbuild src/server.ts --bundle --outfile=dist/server.js --format=cjs --platform=node --target=node18 --watch"
   },
   "dependencies": {
     "@px-lsp/protocol": "workspace:*",

--- a/packages/server/src/dds/decoder.ts
+++ b/packages/server/src/dds/decoder.ts
@@ -68,6 +68,16 @@ interface ParsedHeader {
   formatName: string;
 }
 
+/**
+ * Decode budget, in pixels. Every decoder allocates width*height*4 bytes of
+ * RGBA out of dimensions the file declares, so the budget has to be per pixel:
+ * a per-axis cap of 0x10000 still admits 65535x65535, which reserved 16.1 GB
+ * (measured) before the data-length check could refuse it. 4096*4096 is the cap
+ * the GUI editor's texture cache already applies (MAX_TEXTURE_PIXELS in
+ * webviews/guiEditor/textureCache.ts), only after the decode instead of before.
+ */
+export const MAX_DECODE_PIXELS = 4096 * 4096;
+
 function readU32(buf: Uint8Array, off: number): number {
   return (buf[off] | (buf[off + 1] << 8) | (buf[off + 2] << 16) | (buf[off + 3] << 24)) >>> 0;
 }
@@ -82,7 +92,12 @@ function parseHeader(buf: Uint8Array): ParsedHeader | null {
 
   const height = readU32(buf, 12);
   const width = readU32(buf, 16);
-  if (width === 0 || height === 0 || width > 0x10000 || height > 0x10000) return null;
+  if (width === 0 || height === 0) return null;
+  // Throw rather than return null so ddsFormatInfo still reports the declared
+  // size (its catch branch) and the caller can say why the preview is missing.
+  if (width * height > MAX_DECODE_PIXELS) {
+    throw new Error(`image too large: ${width}x${height} exceeds ${MAX_DECODE_PIXELS} pixels`);
+  }
 
   // DDS_PIXELFORMAT starts at offset 76, size 32 bytes
   const pfOffset = 76;
@@ -245,11 +260,13 @@ function putPixel(
 }
 
 function decodeDxt1(buf: Uint8Array, off: number, width: number, height: number): Uint8Array {
-  const out = new Uint8Array(width * height * 4);
   const blocksX = Math.ceil(width / 4);
   const blocksY = Math.ceil(height / 4);
   const needed = off + blocksX * blocksY * 8;
+  // Refuse before allocating: a truncated file must not reserve the full RGBA
+  // buffer its header claims.
   if (needed > buf.length) throw new Error("truncated DXT1 data");
+  const out = new Uint8Array(width * height * 4);
 
   let p = off;
   for (let by = 0; by < blocksY; by++) {
@@ -298,10 +315,10 @@ function decodeColorBlock565(buf: Uint8Array, p: number, outColors: [number, num
 }
 
 function decodeDxt3(buf: Uint8Array, off: number, width: number, height: number): Uint8Array {
-  const out = new Uint8Array(width * height * 4);
   const blocksX = Math.ceil(width / 4);
   const blocksY = Math.ceil(height / 4);
   if (off + blocksX * blocksY * 16 > buf.length) throw new Error("truncated DXT3 data");
+  const out = new Uint8Array(width * height * 4);
 
   const colors: [number, number, number][] = [
     [0, 0, 0],
@@ -335,10 +352,10 @@ function decodeDxt3(buf: Uint8Array, off: number, width: number, height: number)
 }
 
 function decodeDxt5(buf: Uint8Array, off: number, width: number, height: number): Uint8Array {
-  const out = new Uint8Array(width * height * 4);
   const blocksX = Math.ceil(width / 4);
   const blocksY = Math.ceil(height / 4);
   if (off + blocksX * blocksY * 16 > buf.length) throw new Error("truncated DXT5 data");
+  const out = new Uint8Array(width * height * 4);
 
   const colors: [number, number, number][] = [
     [0, 0, 0],
@@ -880,10 +897,10 @@ function isAnchorForSubset(i: number, partTable: number[], anchors: number[]): b
 }
 
 function decodeBc7(buf: Uint8Array, off: number, width: number, height: number): Uint8Array {
-  const out = new Uint8Array(width * height * 4);
   const blocksX = Math.ceil(width / 4);
   const blocksY = Math.ceil(height / 4);
   if (off + blocksX * blocksY * 16 > buf.length) throw new Error("truncated BC7 data");
+  const out = new Uint8Array(width * height * 4);
   let p = off;
   for (let by = 0; by < blocksY; by++) {
     for (let bx = 0; bx < blocksX; bx++) {
@@ -905,9 +922,9 @@ function decodeBgra8(
   height: number,
   hasAlpha: boolean
 ): Uint8Array {
-  const out = new Uint8Array(width * height * 4);
   const need = off + width * height * 4;
   if (need > buf.length) throw new Error("truncated BGRA8 data");
+  const out = new Uint8Array(width * height * 4);
   let s = off;
   for (let i = 0; i < width * height; i++) {
     const bch = buf[s];
@@ -925,17 +942,17 @@ function decodeBgra8(
 }
 
 function decodeRgba8(buf: Uint8Array, off: number, width: number, height: number): Uint8Array {
-  const out = new Uint8Array(width * height * 4);
   const need = off + width * height * 4;
   if (need > buf.length) throw new Error("truncated RGBA8 data");
+  const out = new Uint8Array(width * height * 4);
   out.set(buf.subarray(off, need));
   return out;
 }
 
 function decodeRgb8(buf: Uint8Array, off: number, width: number, height: number): Uint8Array {
-  const out = new Uint8Array(width * height * 4);
   const need = off + width * height * 3;
   if (need > buf.length) throw new Error("truncated RGB8 data");
+  const out = new Uint8Array(width * height * 4);
   let s = off;
   for (let i = 0; i < width * height; i++) {
     // D3DFMT_R8G8B8 is stored B,G,R in memory

--- a/packages/server/src/index/indexer.ts
+++ b/packages/server/src/index/indexer.ts
@@ -273,6 +273,20 @@ interface IndexCacheFile {
   >;
 }
 
+/**
+ * Both halves of the cache round trip build ONE contiguous JSON string and block
+ * the event loop for its whole duration. Measured with 460k definitions (the
+ * vanilla tree per vitest.config.ts): a 26.3 MB file, 528 ms to save, 271 ms to
+ * load. That is the deliberate trade the compact row format above exists to
+ * make: the alternative it replaces is a multi-second rescan on every start.
+ *
+ * The ceiling is V8's ~512 MB single-string cap, roughly 20x the measured size.
+ * A tree that reached it throws RangeError, which both sides already degrade
+ * from: the caller of saveIndexCache logs and continues, loadIndexCache returns
+ * null and the caller rescans. So the failure mode is "no cache", not a crash.
+ * If the save or the load ever shows up in the perf trace, the answer is
+ * newline-delimited rows parsed in batches inside the scan's yieldNow rhythm.
+ */
 export function saveIndexCache(cacheFile: string, gameVersion: string, defs: Definition[]): void {
   const kindIdx = new Map<string, number>();
   const kinds: string[] = [];

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -27,6 +27,7 @@ import { createHash } from "crypto";
 import { version as SERVER_VERSION } from "../package.json";
 import type { Definition } from "@px-lsp/protocol/types";
 import { pushAll } from "@px-lsp/protocol/arrays";
+import { iterFiles } from "@px-lsp/protocol/fsWalk";
 import {
   configChangedNotification,
   indexChangedNotification,
@@ -103,7 +104,6 @@ import {
   classifyFile,
   detectGameVersion,
   isWantedLocFile,
-  listFiles,
   loadIndexCache,
   saveIndexCache,
 } from "./index/indexer";
@@ -660,7 +660,18 @@ async function scanRootChunked(
   let totalFiles = 0;
   for (const entry of schema.entries) {
     const dir = path.join(root, ...entry.path.split("/"));
-    let files = listFiles(dir, entry.ext ?? ".txt");
+    // The listing shares the read loop's yield budget below. It used to run to
+    // completion first, and for its whole duration the server answered no
+    // request: completion and hover stalled behind it.
+    let files: string[] = [];
+    for (const file of iterFiles(dir, entry.ext ?? ".txt")) {
+      if (file === null) {
+        if (generation !== scanGeneration) return null; // superseded
+        await yieldNow();
+      } else {
+        files.push(file);
+      }
+    }
     if (entry.kind === "loc_key") {
       files = files.filter((f) => isWantedLocFile(path.relative(root, f), settings.locLanguage));
     }
@@ -700,7 +711,17 @@ async function scanModReferences(
   generation: number
 ): Promise<boolean> {
   const t0 = Date.now();
-  const files = listFiles(root, ".txt");
+  // A mod root is walked whole here, gfx/ and all, so the listing yields on the
+  // same rhythm as the read loop below rather than blocking through it.
+  const files: string[] = [];
+  for (const file of iterFiles(root, ".txt")) {
+    if (file === null) {
+      if (generation !== scanGeneration) return false;
+      await yieldNow();
+    } else {
+      files.push(file);
+    }
+  }
   const BATCH = 150;
   let refCount = 0;
   for (let i = 0; i < files.length; i += BATCH) {

--- a/packages/server/test/dds/fuzz.test.ts
+++ b/packages/server/test/dds/fuzz.test.ts
@@ -105,4 +105,23 @@ describe("fuzz / robustness", () => {
     expect(ddsFormatInfo(buf)).toBeNull();
     expect(() => decodeDds(buf)).toThrow();
   });
+
+  it("refuses an oversized header without allocating for it", () => {
+    // A 128-byte file declaring 65535x65535 DXT1. The old per-axis bound let it
+    // through and reserved 16.1 GB of RGBA (measured) before the data-length
+    // check could say "truncated".
+    const buf = new Uint8Array(128);
+    const dv = new DataView(buf.buffer);
+    dv.setUint32(0, fourCC("DDS "), true);
+    dv.setUint32(4, 124, true);
+    dv.setUint32(12, 65535, true);
+    dv.setUint32(16, 65535, true);
+    dv.setUint32(80, 0x4, true);
+    dv.setUint32(84, fourCC("DXT1"), true);
+
+    expect(() => decodeDds(buf)).toThrow(/too large/);
+    // The header peek still reports what the file claims, so the caller can say
+    // why the preview is missing instead of "not a DDS".
+    expect(ddsFormatInfo(buf)).toEqual({ format: "unsupported", width: 65535, height: 65535 });
+  });
 });

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -1070,9 +1070,7 @@
   "devDependencies": {
     "@px-lsp/protocol": "workspace:*",
     "@px-lsp/server": "workspace:*",
-    "@types/node": "^20.14.0",
-    "@types/vscode": "^1.90.0",
-    "esbuild": "^0.24.0"
+    "@types/vscode": "^1.90.0"
   },
   "dependencies": {
     "vscode-languageclient": "^10.1.0",

--- a/packages/vscode/src/bigWorkspace.ts
+++ b/packages/vscode/src/bigWorkspace.ts
@@ -73,14 +73,29 @@ export function indexedModRoots(cfg: {
 }
 
 /**
- * Script files under `roots`, stopping at `cap`. Bounded on purpose: this runs
- * on the activation path, and a total conversion holds thousands of files whose
- * exact number does not change the answer. Symlinked subtrees are not followed
- * (the indexer's walk does, with cycle guards; here a cheap count must not be
- * able to loop), and dot-directories are skipped like everywhere else.
+ * Entries the walk may visit per file of `cap`. The file cap bounds the
+ * MATCHES; this bounds the WORK, which is the thing that runs on the activation
+ * path. Without it a mod root carrying a large non-script tree (art source, a
+ * bundled asset dump) has no `.txt`/`.yml` to count and is traversed in full,
+ * with readdirSync, before the extension finishes activating. Ten entries per
+ * counted file leaves room for the art a real mod ships beside its script, so
+ * the file threshold is still what decides an ordinary workspace.
+ */
+const ENTRIES_PER_FILE = 10;
+
+/**
+ * Script files under `roots`, stopping at `cap` matches or at
+ * `cap * ENTRIES_PER_FILE` entries visited, whichever comes first. Bounded on
+ * purpose: this runs on the activation path, and a total conversion holds
+ * thousands of files whose exact number does not change the answer. Symlinked
+ * subtrees are not followed (the indexer's walk does, with cycle guards; here a
+ * cheap count must not be able to loop), and dot-directories are skipped like
+ * everywhere else.
  */
 export function countScriptFiles(roots: string[], cap: number): { files: number; partial: boolean } {
   let files = 0;
+  let visited = 0;
+  const entryCap = cap * ENTRIES_PER_FILE;
   const stack = [...roots];
   while (stack.length > 0) {
     const dir = stack.pop()!;
@@ -92,6 +107,7 @@ export function countScriptFiles(roots: string[], cap: number): { files: number;
     }
     for (const entry of entries) {
       if (entry.name.startsWith(".")) continue;
+      if (++visited > entryCap) return { files, partial: true };
       if (entry.isDirectory()) stack.push(path.join(dir, entry.name));
       else if (entry.isFile() && /\.(txt|yml)$/i.test(entry.name)) {
         if (++files >= cap) return { files, partial: true };

--- a/packages/vscode/src/ddsConvert.ts
+++ b/packages/vscode/src/ddsConvert.ts
@@ -9,6 +9,7 @@
  */
 import * as vscode from "vscode";
 import { encodeDds, hasTransparency, type DdsEncodeFormat } from "@px-lsp/server/dds";
+import { makeNonce } from "./webviews/nonce";
 
 const EXT_MIME: Record<string, string> = {
   ".png": "image/png",
@@ -199,13 +200,14 @@ class WebviewDecoder {
 }
 
 function decoderHtml(): string {
+  const nonce = makeNonce();
   return /* html */ `<!DOCTYPE html>
 <html><head>
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src data:; style-src 'unsafe-inline'; script-src 'unsafe-inline'" />
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src data:; style-src 'unsafe-inline'; script-src 'nonce-${nonce}'" />
 <style>body { font-family: sans-serif; color: var(--vscode-editor-foreground); background: var(--vscode-editor-background); padding: 16px; }</style>
 </head><body>
 <p>Decoding images…</p>
-<script>
+<script nonce="${nonce}">
 const vscode = acquireVsCodeApi();
 window.addEventListener("message", (ev) => {
   const msg = ev.data;

--- a/packages/vscode/src/ddsEditor.ts
+++ b/packages/vscode/src/ddsEditor.ts
@@ -6,6 +6,7 @@
  */
 import * as vscode from "vscode";
 import { decodeDds, ddsFormatInfo, encodePng } from "@px-lsp/server/dds";
+import { makeNonce } from "./webviews/nonce";
 
 class DdsDocument implements vscode.CustomDocument {
   constructor(
@@ -66,6 +67,7 @@ export class DdsPreviewProvider implements vscode.CustomReadonlyEditorProvider<D
     void this.maybePromptForDefault();
     panel.webview.options = { enableScripts: true, localResourceRoots: [] };
     const name = document.uri.path.split("/").pop() ?? "texture.dds";
+    const nonce = makeNonce();
     const info = ddsFormatInfo(document.bytes);
     let body: string;
     if (!info) {
@@ -76,7 +78,7 @@ export class DdsPreviewProvider implements vscode.CustomReadonlyEditorProvider<D
         const png = encodePng(img.width, img.height, img.pixels);
         const dataUri = `data:image/png;base64,${Buffer.from(png).toString("base64")}`;
         const kb = (document.bytes.length / 1024).toFixed(1);
-        body = imageHtml(dataUri, `${name} · ${info.format} · ${img.width}×${img.height} · ${kb} KB`);
+        body = imageHtml(dataUri, `${name} · ${info.format} · ${img.width}×${img.height} · ${kb} KB`, nonce);
       } catch (err) {
         body = errorHtml(
           `${name}: ${info.format} ${info.width}×${info.height} — preview failed: ` +
@@ -84,16 +86,16 @@ export class DdsPreviewProvider implements vscode.CustomReadonlyEditorProvider<D
         );
       }
     }
-    panel.webview.html = wrapHtml(body);
+    panel.webview.html = wrapHtml(body, nonce);
   }
 }
 
-function wrapHtml(body: string): string {
+function wrapHtml(body: string, nonce: string): string {
   return /* html */ `<!DOCTYPE html>
 <html lang="en">
 <head>
 <meta charset="UTF-8" />
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src data:; style-src 'unsafe-inline'; script-src 'unsafe-inline'" />
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src data:; style-src 'unsafe-inline'; script-src 'nonce-${nonce}'" />
 <style>
   :root { color-scheme: light dark; }
   html, body { margin: 0; height: 100%; font-family: var(--vscode-font-family, sans-serif); color: var(--vscode-editor-foreground); background: var(--vscode-editor-background); }
@@ -127,7 +129,7 @@ function wrapHtml(body: string): string {
 </html>`;
 }
 
-function imageHtml(dataUri: string, caption: string): string {
+function imageHtml(dataUri: string, caption: string, nonce: string): string {
   return /* html */ `
 <div id="bar">
   <span>${escapeHtml(caption)}</span>
@@ -135,7 +137,7 @@ function imageHtml(dataUri: string, caption: string): string {
   <label><input type="checkbox" id="pix" checked /> pixelated</label>
 </div>
 <div id="stage"><img id="img" class="pixelated" src="${dataUri}" /></div>
-<script>
+<script nonce="${nonce}">
   const stage = document.getElementById("stage");
   const img = document.getElementById("img");
   // Zoom clamps: 5% to 3200%.

--- a/packages/vscode/src/tiger/runner.ts
+++ b/packages/vscode/src/tiger/runner.ts
@@ -36,6 +36,40 @@ const SEVERITY_MAP: Record<string, vscode.DiagnosticSeverity> = {
 
 const DEBOUNCE_MS = 1500;
 
+/** Past this much output from one run the bytes are dropped and the run is reported as unreadable. */
+const MAX_OUTPUT_BYTES = 256 * 1024 * 1024;
+
+/**
+ * A child stream kept as buffers and decoded once, at close.
+ *
+ * `stdout += chunk.toString("utf8")` had two faults: it grew until V8's ~512 MB
+ * string ceiling with nothing to stop it, and it decoded each chunk on its own,
+ * so a multi-byte character split across a chunk boundary was corrupted before
+ * parseTigerJson ever saw it.
+ */
+function collectOutput(stream: NodeJS.ReadableStream | null | undefined): {
+  text(): string;
+  overflowed: boolean;
+} {
+  const chunks: Buffer[] = [];
+  let bytes = 0;
+  const out = {
+    overflowed: false,
+    text: () => Buffer.concat(chunks).toString("utf8"),
+  };
+  stream?.on("data", (chunk: Buffer) => {
+    if (out.overflowed) return;
+    bytes += chunk.length;
+    if (bytes > MAX_OUTPUT_BYTES) {
+      out.overflowed = true;
+      chunks.length = 0;
+      return;
+    }
+    chunks.push(chunk);
+  });
+  return out;
+}
+
 function hasDescriptor(root: string): boolean {
   try {
     return fs.existsSync(path.join(root, "descriptor.mod")) || hasMetadataDescriptor(root);
@@ -267,8 +301,6 @@ export class TigerRunner implements vscode.Disposable {
     args.push(modRoot);
 
     this.log(`tiger: ${cfg.tigerPath} ${args.join(" ")}`);
-    let stdout = "";
-    let stderr = "";
     let child: ChildProcess;
     try {
       child = spawn(cfg.tigerPath, args, { windowsHide: true });
@@ -278,8 +310,8 @@ export class TigerRunner implements vscode.Disposable {
     }
     this.child = child;
     this.showRunning();
-    child.stdout?.on("data", (d: Buffer) => (stdout += d.toString("utf8")));
-    child.stderr?.on("data", (d: Buffer) => (stderr += d.toString("utf8")));
+    const stdout = collectOutput(child.stdout);
+    const stderr = collectOutput(child.stderr);
     child.on("error", (err) => {
       this.child = null;
       this.showDone(null);
@@ -298,13 +330,21 @@ export class TigerRunner implements vscode.Disposable {
         return;
       }
       if (signal) return; // killed by us
-      const reports = parseTigerJson(stdout);
+      if (stdout.overflowed) {
+        this.notifyError(
+          `Paradox Modding Toolkit: ${meta.tiger?.binaryName ?? "tiger"} produced more than ` +
+            `${MAX_OUTPUT_BYTES / (1024 * 1024)} MB of output, so the report was discarded.`
+        );
+        return;
+      }
+      const reports = parseTigerJson(stdout.text());
       if (reports === null) {
         // Non-zero exit with no JSON = broken invocation; parse failures degrade to
         // a notification, never a crash.
+        const err = stderr.text();
         this.notifyError(
           `Paradox Modding Toolkit: ${meta.tiger?.binaryName ?? "tiger"} produced no readable JSON report (exit code ${code}).` +
-            (stderr ? ` stderr: ${stderr.slice(0, 300)}` : "")
+            (err ? ` stderr: ${err.slice(0, 300)}` : "")
         );
         return;
       }
@@ -346,7 +386,6 @@ export class TigerRunner implements vscode.Disposable {
       }
       args.push(cfg.modPath);
       this.log(`tiger baseline: ${cfg.tigerPath} ${args.join(" ")}`);
-      let stdout = "";
       let child: ChildProcess;
       try {
         child = spawn(cfg.tigerPath, args, { windowsHide: true });
@@ -355,10 +394,19 @@ export class TigerRunner implements vscode.Disposable {
         resolve(null);
         return;
       }
-      child.stdout?.on("data", (d: Buffer) => (stdout += d.toString("utf8")));
+      const stdout = collectOutput(child.stdout);
       child.on("error", () => resolve(null));
       child.on("close", () => {
-        const reports = parseTigerJson(stdout);
+        if (stdout.overflowed) {
+          this.notifyError(
+            `Paradox Modding Toolkit: tiger produced more than ${MAX_OUTPUT_BYTES / (1024 * 1024)} MB ` +
+              `of output, so no baseline was written.`
+          );
+          resolve(null);
+          return;
+        }
+        const text = stdout.text();
+        const reports = parseTigerJson(text);
         if (reports === null) {
           this.notifyError("Paradox Modding Toolkit: tiger produced no readable JSON for the baseline.");
           resolve(null);
@@ -366,7 +414,7 @@ export class TigerRunner implements vscode.Disposable {
         }
         try {
           fs.mkdirSync(path.dirname(outFile), { recursive: true });
-          fs.writeFileSync(outFile, stdout);
+          fs.writeFileSync(outFile, text);
         } catch (err) {
           this.notifyError(`Paradox Modding Toolkit: could not write the baseline file: ${String(err)}`);
           resolve(null);

--- a/packages/vscode/src/tigerDownload.ts
+++ b/packages/vscode/src/tigerDownload.ts
@@ -12,9 +12,45 @@
  */
 import * as fs from "fs";
 import * as path from "path";
-import { execFileSync } from "child_process";
+import { execFile } from "child_process";
+import { createHash } from "crypto";
+import { promisify } from "util";
 import type { GameMeta } from "@px-lsp/server/games/profile";
 import { isCk3, metaFor } from "./meta";
+
+/**
+ * Both child processes run on the extension host thread. execFileSync blocked
+ * every other extension in the window for as long as tar took, and again for as
+ * long as the freshly written binary took to answer `--version` (up to its 15 s
+ * timeout; a first run on Windows with Defender scanning 20 MB is the slow
+ * case). The function is already async and already reports progress.
+ */
+const execFileAsync = promisify(execFile);
+
+const ALLOWED_DOWNLOAD_HOSTS = new Set(["github.com", "objects.githubusercontent.com"]);
+
+/**
+ * The parsed asset URL, or null when it is not a GitHub release URL.
+ *
+ * `browser_download_url` is a field of the GitHub API answer, and what comes
+ * back is written to disk, unpacked and then executed. There is no checksum to
+ * verify against (tiger publishes none), so the host is the one thing that can
+ * be asserted, and it is asserted before the bytes are fetched.
+ */
+export function checkedDownloadUrl(raw: string): URL | null {
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    return null;
+  }
+  if (url.protocol !== "https:" || !ALLOWED_DOWNLOAD_HOSTS.has(url.hostname)) return null;
+  return url;
+}
+
+/** Hang guards: without them a stalled connection leaves the progress notification up forever. */
+const API_TIMEOUT_MS = 20_000;
+const DOWNLOAD_TIMEOUT_MS = 300_000;
 
 /** Which tiger to fetch/run. The tiger releases ship one archive per game
  * (ck3-tiger-*, vic3-tiger-*); flavors keep the downloads apart. */
@@ -146,6 +182,7 @@ export async function downloadLatestTiger(
   report("querying latest release...");
   const apiRes = await fetch(`https://api.github.com/repos/${flavor.repoSlug}/releases/latest`, {
     headers: { "User-Agent": "ck3-modding-vscode", Accept: "application/vnd.github+json" },
+    signal: AbortSignal.timeout(API_TIMEOUT_MS),
   });
   if (!apiRes.ok) throw new Error(`GitHub API returned ${apiRes.status} for the tiger releases feed.`);
   const release = (await apiRes.json()) as { tag_name?: string; assets?: ReleaseAsset[] };
@@ -159,12 +196,26 @@ export async function downloadLatestTiger(
     );
   }
 
-  report(`downloading ${asset.name}...`);
-  const dlRes = await fetch(asset.browser_download_url, {
+  const assetUrl = checkedDownloadUrl(asset.browser_download_url);
+  if (!assetUrl) {
+    throw new Error(
+      `refusing to download ${asset.name}: ${asset.browser_download_url} is not an https GitHub release URL.`
+    );
+  }
+
+  report(`downloading ${assetUrl.href}...`);
+  const dlRes = await fetch(assetUrl, {
     headers: { "User-Agent": "ck3-modding-vscode" },
+    signal: AbortSignal.timeout(DOWNLOAD_TIMEOUT_MS),
   });
   if (!dlRes.ok) throw new Error(`download failed with HTTP ${dlRes.status}.`);
   const buffer = Buffer.from(await dlRes.arrayBuffer());
+  // tiger publishes no checksums, so there is nothing to verify against. The
+  // hash goes to the output channel instead, where it can be compared with the
+  // release page by hand.
+  report(
+    `${asset.name}: ${buffer.length} bytes, sha256 ${createHash("sha256").update(buffer).digest("hex")}`
+  );
 
   const destDir = path.join(tigerStorageDir(storageDir, flavor), tag);
   fs.rmSync(destDir, { recursive: true, force: true });
@@ -175,7 +226,7 @@ export async function downloadLatestTiger(
   report("unpacking...");
   // bsdtar ships with Windows 10+ and handles zip; GNU/bsd tar handles tar.gz.
   try {
-    execFileSync("tar", ["-xf", archivePath, "-C", destDir], { windowsHide: true });
+    await execFileAsync("tar", ["-xf", archivePath, "-C", destDir], { windowsHide: true });
   } catch (err) {
     throw new Error(`could not unpack ${asset.name}: ${String(err)}`);
   } finally {
@@ -203,7 +254,7 @@ export async function downloadLatestTiger(
 
   // Sanity check the binary runs.
   try {
-    execFileSync(binaryPath, ["--version"], { windowsHide: true, timeout: 15000 });
+    await execFileAsync(binaryPath, ["--version"], { windowsHide: true, timeout: 15000 });
   } catch (err) {
     throw new Error(`downloaded tiger does not run: ${String(err)}`);
   }

--- a/packages/vscode/src/tigerDownload.ts
+++ b/packages/vscode/src/tigerDownload.ts
@@ -30,22 +30,89 @@ const execFileAsync = promisify(execFile);
 const ALLOWED_DOWNLOAD_HOSTS = new Set(["github.com", "objects.githubusercontent.com"]);
 
 /**
- * The parsed asset URL, or null when it is not a GitHub release URL.
+ * The parsed download URL, or null when it is not a GitHub release URL.
+ * `base` resolves a relative `Location` header against the hop that sent it.
  *
  * `browser_download_url` is a field of the GitHub API answer, and what comes
  * back is written to disk, unpacked and then executed. There is no checksum to
  * verify against (tiger publishes none), so the host is the one thing that can
- * be asserted, and it is asserted before the bytes are fetched.
+ * be asserted, and it is asserted for every URL the download touches, not just
+ * the first one.
  */
-export function checkedDownloadUrl(raw: string): URL | null {
+export function checkedDownloadUrl(raw: string, base?: URL): URL | null {
   let url: URL;
   try {
-    url = new URL(raw);
+    url = new URL(raw, base);
   } catch {
     return null;
   }
   if (url.protocol !== "https:" || !ALLOWED_DOWNLOAD_HOSTS.has(url.hostname)) return null;
   return url;
+}
+
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+
+/**
+ * GitHub hands a release asset over as a redirect chain (github.com answers a
+ * 302 to a signed objects.githubusercontent.com URL), so redirects have to be
+ * followed. Five hops is far more than that chain has ever taken and keeps a
+ * redirect loop from spending the whole download timeout.
+ */
+const MAX_DOWNLOAD_REDIRECTS = 5;
+
+/** Where a download response points next. */
+export type RedirectStep =
+  /** Not a redirect: this response carries the bytes. */
+  | { kind: "done" }
+  /** A redirect to an allowed host. */
+  | { kind: "follow"; url: URL }
+  /** A redirect off the allowlist. */
+  | { kind: "refused"; target: string };
+
+/**
+ * The next step of a download's redirect chain.
+ *
+ * `fetch` follows redirects itself, which would leave the allowlist covering
+ * only the first URL: a hop off it would then deliver the bytes that get
+ * unpacked and executed, which is the whole thing the check exists to stop.
+ * Split out of the fetch loop so each branch is testable without a network.
+ */
+export function redirectStep(status: number, location: string | null, from: URL): RedirectStep {
+  if (!REDIRECT_STATUSES.has(status) || location === null) return { kind: "done" };
+  const url = checkedDownloadUrl(location, from);
+  return url ? { kind: "follow", url } : { kind: "refused", target: location };
+}
+
+/**
+ * GET `url`, checking every redirect target against the host allowlist.
+ *
+ * The abort signal is created once and shared across the chain, so the timeout
+ * bounds the whole download instead of restarting at each hop.
+ */
+async function fetchCheckedDownload(url: URL, timeoutMs: number): Promise<Response> {
+  const signal = AbortSignal.timeout(timeoutMs);
+  let current = url;
+  for (let hop = 0; ; hop++) {
+    const res = await fetch(current, {
+      headers: { "User-Agent": "ck3-modding-vscode" },
+      redirect: "manual",
+      signal,
+    });
+    const step = redirectStep(res.status, res.headers.get("location"), current);
+    if (step.kind === "done") return res;
+    if (step.kind === "refused") {
+      throw new Error(`refusing to follow the redirect to ${step.target}: not an https GitHub release URL.`);
+    }
+    if (hop >= MAX_DOWNLOAD_REDIRECTS) {
+      throw new Error(`download of ${url.href} still redirecting after ${MAX_DOWNLOAD_REDIRECTS} hops.`);
+    }
+    try {
+      await res.body?.cancel();
+    } catch {
+      // a 3xx body is empty in practice; failing to drain it is not fatal
+    }
+    current = step.url;
+  }
 }
 
 /** Hang guards: without them a stalled connection leaves the progress notification up forever. */
@@ -204,10 +271,7 @@ export async function downloadLatestTiger(
   }
 
   report(`downloading ${assetUrl.href}...`);
-  const dlRes = await fetch(assetUrl, {
-    headers: { "User-Agent": "ck3-modding-vscode" },
-    signal: AbortSignal.timeout(DOWNLOAD_TIMEOUT_MS),
-  });
+  const dlRes = await fetchCheckedDownload(assetUrl, DOWNLOAD_TIMEOUT_MS);
   if (!dlRes.ok) throw new Error(`download failed with HTTP ${dlRes.status}.`);
   const buffer = Buffer.from(await dlRes.arrayBuffer());
   // tiger publishes no checksums, so there is nothing to verify against. The

--- a/packages/vscode/src/webviews/dashboard/view.ts
+++ b/packages/vscode/src/webviews/dashboard/view.ts
@@ -6,6 +6,7 @@ import { metaFor } from "../../meta";
 import type { FocusMod } from "../../views";
 import type { ErrorLogWatcher } from "../../errorLog";
 import { ICONS, visibleActionGroups, type ActionGroup } from "./actions";
+import { makeNonce } from "../nonce";
 
 /** The three collapsible sections, in render order. */
 type SectionId = "mods" | "toggles" | "tools";
@@ -752,11 +753,4 @@ vscode.postMessage({ type: "ready" });
 </script>
 </body>
 </html>`;
-}
-
-function makeNonce(): string {
-  const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
-  let out = "";
-  for (let i = 0; i < 32; i++) out += chars[Math.floor(Math.random() * chars.length)];
-  return out;
 }

--- a/packages/vscode/src/webviews/eventGraph/panel.ts
+++ b/packages/vscode/src/webviews/eventGraph/panel.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode";
 import type { EventDetail, EventGraph, EventGraphParams } from "@px-lsp/protocol/protocol";
 import { layoutGraph } from "./layout";
+import { makeNonce } from "../nonce";
 
 /** Messages the webview sends to the host. */
 type InboundMessage =
@@ -1277,11 +1278,4 @@ window.addEventListener("message", function (ev) {
 </body>
 </html>`;
   }
-}
-
-function makeNonce(): string {
-  const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
-  let out = "";
-  for (let i = 0; i < 32; i++) out += chars[Math.floor(Math.random() * chars.length)];
-  return out;
 }

--- a/packages/vscode/src/webviews/eventSim/panel.ts
+++ b/packages/vscode/src/webviews/eventSim/panel.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode";
 import type { EventDetail } from "@px-lsp/protocol/protocol";
 import { simulationSteps } from "./steps";
+import { makeNonce } from "../nonce";
 
 /** Messages the webview sends to the host. */
 type InboundMessage =
@@ -448,11 +449,4 @@ window.addEventListener("message", function (ev) {
 </script>
 </body>
 </html>`;
-}
-
-function makeNonce(): string {
-  const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
-  let out = "";
-  for (let i = 0; i < 32; i++) out += chars[Math.floor(Math.random() * chars.length)];
-  return out;
 }

--- a/packages/vscode/src/webviews/guiEditor/app/main.ts
+++ b/packages/vscode/src/webviews/guiEditor/app/main.ts
@@ -3572,7 +3572,7 @@ function guardedWrite(line: number, properties: EditProperty[]): void {
  */
 function renderArt(): void {
   const item = selectedItem();
-  const keys = textureKeys();
+  const keys = syncTextureKeys();
   const head = el("div", "head");
   head.appendChild(el("div", undefined, "Textures under gfx/"));
   head.appendChild(
@@ -3666,8 +3666,12 @@ let texturePropertyKey = "texture";
  * The widget's own texture-valued keys, found by their VALUES rather than by a
  * list of key names: a `.dds` in the value is what makes a property a texture,
  * and the vanilla trees spell that key several ways.
+ *
+ * Named `sync` because it also WRITES: a selection that does not carry the
+ * currently chosen key resets the choice to `texture`, which is what keeps the
+ * "Write to" dropdown and the key a pick writes from disagreeing.
  */
-function textureKeys(): string[] {
+function syncTextureKeys(): string[] {
   const widgetInfo = selectedInfo();
   const keys = new Set<string>(["texture"]);
   for (const property of widgetInfo?.properties ?? []) {

--- a/packages/vscode/src/webviews/guiEditor/panel.ts
+++ b/packages/vscode/src/webviews/guiEditor/panel.ts
@@ -50,6 +50,7 @@ import {
   type StoredComponents,
   type StoredPresets,
 } from "./userData";
+import { makeNonce } from "../nonce";
 
 export type FetchLayout = (
   uri: vscode.Uri,
@@ -802,11 +803,4 @@ function buildHtml(webview: vscode.Webview, script: vscode.Uri, fontDataUri: str
     ].join("; "),
     fontDataUri,
   });
-}
-
-function makeNonce(): string {
-  const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
-  let out = "";
-  for (let i = 0; i < 32; i++) out += chars[Math.floor(Math.random() * chars.length)];
-  return out;
 }

--- a/packages/vscode/src/webviews/guiEditor/panel.ts
+++ b/packages/vscode/src/webviews/guiEditor/panel.ts
@@ -86,12 +86,19 @@ type StoredVisibility = Record<string, GuiVisibilityOptions>;
 /**
  * Bounds on the texture walk. A game's `gfx/` tree is tens of thousands of
  * files deep in places, and the browser is a picker, not an asset database: the
- * walk stops at a depth no vanilla sprite path exceeds and at a file count that
- * still holds every texture either root realistically ships, and the answer
+ * walk stops at a depth no vanilla sprite path exceeds and at an entry count
+ * that still holds every texture either root realistically ships, and the answer
  * itself is capped far lower because the panel thumbnails what it lists.
+ *
+ * TEXTURE_WALK_MAX counts every entry the walk MEETS, not the `.dds` it keeps:
+ * models, meshes, `.asset` and portrait data are the bulk of a `gfx/` tree and
+ * they cost the same readdirSync work. Counting hits instead left the walk
+ * unbounded on exactly the trees it was meant to bound (a 22,314-entry tree with
+ * zero `.dds` measured 5,290 ms cold, 776 ms warm, all of it on the extension
+ * host). The value is raised to match the new unit.
  */
 const TEXTURE_WALK_DEPTH = 10;
-const TEXTURE_WALK_MAX = 20000;
+const TEXTURE_WALK_MAX = 200_000;
 const TEXTURE_ANSWER_MAX = 200;
 /** One page of thumbnails is what the app asks for; a longer batch is truncated. */
 const THUMBNAIL_BATCH_MAX = 60;
@@ -353,11 +360,11 @@ export class GuiEditorPanel {
         }
         for (const entry of entries) {
           if (budget <= 0) return;
+          budget--;
           const next = rel === "" ? entry.name : `${rel}/${entry.name}`;
           if (entry.isDirectory()) {
             walk(path.join(dir, entry.name), next, depth + 1);
           } else if (entry.name.toLowerCase().endsWith(".dds")) {
-            budget--;
             const key = `gfx/${next}`;
             if (!seen.has(key)) seen.set(key, { path: key, source });
           }

--- a/packages/vscode/src/webviews/guiEditor/panel.ts
+++ b/packages/vscode/src/webviews/guiEditor/panel.ts
@@ -179,8 +179,21 @@ export class GuiEditorPanel {
       loadGameFont(roots.gamePath, meta.uiFont)
     );
 
+    // onMessage awaits openTextDocument outside its own try, and the .gui can
+    // stop being openable while the panel is up (a branch switch, a rename, a
+    // mod rebuild that moves the folder). A rejection dropped here answers
+    // nothing, so the app's `committing` stays set forever: the canvas keeps
+    // drawing the stale live preview and every later gesture is swallowed by an
+    // `if (committing) return;` guard. Answer the message instead, verbatim.
     this.panel.webview.onDidReceiveMessage(
-      (message: AppToHost) => void this.onMessage(message),
+      (message: AppToHost) => {
+        void this.onMessage(message).catch((err: unknown) => {
+          const id = (message as { id?: number }).id;
+          const refused = err instanceof Error ? err.message : String(err);
+          if (id !== undefined) this.post({ type: "editVerdict", id, refused });
+          else this.post({ type: "error", message: refused });
+        });
+      },
       undefined,
       this.disposables
     );

--- a/packages/vscode/src/webviews/guiTree/panel.ts
+++ b/packages/vscode/src/webviews/guiTree/panel.ts
@@ -1,5 +1,6 @@
 import * as vscode from "vscode";
 import type { GuiTree } from "@px-lsp/protocol/protocol";
+import { makeNonce } from "../nonce";
 
 /** Messages the webview sends to the host. */
 type InboundMessage = { type: "open"; line: number; focus?: boolean } | { type: "refresh" };
@@ -505,11 +506,4 @@ window.addEventListener("message", (ev) => {
 </script>
 </body>
 </html>`;
-}
-
-function makeNonce(): string {
-  const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
-  let out = "";
-  for (let i = 0; i < 32; i++) out += chars[Math.floor(Math.random() * chars.length)];
-  return out;
 }

--- a/packages/vscode/src/webviews/nonce.ts
+++ b/packages/vscode/src/webviews/nonce.ts
@@ -1,0 +1,13 @@
+/**
+ * The CSP nonce every webview page declares.
+ *
+ * A nonce is a barrier to injected script only while it is unpredictable, and
+ * `Math.random()` is not a CSPRNG: V8's state is recoverable from observed
+ * output. Five hand-rolled copies of this used it. 24 random bytes is 32
+ * base64url characters, the same length those copies produced.
+ */
+import { randomBytes } from "crypto";
+
+export function makeNonce(): string {
+  return randomBytes(24).toString("base64url");
+}

--- a/packages/vscode/test/bigWorkspace.test.ts
+++ b/packages/vscode/test/bigWorkspace.test.ts
@@ -80,6 +80,15 @@ describe("countScriptFiles", () => {
     expect(countScriptFiles([root], 5)).toEqual({ files: 5, partial: true });
   });
 
+  it("stops on entries visited too, not only on files matched", () => {
+    // A tree with no script files at all: the file cap can never fire, so
+    // without an entry bound this walks the whole thing on the activation path.
+    const files: string[] = [];
+    for (let i = 0; i < 40; i++) files.push(`gfx/portraits/p${i}.dds`);
+    const root = modTree(files);
+    expect(countScriptFiles([root], 2)).toEqual({ files: 0, partial: true });
+  });
+
   it("contributes nothing for a root that does not exist", () => {
     expect(countScriptFiles([path.join("D:", "nope", "gone")], 10)).toEqual({ files: 0, partial: false });
   });

--- a/packages/vscode/test/onboarding.test.ts
+++ b/packages/vscode/test/onboarding.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest";
 import { parseLibraryFoldersVdf } from "../src/steamDetect";
-import { checkedDownloadUrl, pickTigerAsset, preferPlainBinary, tigerFlavorFor } from "../src/tigerDownload";
+import {
+  checkedDownloadUrl,
+  pickTigerAsset,
+  preferPlainBinary,
+  redirectStep,
+  tigerFlavorFor,
+} from "../src/tigerDownload";
 
 describe("parseLibraryFoldersVdf", () => {
   it("extracts every library path with unescaped backslashes", () => {
@@ -95,5 +101,45 @@ describe("checkedDownloadUrl", () => {
     expect(checkedDownloadUrl("https://github.com.evil.test/a.zip")).toBeNull();
     expect(checkedDownloadUrl("file:///C:/a.zip")).toBeNull();
     expect(checkedDownloadUrl("not a url")).toBeNull();
+  });
+
+  it("resolves a relative Location against the hop that sent it", () => {
+    const from = new URL("https://github.com/amtep/ck3-tiger/releases/download/v1/a.zip");
+    expect(checkedDownloadUrl("/other/a.zip", from)?.href).toBe("https://github.com/other/a.zip");
+    // A relative target cannot leave the host, but an absolute one ignores the base.
+    expect(checkedDownloadUrl("https://evil.test/a.zip", from)).toBeNull();
+  });
+});
+
+describe("redirectStep", () => {
+  const from = new URL("https://github.com/amtep/ck3-tiger/releases/download/v1/a.zip");
+
+  it("follows the signed CDN hop a GitHub release download answers with", () => {
+    const step = redirectStep(302, "https://objects.githubusercontent.com/x/a.zip?token=1", from);
+    expect(step).toEqual({
+      kind: "follow",
+      url: new URL("https://objects.githubusercontent.com/x/a.zip?token=1"),
+    });
+  });
+
+  it("refuses a hop off the allowlist, which is what would deliver the bytes", () => {
+    for (const status of [301, 302, 303, 307, 308]) {
+      expect(redirectStep(status, "https://evil.test/a.zip", from)).toEqual({
+        kind: "refused",
+        target: "https://evil.test/a.zip",
+      });
+    }
+    expect(redirectStep(302, "http://github.com/a.zip", from)).toEqual({
+      kind: "refused",
+      target: "http://github.com/a.zip",
+    });
+  });
+
+  it("treats a non-redirect, or a redirect without a target, as the final response", () => {
+    expect(redirectStep(200, null, from)).toEqual({ kind: "done" });
+    expect(redirectStep(404, null, from)).toEqual({ kind: "done" });
+    // A stray Location on a 200 is not a redirect and must not be chased.
+    expect(redirectStep(200, "https://evil.test/a.zip", from)).toEqual({ kind: "done" });
+    expect(redirectStep(302, null, from)).toEqual({ kind: "done" });
   });
 });

--- a/packages/vscode/test/onboarding.test.ts
+++ b/packages/vscode/test/onboarding.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { parseLibraryFoldersVdf } from "../src/steamDetect";
-import { pickTigerAsset, preferPlainBinary, tigerFlavorFor } from "../src/tigerDownload";
+import { checkedDownloadUrl, pickTigerAsset, preferPlainBinary, tigerFlavorFor } from "../src/tigerDownload";
 
 describe("parseLibraryFoldersVdf", () => {
   it("extracts every library path with unescaped backslashes", () => {
@@ -77,5 +77,23 @@ describe("preferPlainBinary", () => {
   it("falls back to the only binary present and to null when empty", () => {
     expect(preferPlainBinary(["/x/ck3-tiger-auto.exe"])).toBe("/x/ck3-tiger-auto.exe");
     expect(preferPlainBinary([])).toBeNull();
+  });
+});
+
+describe("checkedDownloadUrl", () => {
+  it("accepts the two hosts a GitHub release download resolves to", () => {
+    expect(checkedDownloadUrl("https://github.com/amtep/ck3-tiger/releases/download/v1/a.zip")?.host).toBe(
+      "github.com"
+    );
+    expect(checkedDownloadUrl("https://objects.githubusercontent.com/x/a.zip")?.host).toBe(
+      "objects.githubusercontent.com"
+    );
+  });
+
+  it("refuses anything else, since the bytes are unpacked and executed", () => {
+    expect(checkedDownloadUrl("http://github.com/a.zip")).toBeNull();
+    expect(checkedDownloadUrl("https://github.com.evil.test/a.zip")).toBeNull();
+    expect(checkedDownloadUrl("file:///C:/a.zip")).toBeNull();
+    expect(checkedDownloadUrl("not a url")).toBeNull();
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,15 +113,9 @@ importers:
       '@px-lsp/server':
         specifier: workspace:*
         version: link:../server
-      '@types/node':
-        specifier: ^20.14.0
-        version: 20.19.43
       '@types/vscode':
         specifier: ^1.90.0
         version: 1.125.0
-      esbuild:
-        specifier: ^0.24.0
-        version: 0.24.2
 
 packages:
 
@@ -231,34 +225,16 @@ packages:
     resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
     engines: {node: '>=20.19.0'}
 
-  '@esbuild/aix-ppc64@0.24.2':
-    resolution: {integrity: sha512-thpVCb/rhxE/BnMLQ7GReQLLN8q9qbHmI55F4489/ByVg2aQaQ6kbcLb6FHkocZzQhxc4gx0sCk0tJkKBFzDhA==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [aix]
-
   '@esbuild/aix-ppc64@0.28.1':
     resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.24.2':
-    resolution: {integrity: sha512-cNLgeqCqV8WxfcTIOeL4OAtSmL8JjcN6m09XIgro1Wi7cF4t/THaWEa7eL5CMoMBdjoHOTh/vwTO/o2TRXIyzg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [android]
-
   '@esbuild/android-arm64@0.28.1':
     resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [android]
-
-  '@esbuild/android-arm@0.24.2':
-    resolution: {integrity: sha512-tmwl4hJkCfNHwFB3nBa8z1Uy3ypZpxqxfTQOcHX+xRByyYgunVbZ9MzUUfb0RxaHIMnbHagwAxuTL+tnNM+1/Q==}
-    engines: {node: '>=18'}
-    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.28.1':
@@ -267,34 +243,16 @@ packages:
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.24.2':
-    resolution: {integrity: sha512-B6Q0YQDqMx9D7rvIcsXfmJfvUYLoP722bgfBlO5cGvNVb5V/+Y7nhBE3mHV9OpxBf4eAS2S68KZztiPaWq4XYw==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [android]
-
   '@esbuild/android-x64@0.28.1':
     resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.24.2':
-    resolution: {integrity: sha512-kj3AnYWc+CekmZnS5IPu9D+HWtUI49hbnyqk0FLEJDbzCIQt7hg7ucF1SQAilhtYpIujfaHr6O0UHlzzSPdOeA==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [darwin]
-
   '@esbuild/darwin-arm64@0.28.1':
     resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [darwin]
-
-  '@esbuild/darwin-x64@0.24.2':
-    resolution: {integrity: sha512-WeSrmwwHaPkNR5H3yYfowhZcbriGqooyu3zI/3GGpF8AyUdsrrP0X6KumITGA9WOyiJavnGZUwPGvxvwfWPHIA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.28.1':
@@ -303,22 +261,10 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.24.2':
-    resolution: {integrity: sha512-UN8HXjtJ0k/Mj6a9+5u6+2eZ2ERD7Edt1Q9IZiB5UZAIdPnVKDoG7mdTVGhHJIeEml60JteamR3qhsr1r8gXvg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [freebsd]
-
   '@esbuild/freebsd-arm64@0.28.1':
     resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [freebsd]
-
-  '@esbuild/freebsd-x64@0.24.2':
-    resolution: {integrity: sha512-TvW7wE/89PYW+IevEJXZ5sF6gJRDY/14hyIGFXdIucxCsbRmLUcjseQu1SyTko+2idmCw94TgyaEZi9HUSOe3Q==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.28.1':
@@ -327,22 +273,10 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.24.2':
-    resolution: {integrity: sha512-7HnAD6074BW43YvvUmE/35Id9/NB7BeX5EoNkK9obndmZBUk8xmJJeU7DwmUeN7tkysslb2eSl6CTrYz6oEMQg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [linux]
-
   '@esbuild/linux-arm64@0.28.1':
     resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [linux]
-
-  '@esbuild/linux-arm@0.24.2':
-    resolution: {integrity: sha512-n0WRM/gWIdU29J57hJyUdIsk0WarGd6To0s+Y+LwvlC55wt+GT/OgkwoXCXvIue1i1sSNWblHEig00GBWiJgfA==}
-    engines: {node: '>=18'}
-    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.28.1':
@@ -351,22 +285,10 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.24.2':
-    resolution: {integrity: sha512-sfv0tGPQhcZOgTKO3oBE9xpHuUqguHvSo4jl+wjnKwFpapx+vUDcawbwPNuBIAYdRAvIDBfZVvXprIj3HA+Ugw==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [linux]
-
   '@esbuild/linux-ia32@0.28.1':
     resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
     engines: {node: '>=18'}
     cpu: [ia32]
-    os: [linux]
-
-  '@esbuild/linux-loong64@0.24.2':
-    resolution: {integrity: sha512-CN9AZr8kEndGooS35ntToZLTQLHEjtVB5n7dl8ZcTZMonJ7CCfStrYhrzF97eAecqVbVJ7APOEe18RPI4KLhwQ==}
-    engines: {node: '>=18'}
-    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.28.1':
@@ -375,22 +297,10 @@ packages:
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.24.2':
-    resolution: {integrity: sha512-iMkk7qr/wl3exJATwkISxI7kTcmHKE+BlymIAbHO8xanq/TjHaaVThFF6ipWzPHryoFsesNQJPE/3wFJw4+huw==}
-    engines: {node: '>=18'}
-    cpu: [mips64el]
-    os: [linux]
-
   '@esbuild/linux-mips64el@0.28.1':
     resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
     engines: {node: '>=18'}
     cpu: [mips64el]
-    os: [linux]
-
-  '@esbuild/linux-ppc64@0.24.2':
-    resolution: {integrity: sha512-shsVrgCZ57Vr2L8mm39kO5PPIb+843FStGt7sGGoqiiWYconSxwTiuswC1VJZLCjNiMLAMh34jg4VSEQb+iEbw==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.28.1':
@@ -399,22 +309,10 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.24.2':
-    resolution: {integrity: sha512-4eSFWnU9Hhd68fW16GD0TINewo1L6dRrB+oLNNbYyMUAeOD2yCK5KXGK1GH4qD/kT+bTEXjsyTCiJGHPZ3eM9Q==}
-    engines: {node: '>=18'}
-    cpu: [riscv64]
-    os: [linux]
-
   '@esbuild/linux-riscv64@0.28.1':
     resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
     engines: {node: '>=18'}
     cpu: [riscv64]
-    os: [linux]
-
-  '@esbuild/linux-s390x@0.24.2':
-    resolution: {integrity: sha512-S0Bh0A53b0YHL2XEXC20bHLuGMOhFDO6GN4b3YjRLK//Ep3ql3erpNcPlEFed93hsQAjAQDNsvcK+hV90FubSw==}
-    engines: {node: '>=18'}
-    cpu: [s390x]
     os: [linux]
 
   '@esbuild/linux-s390x@0.28.1':
@@ -423,34 +321,16 @@ packages:
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-x64@0.24.2':
-    resolution: {integrity: sha512-8Qi4nQcCTbLnK9WoMjdC9NiTG6/E38RNICU6sUNqK0QFxCYgoARqVqxdFmWkdonVsvGqWhmm7MO0jyTqLqwj0Q==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [linux]
-
   '@esbuild/linux-x64@0.28.1':
     resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/netbsd-arm64@0.24.2':
-    resolution: {integrity: sha512-wuLK/VztRRpMt9zyHSazyCVdCXlpHkKm34WUyinD2lzK07FAHTq0KQvZZlXikNWkDGoT6x3TD51jKQ7gMVpopw==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [netbsd]
-
   '@esbuild/netbsd-arm64@0.28.1':
     resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [netbsd]
-
-  '@esbuild/netbsd-x64@0.24.2':
-    resolution: {integrity: sha512-VefFaQUc4FMmJuAxmIHgUmfNiLXY438XrL4GDNV1Y1H/RW3qow68xTwjZKfj/+Plp9NANmzbH5R40Meudu8mmw==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [netbsd]
 
   '@esbuild/netbsd-x64@0.28.1':
@@ -459,22 +339,10 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/openbsd-arm64@0.24.2':
-    resolution: {integrity: sha512-YQbi46SBct6iKnszhSvdluqDmxCJA+Pu280Av9WICNwQmMxV7nLRHZfjQzwbPs3jeWnuAhE9Jy0NrnJ12Oz+0A==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openbsd]
-
   '@esbuild/openbsd-arm64@0.28.1':
     resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [openbsd]
-
-  '@esbuild/openbsd-x64@0.24.2':
-    resolution: {integrity: sha512-+iDS6zpNM6EnJyWv0bMGLWSWeXGN/HTaF/LXHXHwejGsVi+ooqDfMCCTerNFxEkM3wYVcExkeGXNqshc9iMaOA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.28.1':
@@ -489,23 +357,11 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
-  '@esbuild/sunos-x64@0.24.2':
-    resolution: {integrity: sha512-hTdsW27jcktEvpwNHJU4ZwWFGkz2zRJUz8pvddmXPtXDzVKTTINmlmga3ZzwcuMpUvLw7JkLy9QLKyGpD2Yxig==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [sunos]
-
   '@esbuild/sunos-x64@0.28.1':
     resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
-
-  '@esbuild/win32-arm64@0.24.2':
-    resolution: {integrity: sha512-LihEQ2BBKVFLOC9ZItT9iFprsE9tqjDjnbulhHoFxYQtQfai7qfluVODIYxt1PgdoyQkz23+01rzwNwYfutxUQ==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [win32]
 
   '@esbuild/win32-arm64@0.28.1':
     resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
@@ -513,22 +369,10 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.24.2':
-    resolution: {integrity: sha512-q+iGUwfs8tncmFC9pcnD5IvRHAzmbwQ3GPS5/ceCyHdjXubwQWI12MKWSNSMYLJMq23/IUCvJMS76PDqXe1fxA==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [win32]
-
   '@esbuild/win32-ia32@0.28.1':
     resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
     engines: {node: '>=18'}
     cpu: [ia32]
-    os: [win32]
-
-  '@esbuild/win32-x64@0.24.2':
-    resolution: {integrity: sha512-7VTgWzgMGvup6aSqDPLiW5zHaxYJGTO4OokMjIlrCtf+VpEL+cXKtCvg723iguPYI5oaUNdS+/V7OU2gvXVWEg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.28.1':
@@ -825,9 +669,6 @@ packages:
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
-
-  '@types/node@20.19.43':
-    resolution: {integrity: sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==}
 
   '@types/node@26.1.1':
     resolution: {integrity: sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==}
@@ -1297,11 +1138,6 @@ packages:
   es-set-tostringtag@2.1.0:
     resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
-
-  esbuild@0.24.2:
-    resolution: {integrity: sha512-+9egpBW8I3CD5XPe0n6BfT5fxLzxrlDzqydF3aviG+9ni1lDC/OvMHcxqEFV0+LANZG5R1bFMWfUrjVsdwxJvA==}
-    engines: {node: '>=18'}
-    hasBin: true
 
   esbuild@0.28.1:
     resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
@@ -2283,9 +2119,6 @@ packages:
   underscore@1.13.8:
     resolution: {integrity: sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==}
 
-  undici-types@6.21.0:
-    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
-
   undici-types@7.29.0:
     resolution: {integrity: sha512-vamA8dGlzMwhpyYpQp9d8vka3o4D/yn5I7ez7Or+msDA4bZ8Uh+Zy91WvWf3I73gDAkFha9JcYRqm2li0Npfgg==}
 
@@ -2656,127 +2489,64 @@ snapshots:
 
   '@csstools/css-tokenizer@4.0.0': {}
 
-  '@esbuild/aix-ppc64@0.24.2':
-    optional: true
-
   '@esbuild/aix-ppc64@0.28.1':
-    optional: true
-
-  '@esbuild/android-arm64@0.24.2':
     optional: true
 
   '@esbuild/android-arm64@0.28.1':
     optional: true
 
-  '@esbuild/android-arm@0.24.2':
-    optional: true
-
   '@esbuild/android-arm@0.28.1':
-    optional: true
-
-  '@esbuild/android-x64@0.24.2':
     optional: true
 
   '@esbuild/android-x64@0.28.1':
     optional: true
 
-  '@esbuild/darwin-arm64@0.24.2':
-    optional: true
-
   '@esbuild/darwin-arm64@0.28.1':
-    optional: true
-
-  '@esbuild/darwin-x64@0.24.2':
     optional: true
 
   '@esbuild/darwin-x64@0.28.1':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.24.2':
-    optional: true
-
   '@esbuild/freebsd-arm64@0.28.1':
-    optional: true
-
-  '@esbuild/freebsd-x64@0.24.2':
     optional: true
 
   '@esbuild/freebsd-x64@0.28.1':
     optional: true
 
-  '@esbuild/linux-arm64@0.24.2':
-    optional: true
-
   '@esbuild/linux-arm64@0.28.1':
-    optional: true
-
-  '@esbuild/linux-arm@0.24.2':
     optional: true
 
   '@esbuild/linux-arm@0.28.1':
     optional: true
 
-  '@esbuild/linux-ia32@0.24.2':
-    optional: true
-
   '@esbuild/linux-ia32@0.28.1':
-    optional: true
-
-  '@esbuild/linux-loong64@0.24.2':
     optional: true
 
   '@esbuild/linux-loong64@0.28.1':
     optional: true
 
-  '@esbuild/linux-mips64el@0.24.2':
-    optional: true
-
   '@esbuild/linux-mips64el@0.28.1':
-    optional: true
-
-  '@esbuild/linux-ppc64@0.24.2':
     optional: true
 
   '@esbuild/linux-ppc64@0.28.1':
     optional: true
 
-  '@esbuild/linux-riscv64@0.24.2':
-    optional: true
-
   '@esbuild/linux-riscv64@0.28.1':
-    optional: true
-
-  '@esbuild/linux-s390x@0.24.2':
     optional: true
 
   '@esbuild/linux-s390x@0.28.1':
     optional: true
 
-  '@esbuild/linux-x64@0.24.2':
-    optional: true
-
   '@esbuild/linux-x64@0.28.1':
-    optional: true
-
-  '@esbuild/netbsd-arm64@0.24.2':
     optional: true
 
   '@esbuild/netbsd-arm64@0.28.1':
     optional: true
 
-  '@esbuild/netbsd-x64@0.24.2':
-    optional: true
-
   '@esbuild/netbsd-x64@0.28.1':
     optional: true
 
-  '@esbuild/openbsd-arm64@0.24.2':
-    optional: true
-
   '@esbuild/openbsd-arm64@0.28.1':
-    optional: true
-
-  '@esbuild/openbsd-x64@0.24.2':
     optional: true
 
   '@esbuild/openbsd-x64@0.28.1':
@@ -2785,25 +2555,13 @@ snapshots:
   '@esbuild/openharmony-arm64@0.28.1':
     optional: true
 
-  '@esbuild/sunos-x64@0.24.2':
-    optional: true
-
   '@esbuild/sunos-x64@0.28.1':
-    optional: true
-
-  '@esbuild/win32-arm64@0.24.2':
     optional: true
 
   '@esbuild/win32-arm64@0.28.1':
     optional: true
 
-  '@esbuild/win32-ia32@0.24.2':
-    optional: true
-
   '@esbuild/win32-ia32@0.28.1':
-    optional: true
-
-  '@esbuild/win32-x64@0.24.2':
     optional: true
 
   '@esbuild/win32-x64@0.28.1':
@@ -3086,10 +2844,6 @@ snapshots:
       undici-types: 7.29.0
 
   '@types/json-schema@7.0.15': {}
-
-  '@types/node@20.19.43':
-    dependencies:
-      undici-types: 6.21.0
 
   '@types/node@26.1.1':
     dependencies:
@@ -3624,34 +3378,6 @@ snapshots:
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
       hasown: 2.0.4
-
-  esbuild@0.24.2:
-    optionalDependencies:
-      '@esbuild/aix-ppc64': 0.24.2
-      '@esbuild/android-arm': 0.24.2
-      '@esbuild/android-arm64': 0.24.2
-      '@esbuild/android-x64': 0.24.2
-      '@esbuild/darwin-arm64': 0.24.2
-      '@esbuild/darwin-x64': 0.24.2
-      '@esbuild/freebsd-arm64': 0.24.2
-      '@esbuild/freebsd-x64': 0.24.2
-      '@esbuild/linux-arm': 0.24.2
-      '@esbuild/linux-arm64': 0.24.2
-      '@esbuild/linux-ia32': 0.24.2
-      '@esbuild/linux-loong64': 0.24.2
-      '@esbuild/linux-mips64el': 0.24.2
-      '@esbuild/linux-ppc64': 0.24.2
-      '@esbuild/linux-riscv64': 0.24.2
-      '@esbuild/linux-s390x': 0.24.2
-      '@esbuild/linux-x64': 0.24.2
-      '@esbuild/netbsd-arm64': 0.24.2
-      '@esbuild/netbsd-x64': 0.24.2
-      '@esbuild/openbsd-arm64': 0.24.2
-      '@esbuild/openbsd-x64': 0.24.2
-      '@esbuild/sunos-x64': 0.24.2
-      '@esbuild/win32-arm64': 0.24.2
-      '@esbuild/win32-ia32': 0.24.2
-      '@esbuild/win32-x64': 0.24.2
 
   esbuild@0.28.1:
     optionalDependencies:
@@ -4740,8 +4466,6 @@ snapshots:
   uc.micro@2.1.0: {}
 
   underscore@1.13.8: {}
-
-  undici-types@6.21.0: {}
 
   undici-types@7.29.0: {}
 


### PR DESCRIPTION
Fixes the verified findings from the 2026-08 adversarial audit. Fifteen of the sixteen items are here, one commit per item or per related pair. Every claim marked unsure was checked against the code first. Nothing outside the named findings was touched.

## Fixed

| id | severity | what was done |
|---|---|---|
| 1 | medium | `parseHeader` now budgets the decode by pixel count (`MAX_DECODE_PIXELS = 4096*4096`, the cap `textureCache.ts` already applied after the fact), so all three call sites inherit it. It throws instead of returning null, so `ddsFormatInfo` still reports the declared size and the `.dds` editor says "preview failed: image too large" rather than "not a DDS file". Every decoder now checks the data length before allocating. New test covers a 128-byte header declaring 65535x65535. |
| 3 | low | The GUI editor's message pump catches a rejected `onMessage` and answers it: the message's own id gets an `editVerdict` with the reason verbatim, anything else gets an `error`. The app can clear `committing` again, so a `.gui` that vanishes mid-session no longer leaves the panel drawing a stale preview and swallowing every gesture. |
| 4 | medium | The `gfx/` walk's budget decrements per entry visited instead of per `.dds` found, and `TEXTURE_WALK_MAX` is raised to 200,000 to match the new unit. Directories and the non-`.dds` bulk of a `gfx/` tree now count toward the stop condition. |
| 5 | low | `downloadLatestTiger` uses `promisify(execFile)` and awaits both child processes, so tar and the `--version` probe no longer block the extension host. |
| 6 | low | The tiger download URL must be https and `github.com` or `objects.githubusercontent.com` (`checkedDownloadUrl`, unit tested). The sha256 of the bytes goes to the output channel so it can be compared with the release page by hand; upstream publishes no checksum to verify against. Both fetches carry a timeout. |
| 7 | medium | `fsWalk` grows `iterFiles()`: the same walk as a generator, yielding each match and a `null` every 500 entries visited. Both root scans drive their listing from that rhythm, so the listing phase yields and aborts on supersede like the read phase already did. `listFiles` and `walkDir` keep their signatures. |
| 8 | low | `packages/vscode` no longer declares its own `esbuild` and `@types/node`. `node_modules/.pnpm` now holds one esbuild (0.28.1) and one `@types/node` (26.1.1), and `pnpm run compile` still builds all three bundles. |
| 9 | low | The DDS preview and the image converter declare and carry a CSP nonce, like the other five webviews. |
| 10 | low | Five copies of `makeNonce()` built from `Math.random()` are replaced by `webviews/nonce.ts`: `randomBytes(24)` as base64url, same 32 characters, from the platform CSPRNG. |
| 13 | low | `textureKeys()` is renamed `syncTextureKeys()` and its comment says what it writes. The reset is the wanted behaviour and its only caller relies on it, so the name was the defect. |
| 14 | low | Documented, not rewritten. The measured cost (26.3 MB, 528 ms to save, 271 ms to load at 460k definitions) and the ~512 MB string ceiling are now stated at the function, together with the fact that both call paths already degrade to "no cache" on a `RangeError`. The worklist conditioned the newline-delimited rewrite on this showing up in the perf trace; it is a sub-second one-off that replaces a multi-second rescan, so the format is unchanged. |
| 15 | low | `countScriptFiles` also stops after `cap * 10` entries visited and reports the count as partial. The answer feeds a yes/no threshold question, so a floor is as good as an exact count, and a mod's art tree no longer gets walked in full on the activation path. New test covers a tree with no script files in it. |
| 17 | low | `pnpm.onlyBuiltDependencies` records the decision. `@vscode/vsce-sign` is included alongside esbuild and keytar because it was in the ignored set too; the install is warning free again. |
| 18 | low | Both packages say `private: true` instead of `publishConfig.access: "public"`, the dead `prepublishOnly` hook is gone, and `packages/server/README.md` says the release tarball is the distribution. From npm the `exports` never resolved: they map every subpath to raw `.ts`. |
| 19 | low | `collectOutput` keeps tiger's stdout and stderr as buffers and decodes once at close, which also fixes a multi-byte character split across a chunk boundary. Past 256 MB the bytes are dropped and the run is reported as unreadable. |

## Skipped

- **[2] split `guiEditor/app/main.ts` (4137 lines).** The line counts are right, but the seam the item names is not there. Measured against the file: the devtools halo needs 38 top-level names from the rest of `main.ts` and leaks 27 back into it; the inspector needs 29 and leaks 6; gestures needs 28 and leaks 14; the tree, layers and palette panels need 17, 19 and 16. The item's premise for the two big extractions ("no other section reads their state") does not hold, so this is a redesign of the app shell rather than a move, and it is not something to land unreviewed on an audit-fix branch. The two genuinely free pieces (`toasts`, 27 lines, needs only its own DOM root; `edits`, 58 lines, needs only `host`) are available on their own if you want a first step. Everything else in the file is bound to shared mutable state.

## Checks

One run, on this branch, after all changes.

- `pnpm install` — pass. No ignored-build-scripts warning any more; the lockfile is updated by the `packages/vscode` dependency removal.
- `pnpm run typecheck` (`tsc --noEmit` plus the webview app project) — pass, clean.
- `pnpm run lint` (`eslint .` plus `prettier --check .`) — pass, zero findings, "All matched files use Prettier code style!".
- `pnpm run compile` — pass. server.js 2.0 mb, extension.js 1.3 mb, guiEditor.js 153.4 kb.
- `pnpm test` (vitest 4.1.10) — pass: 101 files / 1424 tests passed, 6 files / 40 tests skipped, 17 s. The skips are the corpus-gated suites (no `dev-paths.json`, no game install). More suites ran than in the audit because `dist/` was built first, as CI does.

Nothing was failing before these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Harden audit-identified resource, network, webview, and packaging behaviors while preserving existing APIs and fallback paths.

Bug Fixes:
- Prevent oversized or truncated DDS files from causing excessive memory allocation and provide clearer preview failures.
- Keep GUI editing responsive after message-handler failures and bound filesystem scans by visited entries.
- Prevent extension-host blocking during Tiger downloads and handle unsafe redirects, stalled requests, and excessive or invalid process output safely.

Enhancements:
- Use a shared cryptographically secure nonce implementation and apply CSP nonces to all affected webviews.
- Make recursive file discovery yield periodically so indexing and reference scans can be superseded without blocking requests.
- Clarify index-cache limitations and align texture-key naming with its state-reset behavior.

Build:
- Consolidate esbuild and Node type dependencies at the workspace level and update the lockfile.
- Declare approved native dependencies for pnpm builds and mark non-publishable workspace packages as private.

Documentation:
- Document the server release tarball as the distribution method and record index-cache performance characteristics and fallback behavior.

Tests:
- Add coverage for oversized DDS headers, paced walks over unmatched trees, bounded script counting, and validated download redirects.