### PR TITLE
DDS viewer rework + texture size/encoding in hover (closes #15)

### DIFF
--- a/packages/server/src/features/textureHover.ts
+++ b/packages/server/src/features/textureHover.ts
@@ -9,7 +9,7 @@ import type { TextDocument } from "vscode-languageserver-textdocument";
 import { URI } from "vscode-uri";
 import * as fs from "fs";
 import * as path from "path";
-import { ddsToPngDataUri } from "../dds";
+import { ddsFormatInfo, ddsToPngDataUri } from "../dds";
 import { getLineText } from "../documents";
 import type { ParadoxSettings } from "@px-lsp/protocol/protocol";
 import { assetRoots, bareNameBaseDirs } from "./assetPaths";
@@ -17,30 +17,53 @@ import { assetRoots, bareNameBaseDirs } from "./assetPaths";
 const DDS_PATH = /[A-Za-z0-9_\-./\\]+\.dds/gi;
 const CACHE_MAX = 100;
 
-/** data-URI cache keyed by fsPath:mtime. */
-const cache = new Map<string, string | null>();
+interface TexturePreview {
+  /** PNG data URI, or null when the format can't be decoded. */
+  uri: string | null;
+  format: string;
+  width: number;
+  height: number;
+  fileBytes: number;
+}
 
-function cachedDataUri(fsPath: string): string | null {
-  let mtime: number;
+/** Preview cache keyed by fsPath:mtime. */
+const cache = new Map<string, TexturePreview | null>();
+
+function cachedPreview(fsPath: string): TexturePreview | null {
+  let stat: fs.Stats;
   try {
-    mtime = fs.statSync(fsPath).mtimeMs;
+    stat = fs.statSync(fsPath);
   } catch {
     return null;
   }
-  const key = `${fsPath}:${mtime}`;
+  const key = `${fsPath}:${stat.mtimeMs}`;
   if (cache.has(key)) return cache.get(key) ?? null;
-  let uri: string | null;
+  let entry: TexturePreview | null = null;
   try {
-    uri = ddsToPngDataUri(fs.readFileSync(fsPath), 256);
+    const buf = fs.readFileSync(fsPath);
+    const info = ddsFormatInfo(buf);
+    if (info) {
+      let uri: string | null;
+      try {
+        uri = ddsToPngDataUri(buf, 256);
+      } catch {
+        uri = null; // unsupported format → caller degrades to a file link
+      }
+      entry = { uri, format: info.format, width: info.width, height: info.height, fileBytes: stat.size };
+    }
   } catch {
-    uri = null; // unsupported format → caller degrades to a file link
+    entry = null;
   }
   if (cache.size >= CACHE_MAX) {
     const first = cache.keys().next().value;
     if (first !== undefined) cache.delete(first);
   }
-  cache.set(key, uri);
-  return uri;
+  cache.set(key, entry);
+  return entry;
+}
+
+function formatBytes(n: number): string {
+  return n >= 1024 * 1024 ? `${(n / (1024 * 1024)).toFixed(1)} MB` : `${(n / 1024).toFixed(1)} KB`;
 }
 
 export function provideTextureHover(
@@ -107,9 +130,14 @@ export function provideTextureHover(
     end: { line: position.line, character: hit.end },
   };
   const fileLink = URI.file(resolved.fsPath).toString();
-  const dataUri = cachedDataUri(resolved.fsPath);
-  const body = dataUri
-    ? `![texture](${dataUri})\n\n*${rel} (${resolved.label})* — [open file](${fileLink})`
-    : `Texture *${rel}* (${resolved.label}) — format not previewable, [open file](${fileLink})`;
+  const preview = cachedPreview(resolved.fsPath);
+  // The path is what's hovered, so the caption carries what the file itself
+  // knows: dimensions, encoding, size on disk, and where it resolved.
+  const meta = preview
+    ? `${preview.width}×${preview.height} · ${preview.format} · ${formatBytes(preview.fileBytes)} · ${resolved.label}`
+    : `texture (${resolved.label})`;
+  const body = preview?.uri
+    ? `![texture](${preview.uri})\n\n*${meta}* — [open file](${fileLink})`
+    : `*${meta}* — not previewable, [open file](${fileLink})`;
   return { contents: { kind: MarkupKind.Markdown, value: body }, range };
 }

--- a/packages/server/test/assetPaths.test.ts
+++ b/packages/server/test/assetPaths.test.ts
@@ -195,8 +195,8 @@ gated("asset paths against vanilla", () => {
     const hover = provideTextureHover(settings, doc, { line: 1, character: 12 }, "trait");
     expect(hover).not.toBeNull();
     const value = (hover!.contents as { value: string }).value;
-    expect(value).toContain("reveler.dds");
-    expect(value).toContain("vanilla");
+    // The caption carries dimensions + encoding + size, not the (redundant) path.
+    expect(value).toMatch(/\d+×\d+ · \S+ · [\d.]+ [KM]B · vanilla/);
   });
 
   it("does not resolve a bare icon when the field is not a mapped bare-name field", () => {

--- a/packages/vscode/src/ddsEditor.ts
+++ b/packages/vscode/src/ddsEditor.ts
@@ -134,7 +134,7 @@ function pageHtml(opts: {
   const barButton = (id: string, name_: Parameters<typeof icon>[0], label: string, tip: string): string =>
     `<button id="${id}" class="px-btn" data-variant="ghost" data-size="sm" data-tip="${tip}" data-tip-wrap>${icon(name_)}${label}</button>`;
   const toolButton = (id: string, name_: Parameters<typeof icon>[0], tip: string): string =>
-    `<button id="${id}" class="px-btn" data-variant="ghost" data-size="icon-sm" data-tip="${tip}" data-tip-side="right" data-tip-wrap>${icon(name_)}</button>`;
+    `<button id="${id}" class="px-btn" data-variant="ghost" data-size="icon-sm" data-tip="${tip}" data-tip-wrap>${icon(name_)}</button>`;
 
   const stage = error
     ? `<div class="err">${escapeHtml(error)}</div>`
@@ -142,13 +142,13 @@ function pageHtml(opts: {
   <img id="img" src="${dataUri}" />
   <div id="stageTools">
     ${toolButton("zout", "zoomOut", "Zoom out")}
-    <span id="zoomLabel" class="px-muted px-xs" data-tip="Wheel zooms, drag pans" data-tip-side="right" data-tip-wrap>100%</span>
+    <span id="zoomLabel" class="px-muted px-xs" data-tip="Wheel zooms, drag pans" data-tip-wrap>100%</span>
     ${toolButton("zin", "zoomIn", "Zoom in")}
     <div class="px-separator" data-orientation="vertical"></div>
     ${toolButton("zfit", "maximize", "Fit the image to the window")}
     ${toolButton("recenter", "locate", "Recenter at the current zoom")}
     <div class="px-separator" data-orientation="vertical"></div>
-    <label class="px-toggle" data-size="sm" data-tip="Pixelated: nearest-neighbour scaling to inspect single pixels. Off matches how the game samples the texture (smooth)" data-tip-side="right" data-tip-wrap><input id="pix" type="checkbox" />${icon("grid")}</label>
+    <label class="px-toggle" data-size="sm" data-tip="Pixelated: nearest-neighbour scaling to inspect single pixels. Off matches how the game samples the texture (smooth)" data-tip-wrap><input id="pix" type="checkbox" />${icon("grid")}</label>
   </div>`;
 
   return /* html */ `<!DOCTYPE html>
@@ -188,6 +188,8 @@ ${uiCss}
     background: color-mix(in oklch, var(--px-bg) 75%, transparent);
   }
   #zoomLabel { min-width: 44px; height: var(--px-h-sm); line-height: var(--px-h-sm); padding: 0 6px; text-align: center; font-variant-numeric: tabular-nums; cursor: default; }
+  /* The tools sit on the bottom edge, so their tooltips open upward. */
+  #stageTools [data-tip]::after { top: auto; bottom: calc(100% + 6px); }
   .err { padding: 24px; color: var(--px-destructive); }
 </style>
 </head>

--- a/packages/vscode/src/ddsEditor.ts
+++ b/packages/vscode/src/ddsEditor.ts
@@ -282,11 +282,19 @@ ${uiCss}
       apply();
     }
 
-    img.addEventListener("load", () => center(fitScale() > 0 ? fitScale() : 1));
-    if (img.complete && img.naturalWidth > 0) center(fitScale() > 0 ? fitScale() : 1);
+    const fit = () => center(fitScale() > 0 ? fitScale() : 1);
+    img.addEventListener("load", fit);
+    if (img.complete && img.naturalWidth > 0) fit();
+
+    // The webview often lays out at a provisional size before the editor pane
+    // settles, so a load-time fit is wrong minutes later. Keep the image
+    // fitted on every stage resize until the user zooms or pans themselves.
+    let touched = false;
+    new ResizeObserver(() => { if (!touched) fit(); }).observe(stage);
 
     stage.addEventListener("wheel", (e) => {
       e.preventDefault();
+      touched = true;
       const r = stage.getBoundingClientRect();
       zoomAt(e.clientX - r.left, e.clientY - r.top, e.deltaY < 0 ? 1.15 : 1 / 1.15);
     }, { passive: false });
@@ -298,6 +306,7 @@ ${uiCss}
       if (e.target instanceof Element && e.target.closest("#stageTools")) return;
       if (e.button !== 0 && e.button !== 1) return;
       e.preventDefault();
+      touched = true;
       panning = true; panX = e.clientX; panY = e.clientY;
       stage.classList.add("panning");
     });
@@ -315,10 +324,11 @@ ${uiCss}
     img.addEventListener("dragstart", (e) => e.preventDefault());
 
     const cx = () => stage.clientWidth / 2, cy = () => stage.clientHeight / 2;
-    document.getElementById("zin").addEventListener("click", () => zoomAt(cx(), cy(), 1.25));
-    document.getElementById("zout").addEventListener("click", () => zoomAt(cx(), cy(), 1 / 1.25));
-    document.getElementById("zfit").addEventListener("click", () => center(fitScale()));
-    document.getElementById("recenter").addEventListener("click", () => center(scale));
+    document.getElementById("zin").addEventListener("click", () => { touched = true; zoomAt(cx(), cy(), 1.25); });
+    document.getElementById("zout").addEventListener("click", () => { touched = true; zoomAt(cx(), cy(), 1 / 1.25); });
+    // Fit re-arms the auto-fit: the view should stay fitted through resizes again.
+    document.getElementById("zfit").addEventListener("click", () => { touched = false; fit(); });
+    document.getElementById("recenter").addEventListener("click", () => { touched = true; center(scale); });
     document.getElementById("pix").addEventListener("change", (e) => img.classList.toggle("pixelated", e.target.checked));
   }
 </script>

--- a/packages/vscode/src/ddsEditor.ts
+++ b/packages/vscode/src/ddsEditor.ts
@@ -94,25 +94,31 @@ export class DdsPreviewProvider implements vscode.CustomReadonlyEditorProvider<D
     panel.webview.html = pageHtml({ name, meta, dataUri, error, nonce });
 
     const messages = panel.webview.onDidReceiveMessage(async (msg: { type?: string }) => {
-      switch (msg?.type) {
-        case "copyPath":
-          await vscode.env.clipboard.writeText(scriptPath(document.uri.fsPath));
-          break;
-        case "copyName":
-          await vscode.env.clipboard.writeText(name);
-          break;
-        case "reveal":
-          await vscode.commands.executeCommand("revealFileInOS", document.uri);
-          break;
-        case "savePng": {
-          if (!png) return;
-          const target = await vscode.window.showSaveDialog({
-            defaultUri: document.uri.with({ path: document.uri.path.replace(/\.dds$/i, ".png") }),
-            filters: { "PNG image": ["png"] },
-          });
-          if (target) await vscode.workspace.fs.writeFile(target, png);
-          break;
+      try {
+        switch (msg?.type) {
+          case "copyPath":
+            await vscode.env.clipboard.writeText(scriptPath(document.uri.fsPath));
+            break;
+          case "copyName":
+            await vscode.env.clipboard.writeText(name);
+            break;
+          case "reveal":
+            await vscode.commands.executeCommand("revealFileInOS", document.uri);
+            break;
+          case "savePng": {
+            if (!png) return;
+            const target = await vscode.window.showSaveDialog({
+              defaultUri: document.uri.with({ path: document.uri.path.replace(/\.dds$/i, ".png") }),
+              filters: { "PNG image": ["png"] },
+            });
+            if (target) await vscode.workspace.fs.writeFile(target, png);
+            break;
+          }
         }
+      } catch (err) {
+        void vscode.window.showErrorMessage(
+          `DDS preview: ${msg?.type ?? "action"} failed: ${err instanceof Error ? err.message : String(err)}`
+        );
       }
     });
     panel.onDidDispose(() => messages.dispose());
@@ -144,7 +150,7 @@ function pageHtml(opts: {
   const barButton = (id: string, name_: Parameters<typeof icon>[0], label: string, tip: string): string =>
     `<button id="${id}" class="px-btn" data-variant="ghost" data-size="sm" data-tip="${tip}" data-tip-wrap>${icon(name_)}${label}</button>`;
   const toolButton = (id: string, name_: Parameters<typeof icon>[0], tip: string): string =>
-    `<button id="${id}" class="px-btn" data-variant="ghost" data-size="icon-sm" data-tip="${tip}" data-tip-wrap>${icon(name_)}</button>`;
+    `<button id="${id}" class="px-btn" data-variant="ghost" data-size="icon-sm" data-tip="${tip}" data-tip-side="top" data-tip-wrap>${icon(name_)}</button>`;
 
   const stageInfo = meta ? `<div id="stageInfo">${escapeHtml(meta)}</div>` : "";
   const stage = error
@@ -153,13 +159,13 @@ function pageHtml(opts: {
   <img id="img" src="${dataUri}" />
   <div id="stageTools">
     ${toolButton("zout", "zoomOut", "Zoom out")}
-    <span id="zoomLabel" class="px-muted px-xs" data-tip="Wheel zooms, drag pans" data-tip-wrap>100%</span>
+    <span id="zoomLabel" class="px-muted px-xs" data-tip="Wheel zooms, drag pans" data-tip-side="top" data-tip-wrap>100%</span>
     ${toolButton("zin", "zoomIn", "Zoom in")}
     <div class="px-separator" data-orientation="vertical"></div>
     ${toolButton("zfit", "maximize", "Fit the image to the window")}
     ${toolButton("recenter", "locate", "Recenter at the current zoom")}
     <div class="px-separator" data-orientation="vertical"></div>
-    <label class="px-toggle" data-size="sm" data-tip="Pixelated: nearest-neighbour scaling to inspect single pixels. Off matches how the game samples the texture (smooth)" data-tip-wrap><input id="pix" type="checkbox" />${icon("grid")}</label>
+    <label class="px-toggle" data-size="sm" data-tip="Pixelated: nearest-neighbour scaling to inspect single pixels. Off matches how the game samples the texture (smooth)" data-tip-side="top" data-tip-wrap><input id="pix" type="checkbox" />${icon("grid")}</label>
   </div>
   ${stageInfo}`;
 
@@ -209,8 +215,6 @@ ${uiCss}
     background: color-mix(in oklch, var(--px-bg) 75%, transparent);
   }
   #zoomLabel { min-width: 44px; height: var(--px-h-sm); line-height: var(--px-h-sm); padding: 0 6px; text-align: center; font-variant-numeric: tabular-nums; cursor: default; }
-  /* The tools sit on the bottom edge, so their tooltips open upward. */
-  #stageTools [data-tip]::after { top: auto; bottom: calc(100% + 6px); }
   #stageInfo {
     position: absolute; right: 8px; bottom: 8px;
     padding: 4px 10px; border-radius: var(--px-radius);
@@ -290,6 +294,8 @@ ${uiCss}
     // Left- or middle-button drag pans; preventDefault suppresses image drag / autoscroll.
     let panX = 0, panY = 0, panning = false;
     stage.addEventListener("mousedown", (e) => {
+      // Clicks on the floating tools interact with them, never pan.
+      if (e.target instanceof Element && e.target.closest("#stageTools")) return;
       if (e.button !== 0 && e.button !== 1) return;
       e.preventDefault();
       panning = true; panX = e.clientX; panY = e.clientY;

--- a/packages/vscode/src/ddsEditor.ts
+++ b/packages/vscode/src/ddsEditor.ts
@@ -3,10 +3,16 @@
  * the image instead of VS Code's "binary or unsupported encoding" notice.
  * Decoding runs in the extension host with the same pure-TS decoder the hover
  * previews use (DXT1/3/5, BC7, uncompressed); the webview only displays.
+ *
+ * The chrome is px-ui (webviews/shared/ui.css): top bar with the file's facts
+ * and clipboard/export actions, viewer tools floating bottom-left like the GUI
+ * editor's stage tools.
  */
 import * as vscode from "vscode";
 import { decodeDds, ddsFormatInfo, encodePng } from "@px-lsp/server/dds";
 import { makeNonce } from "./webviews/nonce";
+import uiCss from "./webviews/shared/ui.css";
+import { icon } from "./webviews/shared/icons";
 
 class DdsDocument implements vscode.CustomDocument {
   constructor(
@@ -69,140 +75,213 @@ export class DdsPreviewProvider implements vscode.CustomReadonlyEditorProvider<D
     const name = document.uri.path.split("/").pop() ?? "texture.dds";
     const nonce = makeNonce();
     const info = ddsFormatInfo(document.bytes);
-    let body: string;
+    let png: Uint8Array | null = null;
+    let dataUri: string | null = null;
+    let error: string | null = null;
+    let meta = "";
     if (!info) {
-      body = errorHtml(`${name} is not a DDS file (bad magic).`);
+      error = "Not a DDS file (bad magic).";
     } else {
+      meta = `${info.width}×${info.height} · ${info.format} · ${formatBytes(document.bytes.length)}`;
       try {
         const img = decodeDds(document.bytes);
-        const png = encodePng(img.width, img.height, img.pixels);
-        const dataUri = `data:image/png;base64,${Buffer.from(png).toString("base64")}`;
-        const kb = (document.bytes.length / 1024).toFixed(1);
-        body = imageHtml(dataUri, `${name} · ${info.format} · ${img.width}×${img.height} · ${kb} KB`, nonce);
+        png = encodePng(img.width, img.height, img.pixels);
+        dataUri = `data:image/png;base64,${Buffer.from(png).toString("base64")}`;
       } catch (err) {
-        body = errorHtml(
-          `${name}: ${info.format} ${info.width}×${info.height} — preview failed: ` +
-            (err instanceof Error ? err.message : String(err))
-        );
+        error = `Preview failed: ${err instanceof Error ? err.message : String(err)}`;
       }
     }
-    panel.webview.html = wrapHtml(body, nonce);
+    panel.webview.html = pageHtml({ name, meta, dataUri, error, nonce });
+
+    const messages = panel.webview.onDidReceiveMessage(async (msg: { type?: string }) => {
+      switch (msg?.type) {
+        case "copyPath":
+          await vscode.env.clipboard.writeText(document.uri.fsPath);
+          break;
+        case "copyName":
+          await vscode.env.clipboard.writeText(name);
+          break;
+        case "reveal":
+          await vscode.commands.executeCommand("revealFileInOS", document.uri);
+          break;
+        case "savePng": {
+          if (!png) return;
+          const target = await vscode.window.showSaveDialog({
+            defaultUri: document.uri.with({ path: document.uri.path.replace(/\.dds$/i, ".png") }),
+            filters: { "PNG image": ["png"] },
+          });
+          if (target) await vscode.workspace.fs.writeFile(target, png);
+          break;
+        }
+      }
+    });
+    panel.onDidDispose(() => messages.dispose());
   }
 }
 
-function wrapHtml(body: string, nonce: string): string {
+function formatBytes(n: number): string {
+  return n >= 1024 * 1024 ? `${(n / (1024 * 1024)).toFixed(1)} MB` : `${(n / 1024).toFixed(1)} KB`;
+}
+
+function pageHtml(opts: {
+  name: string;
+  meta: string;
+  dataUri: string | null;
+  error: string | null;
+  nonce: string;
+}): string {
+  const { name, meta, dataUri, error, nonce } = opts;
+  const barButton = (id: string, name_: Parameters<typeof icon>[0], label: string, tip: string): string =>
+    `<button id="${id}" class="px-btn" data-variant="ghost" data-size="sm" data-tip="${tip}" data-tip-wrap>${icon(name_)}${label}</button>`;
+  const toolButton = (id: string, name_: Parameters<typeof icon>[0], tip: string): string =>
+    `<button id="${id}" class="px-btn" data-variant="ghost" data-size="icon-sm" data-tip="${tip}" data-tip-side="right" data-tip-wrap>${icon(name_)}</button>`;
+
+  const stage = error
+    ? `<div class="err">${escapeHtml(error)}</div>`
+    : /* html */ `
+  <img id="img" src="${dataUri}" />
+  <div id="stageTools">
+    ${toolButton("zout", "zoomOut", "Zoom out")}
+    <span id="zoomLabel" class="px-muted px-xs" data-tip="Wheel zooms, drag pans" data-tip-side="right" data-tip-wrap>100%</span>
+    ${toolButton("zin", "zoomIn", "Zoom in")}
+    <div class="px-separator" data-orientation="vertical"></div>
+    ${toolButton("zfit", "maximize", "Fit the image to the window")}
+    ${toolButton("recenter", "locate", "Recenter at the current zoom")}
+    <div class="px-separator" data-orientation="vertical"></div>
+    <label class="px-toggle" data-size="sm" data-tip="Pixelated: nearest-neighbour scaling to inspect single pixels. Off matches how the game samples the texture (smooth)" data-tip-side="right" data-tip-wrap><input id="pix" type="checkbox" />${icon("grid")}</label>
+  </div>`;
+
   return /* html */ `<!DOCTYPE html>
 <html lang="en">
 <head>
 <meta charset="UTF-8" />
 <meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src data:; style-src 'unsafe-inline'; script-src 'nonce-${nonce}'" />
+<title>DDS Preview</title>
 <style>
-  :root { color-scheme: light dark; }
-  html, body { margin: 0; height: 100%; font-family: var(--vscode-font-family, sans-serif); color: var(--vscode-editor-foreground); background: var(--vscode-editor-background); }
-  body { display: flex; flex-direction: column; }
+${uiCss}
+  body { overflow: hidden; }
+  #app { display: flex; flex-direction: column; height: 100vh; }
   #bar {
-    flex: 0 0 auto; display: flex; gap: 10px; align-items: center;
-    padding: 5px 10px; font-size: 0.9em;
-    background: var(--vscode-editorWidget-background, var(--vscode-editor-background));
-    border-bottom: 1px solid var(--vscode-panel-border, rgba(128,128,128,0.35));
+    display: flex; align-items: center; gap: 6px; flex: 0 0 auto;
+    padding: 6px 8px; border-bottom: 1px solid var(--px-border);
   }
-  #bar button {
-    padding: 1px 8px; cursor: pointer; border-radius: 2px;
-    color: var(--vscode-button-secondaryForeground, var(--vscode-editor-foreground));
-    background: var(--vscode-button-secondaryBackground, transparent);
-    border: 1px solid var(--vscode-panel-border, rgba(128,128,128,0.4));
-  }
+  #bar .px-separator { height: 20px; align-self: center; }
+  #fileName { font-weight: 600; max-width: 260px; }
+  #meta { color: var(--px-muted-fg); font-size: var(--px-text-sm); white-space: nowrap; }
+  /* A checkbox inside a toggle: hidden, its state shown on the label (the px-switch pattern). */
+  .px-toggle > input[type="checkbox"] { position: absolute; opacity: 0; width: 0; height: 0; }
+  .px-toggle:has(> input:checked) { background: var(--px-muted); }
+  .px-toggle:has(> input:focus-visible) { border-color: var(--px-ring); box-shadow: 0 0 0 3px var(--px-ring-soft); }
   /* Panning moves the image outside the stage, so clip rather than scroll. */
-  #stage { flex: 1 1 auto; position: relative; overflow: hidden; }
+  #stage { flex: 1 1 auto; position: relative; overflow: hidden; background: #101010; }
   #stage.panning { cursor: grabbing; }
   #img {
     position: absolute; top: 0; left: 0; transform-origin: 0 0;
-    image-rendering: auto;
+    image-rendering: auto; cursor: grab;
     /* checkerboard so alpha is visible */
     background: repeating-conic-gradient(rgba(128,128,128,0.25) 0% 25%, transparent 0% 50%) 0 0 / 16px 16px;
   }
   #img.pixelated { image-rendering: pixelated; }
-  .err { padding: 24px; color: var(--vscode-editorError-foreground, #f14c4c); }
+  #stageTools {
+    position: absolute; left: 8px; bottom: 8px; display: flex; align-items: center; gap: 2px;
+    padding: 2px; border-radius: var(--px-radius);
+    background: color-mix(in oklch, var(--px-bg) 75%, transparent);
+  }
+  #zoomLabel { min-width: 44px; height: var(--px-h-sm); line-height: var(--px-h-sm); padding: 0 6px; text-align: center; font-variant-numeric: tabular-nums; cursor: default; }
+  .err { padding: 24px; color: var(--px-destructive); }
 </style>
 </head>
-<body>${body}</body>
-</html>`;
-}
-
-function imageHtml(dataUri: string, caption: string, nonce: string): string {
-  return /* html */ `
-<div id="bar">
-  <span>${escapeHtml(caption)}</span>
-  <button id="zin">+</button><button id="zout">−</button><button id="zfit">Fit</button><button id="z100">1:1</button>
-  <label><input type="checkbox" id="pix" checked /> pixelated</label>
+<body>
+<div id="app">
+  <div id="bar">
+    <span id="fileName" class="px-truncate">${escapeHtml(name)}</span>
+    ${meta ? `<span id="meta">${escapeHtml(meta)}</span>` : ""}
+    <span class="px-grow"></span>
+    ${barButton("copyName", "copy", "Copy name", "Copy the file name to the clipboard")}
+    ${barButton("copyPath", "copy", "Copy path", "Copy the full path to the clipboard")}
+    ${barButton("reveal", "folderOpen", "Reveal", "Show the file in the system file explorer")}
+    ${dataUri ? barButton("savePng", "imageDown", "Save PNG", "Decode the texture and save it as a .png") : ""}
+  </div>
+  <div id="stage">${stage}</div>
 </div>
-<div id="stage"><img id="img" class="pixelated" src="${dataUri}" /></div>
 <script nonce="${nonce}">
+  const vscode = acquireVsCodeApi();
+  for (const id of ["copyName", "copyPath", "reveal", "savePng"]) {
+    const el = document.getElementById(id);
+    if (el) el.addEventListener("click", () => vscode.postMessage({ type: id }));
+  }
+
   const stage = document.getElementById("stage");
   const img = document.getElementById("img");
-  // Zoom clamps: 5% to 3200%.
-  const MIN = 0.05, MAX = 32;
-  let scale = 1, tx = 0, ty = 0;
+  if (img) {
+    // Zoom clamps: 5% to 3200%.
+    const MIN = 0.05, MAX = 32;
+    let scale = 1, tx = 0, ty = 0;
+    const zoomLabel = document.getElementById("zoomLabel");
 
-  function apply() { img.style.transform = "translate(" + tx + "px," + ty + "px) scale(" + scale + ")"; }
-  function fitScale() {
-    return Math.min(1, stage.clientWidth / img.naturalWidth, stage.clientHeight / img.naturalHeight);
+    function apply() {
+      img.style.transform = "translate(" + tx + "px," + ty + "px) scale(" + scale + ")";
+      zoomLabel.textContent = Math.round(scale * 100) + "%";
+    }
+    function fitScale() {
+      return Math.min(1, stage.clientWidth / img.naturalWidth, stage.clientHeight / img.naturalHeight);
+    }
+    function center(s) {
+      scale = Math.max(MIN, Math.min(MAX, s));
+      tx = (stage.clientWidth - img.naturalWidth * scale) / 2;
+      ty = (stage.clientHeight - img.naturalHeight * scale) / 2;
+      apply();
+    }
+    // Zoom about a stage-relative point, keeping the image pixel under it fixed.
+    function zoomAt(cx, cy, factor) {
+      const next = Math.max(MIN, Math.min(MAX, scale * factor));
+      const ix = (cx - tx) / scale, iy = (cy - ty) / scale;
+      scale = next;
+      tx = cx - ix * scale;
+      ty = cy - iy * scale;
+      apply();
+    }
+
+    img.addEventListener("load", () => center(fitScale() > 0 ? fitScale() : 1));
+    if (img.complete && img.naturalWidth > 0) center(fitScale() > 0 ? fitScale() : 1);
+
+    stage.addEventListener("wheel", (e) => {
+      e.preventDefault();
+      const r = stage.getBoundingClientRect();
+      zoomAt(e.clientX - r.left, e.clientY - r.top, e.deltaY < 0 ? 1.15 : 1 / 1.15);
+    }, { passive: false });
+
+    // Left- or middle-button drag pans; preventDefault suppresses image drag / autoscroll.
+    let panX = 0, panY = 0, panning = false;
+    stage.addEventListener("mousedown", (e) => {
+      if (e.button !== 0 && e.button !== 1) return;
+      e.preventDefault();
+      panning = true; panX = e.clientX; panY = e.clientY;
+      stage.classList.add("panning");
+    });
+    window.addEventListener("mousemove", (e) => {
+      if (!panning) return;
+      tx += e.clientX - panX; ty += e.clientY - panY;
+      panX = e.clientX; panY = e.clientY;
+      apply();
+    });
+    window.addEventListener("mouseup", () => {
+      if (!panning) return;
+      panning = false; stage.classList.remove("panning");
+    });
+    stage.addEventListener("auxclick", (e) => { if (e.button === 1) e.preventDefault(); });
+    img.addEventListener("dragstart", (e) => e.preventDefault());
+
+    const cx = () => stage.clientWidth / 2, cy = () => stage.clientHeight / 2;
+    document.getElementById("zin").addEventListener("click", () => zoomAt(cx(), cy(), 1.25));
+    document.getElementById("zout").addEventListener("click", () => zoomAt(cx(), cy(), 1 / 1.25));
+    document.getElementById("zfit").addEventListener("click", () => center(fitScale()));
+    document.getElementById("recenter").addEventListener("click", () => center(scale));
+    document.getElementById("pix").addEventListener("change", (e) => img.classList.toggle("pixelated", e.target.checked));
   }
-  function center(s) {
-    scale = Math.max(MIN, Math.min(MAX, s));
-    tx = (stage.clientWidth - img.naturalWidth * scale) / 2;
-    ty = (stage.clientHeight - img.naturalHeight * scale) / 2;
-    apply();
-  }
-  // Zoom about a stage-relative point, keeping the image pixel under it fixed.
-  function zoomAt(cx, cy, factor) {
-    const next = Math.max(MIN, Math.min(MAX, scale * factor));
-    const ix = (cx - tx) / scale, iy = (cy - ty) / scale;
-    scale = next;
-    tx = cx - ix * scale;
-    ty = cy - iy * scale;
-    apply();
-  }
-
-  img.addEventListener("load", () => center(fitScale() > 0 ? fitScale() : 1));
-
-  stage.addEventListener("wheel", (e) => {
-    e.preventDefault();
-    const r = stage.getBoundingClientRect();
-    zoomAt(e.clientX - r.left, e.clientY - r.top, e.deltaY < 0 ? 1.15 : 1 / 1.15);
-  }, { passive: false });
-
-  // Middle-button drag pans freely; preventDefault suppresses autoscroll.
-  let panX = 0, panY = 0, panning = false;
-  stage.addEventListener("mousedown", (e) => {
-    if (e.button !== 1) return;
-    e.preventDefault();
-    panning = true; panX = e.clientX; panY = e.clientY;
-    stage.classList.add("panning");
-  });
-  window.addEventListener("mousemove", (e) => {
-    if (!panning) return;
-    tx += e.clientX - panX; ty += e.clientY - panY;
-    panX = e.clientX; panY = e.clientY;
-    apply();
-  });
-  window.addEventListener("mouseup", (e) => {
-    if (e.button !== 1 || !panning) return;
-    panning = false; stage.classList.remove("panning");
-  });
-  stage.addEventListener("auxclick", (e) => { if (e.button === 1) e.preventDefault(); });
-
-  const cx = () => stage.clientWidth / 2, cy = () => stage.clientHeight / 2;
-  document.getElementById("zin").addEventListener("click", () => zoomAt(cx(), cy(), 1.25));
-  document.getElementById("zout").addEventListener("click", () => zoomAt(cx(), cy(), 1 / 1.25));
-  document.getElementById("z100").addEventListener("click", () => center(1));
-  document.getElementById("zfit").addEventListener("click", () => center(fitScale()));
-  document.getElementById("pix").addEventListener("change", (e) => img.classList.toggle("pixelated", e.target.checked));
-</script>`;
-}
-
-function errorHtml(message: string): string {
-  return `<div class="err">${escapeHtml(message)}</div>`;
+</script>
+</body>
+</html>`;
 }
 
 function escapeHtml(s: string): string {

--- a/packages/vscode/src/ddsEditor.ts
+++ b/packages/vscode/src/ddsEditor.ts
@@ -96,7 +96,7 @@ export class DdsPreviewProvider implements vscode.CustomReadonlyEditorProvider<D
     const messages = panel.webview.onDidReceiveMessage(async (msg: { type?: string }) => {
       switch (msg?.type) {
         case "copyPath":
-          await vscode.env.clipboard.writeText(document.uri.fsPath);
+          await vscode.env.clipboard.writeText(scriptPath(document.uri.fsPath));
           break;
         case "copyName":
           await vscode.env.clipboard.writeText(name);
@@ -119,6 +119,16 @@ export class DdsPreviewProvider implements vscode.CustomReadonlyEditorProvider<D
   }
 }
 
+/**
+ * The path as script references it: from the gfx/ root, forward slashes
+ * (`gfx/interface/icons/traits/reveler.dds`). Falls back to the full path for
+ * a texture outside any gfx/ folder.
+ */
+function scriptPath(fsPath: string): string {
+  const m = /(?:^|[\\/])(gfx[\\/].+)$/i.exec(fsPath);
+  return m ? m[1].replace(/\\/g, "/") : fsPath;
+}
+
 function formatBytes(n: number): string {
   return n >= 1024 * 1024 ? `${(n / (1024 * 1024)).toFixed(1)} MB` : `${(n / 1024).toFixed(1)} KB`;
 }
@@ -136,8 +146,9 @@ function pageHtml(opts: {
   const toolButton = (id: string, name_: Parameters<typeof icon>[0], tip: string): string =>
     `<button id="${id}" class="px-btn" data-variant="ghost" data-size="icon-sm" data-tip="${tip}" data-tip-wrap>${icon(name_)}</button>`;
 
+  const stageInfo = meta ? `<div id="stageInfo">${escapeHtml(meta)}</div>` : "";
   const stage = error
-    ? `<div class="err">${escapeHtml(error)}</div>`
+    ? `<div class="err">${escapeHtml(error)}</div>${stageInfo}`
     : /* html */ `
   <img id="img" src="${dataUri}" />
   <div id="stageTools">
@@ -149,7 +160,8 @@ function pageHtml(opts: {
     ${toolButton("recenter", "locate", "Recenter at the current zoom")}
     <div class="px-separator" data-orientation="vertical"></div>
     <label class="px-toggle" data-size="sm" data-tip="Pixelated: nearest-neighbour scaling to inspect single pixels. Off matches how the game samples the texture (smooth)" data-tip-wrap><input id="pix" type="checkbox" />${icon("grid")}</label>
-  </div>`;
+  </div>
+  ${stageInfo}`;
 
   return /* html */ `<!DOCTYPE html>
 <html lang="en">
@@ -166,8 +178,17 @@ ${uiCss}
     padding: 6px 8px; border-bottom: 1px solid var(--px-border);
   }
   #bar .px-separator { height: 20px; align-self: center; }
-  #fileName { font-weight: 600; max-width: 260px; }
-  #meta { color: var(--px-muted-fg); font-size: var(--px-text-sm); white-space: nowrap; }
+  #fileNameWrap { position: relative; display: flex; min-width: 0; }
+  #fileName { font-weight: 600; max-width: 260px; cursor: pointer; }
+  #copyToast {
+    position: absolute; left: 50%; top: calc(100% + 6px); transform: translateX(-50%);
+    padding: 3px 8px; border-radius: var(--px-radius-md); z-index: 61;
+    font-size: var(--px-text-xs); color: var(--px-bg); background: var(--px-fg);
+    opacity: 0; transition: opacity var(--px-ease); pointer-events: none; white-space: nowrap;
+  }
+  #copyToast.show { opacity: 1; }
+  /* The toast owns the spot below the name; mute the hover tooltip while it shows. */
+  #fileNameWrap:has(> #copyToast.show) [data-tip]::after { opacity: 0; }
   /* A checkbox inside a toggle: hidden, its state shown on the label (the px-switch pattern). */
   .px-toggle > input[type="checkbox"] { position: absolute; opacity: 0; width: 0; height: 0; }
   .px-toggle:has(> input:checked) { background: var(--px-muted); }
@@ -190,17 +211,22 @@ ${uiCss}
   #zoomLabel { min-width: 44px; height: var(--px-h-sm); line-height: var(--px-h-sm); padding: 0 6px; text-align: center; font-variant-numeric: tabular-nums; cursor: default; }
   /* The tools sit on the bottom edge, so their tooltips open upward. */
   #stageTools [data-tip]::after { top: auto; bottom: calc(100% + 6px); }
+  #stageInfo {
+    position: absolute; right: 8px; bottom: 8px;
+    padding: 4px 10px; border-radius: var(--px-radius);
+    color: var(--px-muted-fg); font-size: var(--px-text-xs); font-variant-numeric: tabular-nums;
+    background: color-mix(in oklch, var(--px-bg) 75%, transparent);
+    pointer-events: none;
+  }
   .err { padding: 24px; color: var(--px-destructive); }
 </style>
 </head>
 <body>
 <div id="app">
   <div id="bar">
-    <span id="fileName" class="px-truncate">${escapeHtml(name)}</span>
-    ${meta ? `<span id="meta">${escapeHtml(meta)}</span>` : ""}
-    <span class="px-grow"></span>
-    ${barButton("copyName", "copy", "Copy name", "Copy the file name to the clipboard")}
-    ${barButton("copyPath", "copy", "Copy path", "Copy the full path to the clipboard")}
+    <span id="fileNameWrap"><span id="fileName" class="px-truncate" data-tip="Copy the file name">${escapeHtml(name)}</span><span id="copyToast">Copied!</span></span>
+    <div class="px-separator" data-orientation="vertical"></div>
+    ${barButton("copyPath", "copy", "Copy path", "Copy the path from the gfx/ root, as script references it")}
     ${barButton("reveal", "folderOpen", "Reveal", "Show the file in the system file explorer")}
     ${dataUri ? barButton("savePng", "imageDown", "Save PNG", "Decode the texture and save it as a .png") : ""}
   </div>
@@ -208,10 +234,18 @@ ${uiCss}
 </div>
 <script nonce="${nonce}">
   const vscode = acquireVsCodeApi();
-  for (const id of ["copyName", "copyPath", "reveal", "savePng"]) {
+  for (const id of ["copyPath", "reveal", "savePng"]) {
     const el = document.getElementById(id);
     if (el) el.addEventListener("click", () => vscode.postMessage({ type: id }));
   }
+  const copyToast = document.getElementById("copyToast");
+  let toastTimer = 0;
+  document.getElementById("fileName").addEventListener("click", () => {
+    vscode.postMessage({ type: "copyName" });
+    copyToast.classList.add("show");
+    clearTimeout(toastTimer);
+    toastTimer = setTimeout(() => copyToast.classList.remove("show"), 1200);
+  });
 
   const stage = document.getElementById("stage");
   const img = document.getElementById("img");

--- a/packages/vscode/src/ddsEditor.ts
+++ b/packages/vscode/src/ddsEditor.ts
@@ -184,6 +184,9 @@ ${uiCss}
     padding: 6px 8px; border-bottom: 1px solid var(--px-border);
   }
   #bar .px-separator { height: 20px; align-self: center; }
+  /* The name has its own padding-free text edge; the buttons carry inner padding.
+     Extra margin around this divider keeps the visual gaps equal. */
+  #fileNameWrap + .px-separator { margin: 0 4px; }
   #fileNameWrap { position: relative; display: flex; min-width: 0; }
   #fileName { font-weight: 600; max-width: 260px; cursor: pointer; }
   #copyToast {
@@ -194,14 +197,14 @@ ${uiCss}
   }
   #copyToast.show { opacity: 1; }
   /* The toast owns the spot below the name; mute the hover tooltip while it shows. */
-  #fileNameWrap:has(> #copyToast.show) [data-tip]::after { opacity: 0; }
+  #fileNameWrap:has(> #copyToast.show)::after { opacity: 0 !important; }
   /* A checkbox inside a toggle: hidden, its state shown on the label (the px-switch pattern). */
   .px-toggle > input[type="checkbox"] { position: absolute; opacity: 0; width: 0; height: 0; }
   .px-toggle:has(> input:checked) { background: var(--px-muted); }
   .px-toggle:has(> input:focus-visible) { border-color: var(--px-ring); box-shadow: 0 0 0 3px var(--px-ring-soft); }
   /* Panning moves the image outside the stage, so clip rather than scroll. */
   #stage { flex: 1 1 auto; position: relative; overflow: hidden; background: #101010; }
-  #stage.panning { cursor: grabbing; }
+  #stage.panning, #stage.panning #img { cursor: grabbing; }
   #img {
     position: absolute; top: 0; left: 0; transform-origin: 0 0;
     image-rendering: auto; cursor: grab;
@@ -228,7 +231,7 @@ ${uiCss}
 <body>
 <div id="app">
   <div id="bar">
-    <span id="fileNameWrap"><span id="fileName" class="px-truncate" data-tip="Copy the file name">${escapeHtml(name)}</span><span id="copyToast">Copied!</span></span>
+    <span id="fileNameWrap" data-tip="Click to copy the file name"><span id="fileName" class="px-truncate">${escapeHtml(name)}</span><span id="copyToast">Copied!</span></span>
     <div class="px-separator" data-orientation="vertical"></div>
     ${barButton("copyPath", "copy", "Copy path", "Copy the path from the gfx/ root, as script references it")}
     ${barButton("reveal", "folderOpen", "Reveal", "Show the file in the system file explorer")}

--- a/packages/vscode/src/webviews/eventGraph/html.ts
+++ b/packages/vscode/src/webviews/eventGraph/html.ts
@@ -335,13 +335,13 @@ ${uiCss}
       <svg id="graph" xmlns="http://www.w3.org/2000/svg"></svg>
       <div id="stageTools">
         <div id="zoomGroup">
-          <button id="zoomOut" class="px-btn" data-variant="ghost" data-size="icon-sm" data-tip="Zoom out (−)" data-tip-side="right">${icon("zoomOut")}</button>
-          <button id="zoomIn" class="px-btn" data-variant="ghost" data-size="icon-sm" data-tip="Zoom in (+)" data-tip-side="right">${icon("zoomIn")}</button>
-          <button id="zoomFit" class="px-btn" data-variant="ghost" data-size="icon-sm" data-tip="Fit the graph (0)" data-tip-side="right">${icon("maximize")}</button>
+          <button id="zoomOut" class="px-btn" data-variant="ghost" data-size="icon-sm" data-tip="Zoom out (−)" data-tip-side="top">${icon("zoomOut")}</button>
+          <button id="zoomIn" class="px-btn" data-variant="ghost" data-size="icon-sm" data-tip="Zoom in (+)" data-tip-side="top">${icon("zoomIn")}</button>
+          <button id="zoomFit" class="px-btn" data-variant="ghost" data-size="icon-sm" data-tip="Fit the graph (0)" data-tip-side="top">${icon("maximize")}</button>
         </div>
         <span id="focusLine" class="px-muted px-xs"></span>
       </div>
-      <button id="info" class="px-btn" data-variant="ghost" data-size="icon-sm" data-tip="" data-tip-side="left" data-tip-wrap>${icon("info")}</button>
+      <button id="info" class="px-btn" data-variant="ghost" data-size="icon-sm" data-tip="" data-tip-side="top" data-tip-align="right" data-tip-wrap>${icon("info")}</button>
       <div id="sim" hidden>
         <div id="simBar">
           <span id="simTitle" class="px-truncate">Simulation</span>

--- a/packages/vscode/src/webviews/flagBuilder/app/main.ts
+++ b/packages/vscode/src/webviews/flagBuilder/app/main.ts
@@ -1232,6 +1232,8 @@ stage.addEventListener(
   { passive: false }
 );
 stage.addEventListener("pointerdown", (down) => {
+  // Drags starting on the floating stage chrome interact with it, never pan.
+  if (down.target instanceof Element && down.target.closest("#stageTools, #stageInfo")) return;
   if (view.frozen || down.button !== 1) return;
   down.preventDefault();
   stage.setPointerCapture(down.pointerId);

--- a/packages/vscode/src/webviews/flagBuilder/html.ts
+++ b/packages/vscode/src/webviews/flagBuilder/html.ts
@@ -51,7 +51,8 @@ ${uiCss}
   #stageTools { left: 8px; }
   #stageInfo { right: 8px; gap: 8px; }
   #resetName[hidden] { display: none; }
-  [data-tip][data-tip-side="right"]::after { left: calc(100% + 6px); right: auto; top: 50%; transform: translateY(-50%); }
+  #origin { padding-left: 8px; }
+  #origin:empty { display: none; }
   #inspector { padding: 4px 10px 12px; display: flex; flex-direction: column; gap: 8px; }
   .colors { display: flex; flex-direction: column; gap: 4px; }
   .color-row { display: grid; grid-template-columns: 44px 18px 92px minmax(0, 1fr) 24px; align-items: center; gap: 6px; }
@@ -113,14 +114,14 @@ ${uiCss}
     <div id="stage">
       <div id="viewport"><canvas id="canvas" width="768" height="512"></canvas></div>
       <div id="stageTools">
-        <button id="lock" class="px-btn" data-variant="ghost" data-size="icon-sm" data-tip="Freeze the canvas zoom and pan" data-tip-side="right" data-tip-wrap>${icon("unlock")}</button>
-        <button id="recenter" class="px-btn" data-variant="ghost" data-size="icon-sm" data-tip="Recenter the canvas (default position and zoom)" data-tip-side="right" data-tip-wrap>${icon("maximize")}</button>
+        <button id="lock" class="px-btn" data-variant="ghost" data-size="icon-sm" data-tip="Freeze the canvas zoom and pan" data-tip-side="top" data-tip-wrap>${icon("unlock")}</button>
+        <button id="recenter" class="px-btn" data-variant="ghost" data-size="icon-sm" data-tip="Recenter the canvas (default position and zoom)" data-tip-side="top" data-tip-wrap>${icon("maximize")}</button>
         <span id="zoom" class="px-muted px-xs"></span>
         <span id="hint" class="px-muted px-xs"></span>
       </div>
       <div id="stageInfo">
         <span id="origin" class="px-muted px-xs"></span>
-        <button id="info" class="px-btn" data-variant="ghost" data-size="icon-sm" data-tip="" data-tip-side="left" data-tip-wrap>${icon("info")}</button>
+        <button id="info" class="px-btn" data-variant="ghost" data-size="icon-sm" data-tip="" data-tip-side="top" data-tip-align="right" data-tip-wrap>${icon("info")}</button>
       </div>
     </div>
     <div id="side" class="px-sidepanel" data-side="right">

--- a/packages/vscode/src/webviews/guiEditor/app/main.ts
+++ b/packages/vscode/src/webviews/guiEditor/app/main.ts
@@ -4943,6 +4943,9 @@ function toWorld(ev: { clientX: number; clientY: number }): { x: number; y: numb
 }
 
 stage.addEventListener("pointerdown", (ev) => {
+  // Drags starting on the floating stage chrome (tools, info, popovers, the
+  // library overlay) interact with it, never pan or select on the canvas.
+  if (ev.target instanceof Element && ev.target.closest("#stageTools, #stageInfo, #clickTip, #textTip, #libraryOverlay")) return;
   if (ev.button === 1) {
     // Middle mouse drags the camera.
     ev.preventDefault();

--- a/packages/vscode/src/webviews/guiEditor/app/main.ts
+++ b/packages/vscode/src/webviews/guiEditor/app/main.ts
@@ -4945,7 +4945,11 @@ function toWorld(ev: { clientX: number; clientY: number }): { x: number; y: numb
 stage.addEventListener("pointerdown", (ev) => {
   // Drags starting on the floating stage chrome (tools, info, popovers, the
   // library overlay) interact with it, never pan or select on the canvas.
-  if (ev.target instanceof Element && ev.target.closest("#stageTools, #stageInfo, #clickTip, #textTip, #libraryOverlay")) return;
+  if (
+    ev.target instanceof Element &&
+    ev.target.closest("#stageTools, #stageInfo, #clickTip, #textTip, #libraryOverlay")
+  )
+    return;
   if (ev.button === 1) {
     // Middle mouse drags the camera.
     ev.preventDefault();

--- a/packages/vscode/src/webviews/guiEditor/html.ts
+++ b/packages/vscode/src/webviews/guiEditor/html.ts
@@ -359,10 +359,10 @@ ${uiCss}
       <div id="textTip" class="px-popover" hidden></div>
       <div id="clickTip" class="px-popover" hidden></div>
       <div id="stageTools">
-        <span id="zoomLabel" class="px-muted px-xs" data-tip="Wheel zooms, middle mouse pans. Ctrl+0 fits the 1920x1080 viewport, Shift+F the selection" data-tip-side="right" data-tip-wrap>100%</span>
+        <span id="zoomLabel" class="px-muted px-xs" data-tip="Wheel zooms, middle mouse pans. Ctrl+0 fits the 1920x1080 viewport, Shift+F the selection" data-tip-side="top" data-tip-wrap>100%</span>
       </div>
       <div id="stageInfo">
-        <button id="info" class="px-btn" data-variant="ghost" data-size="icon-sm" data-tip="" data-tip-side="left" data-tip-wrap>${icon("info")}</button>
+        <button id="info" class="px-btn" data-variant="ghost" data-size="icon-sm" data-tip="" data-tip-side="top" data-tip-align="right" data-tip-wrap>${icon("info")}</button>
       </div>
       <div id="libraryOverlay" hidden>
         <div id="library" hidden></div>

--- a/packages/vscode/src/webviews/shared/ui.css
+++ b/packages/vscode/src/webviews/shared/ui.css
@@ -1050,6 +1050,17 @@ body:not(.vscode-light) .px-tab[aria-selected="true"] {
   top: 50%;
   transform: translateY(-50%);
 }
+/* Above the element, for controls on a view's bottom edge. */
+[data-tip][data-tip-side="top"]::after {
+  top: auto;
+  bottom: calc(100% + 6px);
+}
+/* Right-aligned above, for the bottom-RIGHT corner (a centered tip would leave the window). */
+[data-tip][data-tip-side="top"][data-tip-align="right"]::after {
+  left: auto;
+  right: 0;
+  transform: none;
+}
 
 /* ---------------------------------------------------------------- toast --- */
 


### PR DESCRIPTION
## Why

Issue #15 asked for the texture size in the hover tooltip so checking dimensions stops being a two-step process. While in there, the DDS preview editor still wore the pre-px-ui chrome.

## Hover tooltip

- Now shows **dimensions, exact encoding (DXT1/3/5, BC7, ...), file size** and the mod/vanilla origin under the image preview.
- The path text is dropped: it's the very string being hovered, and opening the file shows it anyway. The 'open file' link stays.
- The gated vanilla hover test now asserts the new caption shape (39/39 dds+assetPaths tests green).

## DDS preview editor

- Restyled with the shared px-ui sheet and icon set, matching the GUI editor.
- Viewer tools float bottom-left like the GUI editor stage tools: zoom −/label/+, fit, recenter. The 1:1 button is removed.
- **Pixelated defaults off**: the game samples textures with bilinear filtering, so the smooth view is what players see in game. The toggle stays for pixel inspection.
- Top bar: file name, dims · encoding · size, then Copy name, Copy path, Reveal in explorer, Save PNG (decodes the DDS and writes a .png via save dialog).
- Left-drag pans now too (middle-drag kept).

Test vsix built and installed locally.

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Rework DDS texture previews to expose richer metadata and provide a consistent, more capable editor experience.

New Features:
- Include texture dimensions, encoding, file size, and mod or vanilla origin in DDS hover previews.
- Add DDS viewer actions for copying names or paths, revealing files, and saving decoded textures as PNG files.

Bug Fixes:
- Make texture preview metadata available even when a DDS format cannot be decoded for display.
- Prevent drags beginning on floating editor controls from panning the underlying canvas or stage.

Enhancements:
- Rework the DDS preview editor with shared px-ui styling, floating viewer controls, smooth default scaling, fit and recenter behavior, and left-drag panning.
- Improve tooltip positioning for controls near the bottom and right edges of shared webviews.

Tests:
- Update vanilla asset hover coverage to validate the new metadata caption format.