### PR TITLE
UX round: event graph cluster, GUI editor save + change log, library showcase

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,7 +100,7 @@ jobs:
       # The human-written notes (docs/release-notes-<version>.md) are the
       # release body AND the Discord post. The H1 and the trailing "Full
       # changelog" pointer are dropped: the release page shows the version
-      # already, and the Discord embed appends its own changelog link. A tag
+      # already, and the Discord post appends its own changelog link. A tag
       # with no notes file falls back to GitHub's generated commit list.
       - name: Collect release notes (tag builds)
         if: startsWith(github.ref, 'refs/tags/v')
@@ -129,9 +129,10 @@ jobs:
 
       # Announce the release in the Discord server's #toolkit-updates, pinging
       # the @Paradox Toolkit role. DISCORD_RELEASE_WEBHOOK is a plain Discord
-      # webhook URL (repo secret). The notes ride in an embed (4096-char
-      # description cap; longer notes are cut at 3900 on a line boundary), the
-      # ping and the link stay in `content` so they render above the embed.
+      # webhook URL (repo secret). The whole post is a plain message, no embed:
+      # `content` caps at 2000 chars, so the notes are cut at 1600 on a line
+      # boundary. Both URLs are wrapped in <> so Discord does not attach its
+      # own link-preview embed to a post that is meant to be embed-free.
       # Missing secret = silent skip; a failed post warns but never fails a
       # release that already shipped.
       - name: Announce on Discord (tag builds)
@@ -143,18 +144,17 @@ jobs:
           [ -z "$WEBHOOK" ] && exit 0
           URL="https://github.com/$GITHUB_REPOSITORY/releases/tag/$GITHUB_REF_NAME"
           if [ "$NOTES_FOUND" = "true" ]; then
-            NOTES=$(head -c 3900 release-body.md)
-            if [ "$(wc -c < release-body.md)" -gt 3900 ]; then
+            NOTES=$(head -c 1600 release-body.md)
+            if [ "$(wc -c < release-body.md)" -gt 1600 ]; then
               NOTES=$(printf '%s' "$NOTES" | sed '$d')
+              NOTES="$NOTES"$'\n'"…"
             fi
           else
             NOTES="See the release page for the changes."
           fi
           jq -n --arg tag "$GITHUB_REF_NAME" --arg url "$URL" --arg notes "$NOTES" \
-            '{content: "<@&1534329963933864079> **Paradox Toolkit \($tag)** is out.\n\($url)",
-              allowed_mentions: {roles: ["1534329963933864079"]},
-              embeds: [{title: "What changed in \($tag)", url: $url, color: 7506394,
-                        description: ($notes + "\n\n[Full changelog](https://github.com/JDeffner/paradox-modding-toolkit/blob/main/packages/vscode/CHANGELOG.md)")}]}' \
+            '{content: "<@&1534329963933864079> **Paradox Toolkit \($tag)** is out.\n\n\($notes)\n\nRelease: <\($url)>\nFull changelog: <https://github.com/JDeffner/paradox-modding-toolkit/blob/main/packages/vscode/CHANGELOG.md>",
+              allowed_mentions: {roles: ["1534329963933864079"]}}' \
             | curl -sf -H "Content-Type: application/json" -d @- "$WEBHOOK" \
             || echo "::warning::Discord release announcement failed"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,7 +144,11 @@ jobs:
           [ -z "$WEBHOOK" ] && exit 0
           URL="https://github.com/$GITHUB_REPOSITORY/releases/tag/$GITHUB_REF_NAME"
           if [ "$NOTES_FOUND" = "true" ]; then
-            NOTES=$(head -c 1600 release-body.md)
+            # head -c cuts BYTES: a multibyte character split at the boundary
+            # would reach jq as invalid UTF-8 and kill the post. iconv -c drops
+            # the incomplete sequence (the line-boundary cut below usually
+            # removes it anyway; this covers the cut landing on a newline).
+            NOTES=$(head -c 1600 release-body.md | iconv -c -f UTF-8 -t UTF-8)
             if [ "$(wc -c < release-body.md)" -gt 1600 ]; then
               NOTES=$(printf '%s' "$NOTES" | sed '$d')
               NOTES="$NOTES"$'\n'"…"

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ docs/*
 # Per-release notes: release.yml reads docs/release-notes-<version>.md as the
 # GitHub Release body and the Discord announcement.
 !docs/release-notes-*.md
+# Features hidden from users until they are fleshed out; code comments point
+# at it, so it travels with the repo.
+!docs/deferred-features.md
 # Machine-specific paths for scripts/tests (copy dev-paths.example.json).
 dev-paths.json
 # Build-time copy of the server bundle data (scripts/copy-server.mjs).

--- a/docs/deferred-features.md
+++ b/docs/deferred-features.md
@@ -1,0 +1,36 @@
+# Deferred features
+
+Features that exist in the code but are hidden from users because they are not
+fleshed out yet. Each entry says where the off switch is, so re-enabling one is
+a two-line change.
+
+## GUI editor: Interact mode (hidden 2026-08-24)
+
+What it is: a tool mode where clicks run the variable-system half of a
+widget's `onclick` and wheels scroll scrollareas, previewing the UI as the
+game plays it. Not fleshed out enough yet.
+
+Hidden by:
+
+- `packages/vscode/src/webviews/guiEditor/html.ts`: `#modeGroup` carries
+  `hidden` (plus the `#modeGroup[hidden]` CSS rule).
+- `packages/vscode/src/webviews/guiEditor/app/main.ts`: `setMode` returns
+  early on `"interact"`, which also disarms the `I` shortcut.
+
+Everything else (interact.ts, the click tip, scroll offsets, the mode's
+status line) is still live code and still compiled.
+
+## GUI editor: preview values from a save game (hidden 2026-08-24)
+
+What it is: the toolbar's "No save" dropdown (`#saveSource`), which feeds real
+values from a chosen save (`paradox/guiSaveValues`) into `[datafunction]`
+previews. Works, but the flow is not fleshed out enough to expose.
+
+Hidden by:
+
+- `packages/vscode/src/webviews/guiEditor/html.ts`: `#saveSource` carries
+  `hidden` (plus the `#saveSource[hidden]` CSS rule).
+
+The host side (pickSave, `px.guiEditor.save` state, the merge under the mod's
+preview table) still runs; a save chosen before the button was hidden keeps
+feeding values.

--- a/packages/server/src/overview/eventBanner.ts
+++ b/packages/server/src/overview/eventBanner.ts
@@ -24,14 +24,25 @@ import { decode, parseScript, type BlockNode, type Statement } from "../parser";
 const TEXTURE_PATH = /\.(dds|tga|png)$/i;
 
 export function computeEventBanner(data: ServerData, theme: string): EventBannerResult {
-  const themeRef = referenceOf(data, theme, "event_theme");
-  if (themeRef === null) return { theme, reason: "no theme definition with a background" };
-  if (TEXTURE_PATH.test(themeRef)) return { theme, texture: themeRef };
+  // The graph sends whatever the event itself names: an override_background
+  // reference (an event_background key, or already a texture path) wins over
+  // the theme, because that is the picture the game actually shows.
+  if (TEXTURE_PATH.test(theme)) return { theme, texture: theme };
 
-  const backgroundRef = referenceOf(data, themeRef, "event_background");
-  if (backgroundRef === null) return { theme, reason: `no background definition named ${themeRef}` };
-  if (!TEXTURE_PATH.test(backgroundRef)) return { theme, reason: `${themeRef} names no texture` };
-  return { theme, texture: backgroundRef };
+  const themeRef = referenceOf(data, theme, "event_theme");
+  if (themeRef !== null) {
+    if (TEXTURE_PATH.test(themeRef)) return { theme, texture: themeRef };
+    const backgroundRef = referenceOf(data, themeRef, "event_background");
+    if (backgroundRef === null) return { theme, reason: `no background definition named ${themeRef}` };
+    if (!TEXTURE_PATH.test(backgroundRef)) return { theme, reason: `${themeRef} names no texture` };
+    return { theme, texture: backgroundRef };
+  }
+
+  // Not a theme: an event_background named directly (override_background).
+  const direct = referenceOf(data, theme, "event_background");
+  if (direct === null) return { theme, reason: "no theme or background definition with a background" };
+  if (!TEXTURE_PATH.test(direct)) return { theme, reason: `${theme} names no texture` };
+  return { theme, texture: direct };
 }
 
 /**

--- a/packages/server/src/overview/eventGraph.ts
+++ b/packages/server/src/overview/eventGraph.ts
@@ -346,7 +346,9 @@ export function computeEventGraph(
     if (facts) {
       if (def?.kind === "event") node.options = facts.options;
       if (facts.trigger) node.triggerSummary = facts.trigger;
-      if (params.themes && facts.theme) node.theme = facts.theme;
+      // override_background wins over the theme: it is the picture the game
+      // actually shows for this event, and the banner resolver takes either.
+      if (params.themes && (facts.background ?? facts.theme)) node.theme = facts.background ?? facts.theme;
     }
     const fires = firesCount.get(id) ?? 0;
     if (fires > 0) node.fires = fires;
@@ -364,6 +366,8 @@ interface DefFacts {
   trigger: string;
   /** `theme = X`, for the banner layer. */
   theme?: string;
+  /** `override_background = { reference = X }`: wins over the theme's picture. */
+  background?: string;
 }
 /** Trigger keys named on a card before it says "…". Two fit the card's width. */
 const TRIGGER_KEYS_SHOWN = 2;
@@ -393,7 +397,10 @@ function fileFacts(): (file: string) => Map<string, DefFacts> {
           const childKey = child.key.text.toLowerCase();
           if (childKey === "option") entry.options++;
           else if (childKey === "theme" && child.value?.kind === "scalar") entry.theme = child.value.text;
-          else if (childKey === "trigger" && entry.trigger === "") entry.trigger = triggerKeys(child.value);
+          else if (childKey === "override_background") {
+            const ref = backgroundReference(child.value);
+            if (ref) entry.background = ref;
+          } else if (childKey === "trigger" && entry.trigger === "") entry.trigger = triggerKeys(child.value);
         }
         facts.set(stmt.key.text, entry);
       }
@@ -408,6 +415,23 @@ function blockOf(value: ValueNode | null | undefined): BlockNode | null {
   if (value?.kind === "block") return value;
   if (value?.kind === "tagged-block") return value.block;
   return null;
+}
+
+/**
+ * The reference of an `override_background` value: `{ reference = X }` in the
+ * current syntax, a bare scalar in the pre-1.5 one. Several blocks would be
+ * trigger-gated variants; the last reference is the file's own fallback.
+ */
+function backgroundReference(value: ValueNode | null | undefined): string | null {
+  if (value?.kind === "scalar") return value.text;
+  const block = blockOf(value);
+  if (!block) return null;
+  let ref: string | null = null;
+  for (const stmt of block.statements) {
+    if (stmt.kind !== "assignment") continue;
+    if (stmt.key.text.toLowerCase() === "reference" && stmt.value?.kind === "scalar") ref = stmt.value.text;
+  }
+  return ref;
 }
 
 /** "is_adult, has_trait…": what a `trigger` block asks, short enough for a card. */

--- a/packages/vscode/src/webviews/eventGraph/app/inspector.ts
+++ b/packages/vscode/src/webviews/eventGraph/app/inspector.ts
@@ -257,13 +257,16 @@ export class Inspector {
       variable: "variable",
       scripted_effect: "effect",
       scripted_trigger: "trigger",
-      script_value: "value",
+      script_value: "<SV>",
       event: "event",
     };
     for (const kind of order) {
       for (const ref of detail.refs.filter((r) => r.kind === kind)) {
         const row = el("div", "px-item");
-        row.title = ref.name;
+        row.title =
+          kind === "script_value"
+            ? `Script Value\n${ref.name}: a number computed by script, defined under common/script_values.`
+            : ref.name;
         row.appendChild(el("span", "px-item-kind", labels[kind] ?? kind));
         row.appendChild(el("span", "px-item-label", ref.name));
         if (ref.defFile && (ref.defCount ?? 0) > 1) {

--- a/packages/vscode/src/webviews/eventGraph/app/main.ts
+++ b/packages/vscode/src/webviews/eventGraph/app/main.ts
@@ -13,6 +13,7 @@ import { GraphHistory, type GraphState } from "../history";
 import { iconEl } from "../../shared/icons";
 import { sidePanel } from "../../shared/sidePanel";
 import { closePopover, isPopoverAnchor, popover, toast } from "../../shared/overlay";
+import { helpDialog } from "../../shared/help";
 import { el, iconButton } from "./dom";
 import { GraphView } from "./view";
 import { Inspector } from "./inspector";
@@ -412,30 +413,119 @@ function updateRailTools(): void {
   $("actingOn").textContent = has ? `Acting on: ${labelFor(selectedId!)}` : "";
 }
 
-$("helpBtn").onclick = () => {
-  const anchor = $("helpBtn");
-  if (isPopoverAnchor(anchor)) {
-    closePopover();
-    return;
-  }
-  const help = el("div", "help");
-  help.appendChild(el("div", "px-popover-title", "How to read the graph"));
-  const list = el("ul");
-  for (const text of [
-    "The card in the middle is what you are looking at. What fires it is on the left, what it fires is on the right, further hops one ring further out.",
-    "A card says its name, then its kind and how many options it has, then what its trigger asks for and how much it fires.",
-    "The colored bar is the kind. Dashed borders are vanilla content, solid is your mod, dotted is a parent mod.",
-    "Click a card to focus and inspect it, drag it to move it, double-click to open its source, right-click to re-centre the graph on it.",
-    "The Cluster tool keeps only the cards connected to the selected one, so you can follow one sequence. Undo brings the rest back.",
-    'An arrow labeled "via" goes through a scripted effect: the event does not name the target itself, the effect it calls does.',
-    "Edits in the inspector are held here until you press Save. The Changes button lists them, and each row goes back to before it.",
-    "Drag the canvas to pan, scroll to zoom. + / − / 0 or the buttons at the bottom left do the same.",
-  ]) {
-    list.appendChild(el("li", "", text));
-  }
-  help.appendChild(list);
-  popover(anchor, help);
-};
+$("helpBtn").onclick = () =>
+  helpDialog({
+    title: "Event Graph",
+    intro:
+      "Every event, on_action and decision of your mod as cards, with an arrow for every “this fires that” the index found. Use it to follow an event chain, spot dead ends, and edit an event without leaving the picture.",
+    sections: [
+      {
+        title: "Reading a card",
+        items: [
+          {
+            lead: "Line by line:",
+            text: "the name (or localized title), then the kind and how many options it has, then what its trigger asks for and how often other content fires it.",
+          },
+          {
+            lead: "The colored bar",
+            text: "on the left is the kind: blue events, purple on_actions, green decisions, orange everything else. The chips at the bottom left dim a kind in the whole graph.",
+          },
+          {
+            lead: "The border",
+            text: "says where it comes from: solid is your mod, dashed is vanilla, dotted is a parent mod.",
+          },
+          {
+            lead: "Arrows",
+            text: "point from the thing that fires to the thing fired. One labeled “via” goes through a scripted effect: the event does not name the target itself, the effect it calls does.",
+          },
+          {
+            lead: "With a card selected,",
+            text: "its own arrows color up (outgoing blue, incoming orange) and everything unrelated dims, so the neighborhood stays readable in a big graph.",
+          },
+        ],
+      },
+      {
+        title: "Moving around",
+        items: [
+          {
+            lead: "Pan and zoom:",
+            text: "drag the canvas, scroll to zoom, and the buttons at the bottom left zoom and fit.",
+          },
+          {
+            lead: "Search:",
+            text: "the box at the top left takes an event id (namespace.123), an on_action or decision name, or a whole namespace; suggestions appear as you type, and typing also outlines every matching card.",
+          },
+          {
+            lead: "Move a card",
+            text: "by dragging it; it stays where you put it and the rest of the map makes room. Undo puts it back.",
+          },
+        ],
+      },
+      {
+        title: "The tools on the left",
+        intro: "The first, second and last need a card selected.",
+        items: [
+          {
+            lead: "Simulate",
+            text: "walks through the selected event block by block, in the order the game runs them, in a floating window you can step deeper from.",
+          },
+          {
+            lead: "Cluster",
+            text: "keeps only the cards connected to the selected one — the sequence it belongs to — and hides the rest. Undo brings the whole graph back.",
+          },
+          { lead: "All nodes", text: "loads everything the mod has, connected or not." },
+          {
+            lead: "Source",
+            text: "opens the selected card's file beside the graph. Double-clicking a card and the small button on its corner do the same; right-click re-centres the graph on it instead.",
+          },
+        ],
+      },
+      {
+        title: "Editing and saving",
+        intro: "Nothing touches your files until you press Save; until then every edit lives in this view.",
+        items: [
+          {
+            lead: "Click a card",
+            text: "to open it in the inspector: its fields with dropdowns listing the game's own values, its title and description text, its options, and every scope, effect and value it references.",
+          },
+          {
+            lead: "Add things",
+            text: "with the “Add field”, “Add effect”, “Add trigger” and “Add option” rows; each list comes from your game files, with the engine's own one-line documentation.",
+          },
+          {
+            lead: "<SV>",
+            text: "marks a script value: a number computed by script, defined under common/script_values.",
+          },
+          {
+            lead: "Changed rows say “unsaved”.",
+            text: "The Changes button lists every pending edit, and each row's undo takes you back to before it. Save writes them all to your mod files, in a safe order.",
+          },
+        ],
+      },
+      {
+        title: "Display options",
+        items: [
+          { lead: "Raw / Loc", text: "captions every card with its id or its localized title." },
+          {
+            lead: "The image button",
+            text: "draws each event's real background behind its card (its override_background, or its theme's). A background that cannot be resolved gets a hatched placeholder instead of a wrong picture.",
+          },
+        ],
+      },
+      {
+        title: "Keyboard",
+        shortcuts: [
+          { keys: ["+", "−"], does: "Zoom in and out" },
+          { keys: ["0"], does: "Fit the whole graph (F does the same)" },
+          { keys: ["/"], does: "Focus the search box" },
+          { keys: ["Esc"], does: "Close the simulation, else clear the selection" },
+          { keys: ["Ctrl", "Z"], does: "Undo (edits, moves, focus changes alike)" },
+          { keys: ["Ctrl", "Shift", "Z"], does: "Redo" },
+          { keys: ["Ctrl", "S"], does: "Save the pending edits to your files" },
+        ],
+      },
+    ],
+  });
 
 // ---------------------------------------------------------------------------
 // Query box

--- a/packages/vscode/src/webviews/eventGraph/app/main.ts
+++ b/packages/vscode/src/webviews/eventGraph/app/main.ts
@@ -43,6 +43,8 @@ let ui: UiState = {
 };
 let currentGraph: EventGraph | null = null;
 let currentParams: EventGraphParams = {};
+/** The cluster filter the LAST render actually drew (null = the whole graph). */
+let renderedCluster: string | null = null;
 const hiddenKinds = new Set<string>();
 
 const history = new GraphHistory({ focus: {}, positions: {}, pending: [] });
@@ -145,9 +147,41 @@ function selectNode(id: string | null): void {
 function refocus(id: string): void {
   const focus: EventGraphParams = { ...baseParams(), root: id };
   // A refocus is a history step: undo takes the reader back where they were.
-  history.push(`focus ${id}`, { ...history.state, focus, positions: {} });
+  history.push(`focus ${id}`, { ...history.state, focus, cluster: undefined, positions: {} });
   afterHistoryChange();
   fetchGraph(focus);
+}
+
+/**
+ * The subgraph connected to `id`, following edges both ways: the sequence the
+ * node belongs to, with every unrelated card gone. Client-side, so the Cluster
+ * tool costs no round trip and undo brings the full graph straight back.
+ */
+function clusterGraph(graph: EventGraph, id: string): EventGraph {
+  const adjacent = new Map<string, string[]>();
+  const link = (a: string, b: string): void => {
+    const list = adjacent.get(a);
+    if (list) list.push(b);
+    else adjacent.set(a, [b]);
+  };
+  for (const edge of graph.edges) {
+    link(edge.from, edge.to);
+    link(edge.to, edge.from);
+  }
+  const keep = new Set<string>([id]);
+  const queue = [id];
+  while (queue.length > 0) {
+    for (const next of adjacent.get(queue.pop()!) ?? []) {
+      if (keep.has(next)) continue;
+      keep.add(next);
+      queue.push(next);
+    }
+  }
+  return {
+    ...graph,
+    nodes: graph.nodes.filter((n) => keep.has(n.id)),
+    edges: graph.edges.filter((e) => keep.has(e.from) && keep.has(e.to)),
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -180,7 +214,14 @@ function applyState(state: GraphState): void {
   view.setOptions({ positions: state.positions });
   if (lastDetail && selectedId) inspector.render(lastDetail, selectedId, state.pending);
   afterHistoryChange();
-  if (!sameFocus(state.focus, currentParams)) fetchGraph(state.focus);
+  if (!sameFocus(state.focus, currentParams)) {
+    fetchGraph(state.focus);
+    return;
+  }
+  // Same focus but a different cluster: redraw from the graph we already hold.
+  if ((state.cluster ?? null) !== renderedCluster && currentGraph) {
+    renderGraph(currentGraph, currentParams);
+  }
 }
 
 function sameFocus(a: EventGraphParams, b: EventGraphParams): boolean {
@@ -325,13 +366,20 @@ $("toolSimulate").onclick = () => {
   if (selectedId) sim.open(selectedId);
 };
 $("toolCenter").onclick = () => {
-  if (selectedId) refocus(selectedId);
+  if (!selectedId || !currentGraph) return;
+  const id = selectedId;
+  // A view-only step: the graph we hold is filtered down to the nodes connected
+  // to the selection. Undo restores the full view; nothing is fetched.
+  history.push(`cluster around ${id}`, { ...history.state, cluster: id, positions: {} });
+  afterHistoryChange();
+  renderGraph(currentGraph, currentParams);
+  selectNode(id);
 };
 $("toolAll").onclick = () => {
   queryEl.value = "";
   hideSuggest();
   const focus: EventGraphParams = { maxNodes: 5000 };
-  history.push("show all nodes", { ...history.state, focus, positions: {} });
+  history.push("show all nodes", { ...history.state, focus, cluster: undefined, positions: {} });
   afterHistoryChange();
   fetchGraph(focus);
 };
@@ -378,6 +426,7 @@ $("helpBtn").onclick = () => {
     "A card says its name, then its kind and how many options it has, then what its trigger asks for and how much it fires.",
     "The colored bar is the kind. Dashed borders are vanilla content, solid is your mod, dotted is a parent mod.",
     "Click a card to focus and inspect it, drag it to move it, double-click to open its source, right-click to re-centre the graph on it.",
+    "The Cluster tool keeps only the cards connected to the selected one, so you can follow one sequence. Undo brings the rest back.",
     'An arrow labeled "via" goes through a scripted effect: the event does not name the target itself, the effect it calls does.',
     "Edits in the inspector are held here until you press Save. The Changes button lists them, and each row goes back to before it.",
     "Drag the canvas to pan, scroll to zoom. + / − / 0 or the buttons at the bottom left do the same.",
@@ -409,7 +458,7 @@ function parseQuery(): EventGraphParams {
 function submitQuery(): void {
   hideSuggest();
   const focus = parseQuery();
-  history.push("change focus", { ...history.state, focus, positions: {} });
+  history.push("change focus", { ...history.state, focus, cluster: undefined, positions: {} });
   afterHistoryChange();
   fetchGraph(focus);
 }
@@ -491,7 +540,7 @@ function pick(index: number): void {
   hideSuggest();
   view.highlight(entry.text);
   const focus = paramsFor(entry.text, entry.kind);
-  history.push(`focus ${entry.text}`, { ...history.state, focus, positions: {} });
+  history.push(`focus ${entry.text}`, { ...history.state, focus, cluster: undefined, positions: {} });
   afterHistoryChange();
   fetchGraph(focus);
 }
@@ -531,9 +580,11 @@ function setFocusLine(text: string, state: "" | "warn" | "error"): void {
   else delete focusLineEl.dataset.state;
 }
 
-function updateInfo(graph: EventGraph, params: EventGraphParams): void {
+function updateInfo(graph: EventGraph, params: EventGraphParams, cluster: string | null): void {
   const lines = [`${graph.nodes.length} nodes · ${graph.edges.length} edges`];
   if (graph.truncated) lines.push("Truncated: this view hides part of the graph.");
+  if (cluster)
+    lines.push(`Clustered around ${cluster}: only the cards connected to it. Undo brings the rest back.`);
   lines.push(
     params.root
       ? `Focused on ${params.root}: what it fires, what fires it, and one hop further.`
@@ -619,7 +670,9 @@ window.addEventListener("message", (ev: MessageEvent<HostToApp>) => {
       }
       if (currentParams.root) queryEl.value = currentParams.root;
       else if (currentParams.namespace) queryEl.value = currentParams.namespace;
-      // The focus the host loaded is the focus the history should hold.
+      // The focus the host loaded is the focus the history should hold. A
+      // cluster from another focus would filter the wrong graph: drop it.
+      if (!sameFocus(history.state.focus, currentParams)) history.state.cluster = undefined;
       history.state.focus = currentParams;
       try {
         renderGraph(msg.graph, currentParams);
@@ -636,7 +689,14 @@ function renderGraph(graph: EventGraph, params: EventGraphParams): void {
   updateRailTools();
   inspector.showPlaceholder();
 
-  if ((graph.nodes ?? []).length === 0) {
+  // The Cluster tool's filter: applied at render time so the full graph stays
+  // in `currentGraph` and undoing the cluster is a redraw, not a fetch.
+  const cluster = history.state.cluster ?? null;
+  const clustered = cluster !== null && (graph.nodes ?? []).some((n) => n.id === cluster);
+  const shown = clustered ? clusterGraph(graph, cluster) : graph;
+  renderedCluster = clustered ? cluster : null;
+
+  if ((shown.nodes ?? []).length === 0) {
     emptyEl.classList.add("show");
     emptyEl.replaceChildren(
       el(
@@ -648,20 +708,22 @@ function renderGraph(graph: EventGraph, params: EventGraphParams): void {
       )
     );
     setFocusLine("Nothing to show", "warn");
-    updateInfo(graph, params);
+    updateInfo(shown, params, renderedCluster);
     return;
   }
   emptyEl.classList.remove("show");
-  view.render(graph, params, {
+  view.render(shown, clustered ? { ...params, root: cluster } : params, {
     positions: history.state.positions,
     titleMode: ui.titleMode,
     banner: ui.banner,
   });
+  // The focus itself is already in the query box; this line only flags a view
+  // that hides something (truncation, cluster).
   setFocusLine(
-    params.root ? `Around ${params.root}` : params.namespace ? `Namespace ${params.namespace}` : "All nodes",
-    graph.truncated ? "warn" : ""
+    clustered ? `Cluster: ${shown.nodes.length} connected cards` : graph.truncated ? "Truncated view" : "",
+    graph.truncated && !clustered ? "warn" : ""
   );
-  updateInfo(graph, params);
+  updateInfo(shown, params, renderedCluster);
 }
 
 updatePanelToggle();

--- a/packages/vscode/src/webviews/eventGraph/app/main.ts
+++ b/packages/vscode/src/webviews/eventGraph/app/main.ts
@@ -718,10 +718,15 @@ function renderGraph(graph: EventGraph, params: EventGraphParams): void {
     banner: ui.banner,
   });
   // The focus itself is already in the query box; this line only flags a view
-  // that hides something (truncation, cluster).
+  // that hides something (truncation, cluster). A cluster cut from a truncated
+  // graph says both: its component may be missing members the server never sent.
   setFocusLine(
-    clustered ? `Cluster: ${shown.nodes.length} connected cards` : graph.truncated ? "Truncated view" : "",
-    graph.truncated && !clustered ? "warn" : ""
+    clustered
+      ? `Cluster: ${shown.nodes.length} connected cards${graph.truncated ? " · truncated view" : ""}`
+      : graph.truncated
+        ? "Truncated view"
+        : "",
+    graph.truncated ? "warn" : ""
   );
   updateInfo(shown, params, renderedCluster);
 }

--- a/packages/vscode/src/webviews/eventGraph/history.ts
+++ b/packages/vscode/src/webviews/eventGraph/history.ts
@@ -45,6 +45,8 @@ export type PendingEdit =
 export interface GraphState {
   /** What the graph is showing (root / namespace / everything). */
   focus: EventGraphParams;
+  /** Show only the nodes connected to this one (the Cluster tool). */
+  cluster?: string;
   /** Node id -> position a drag put it at. Absent = wherever the layout says. */
   positions: Record<string, { x: number; y: number }>;
   /** File edits waiting for Save, oldest first. */
@@ -55,6 +57,7 @@ export interface GraphState {
 function clone(state: GraphState): GraphState {
   return {
     focus: { ...state.focus },
+    cluster: state.cluster,
     positions: { ...state.positions },
     pending: state.pending.map((edit) => ({ ...edit })),
   };

--- a/packages/vscode/src/webviews/eventGraph/html.ts
+++ b/packages/vscode/src/webviews/eventGraph/html.ts
@@ -34,7 +34,7 @@ const TOOLS: { id: string; icon: Parameters<typeof icon>[0]; tip: string; needsC
   {
     id: "toolCenter",
     icon: "locate",
-    tip: "Center: rebuild the graph around the selected event. Needs a card selected",
+    tip: "Cluster: keep only the cards connected to the selected one, so you see the sequence it belongs to. Undo brings the rest back. Needs a card selected",
     needsCard: true,
   },
   {
@@ -53,7 +53,7 @@ const TOOLS: { id: string; icon: Parameters<typeof icon>[0]; tip: string; needsC
 export function eventGraphHtml({ scriptSrc, nonce, csp }: EventGraphHtmlOptions): string {
   const kindToggles = KINDS.map(
     (k) =>
-      `<button class="px-toggle" data-size="sm" data-kind="${k.kind}" aria-pressed="true" data-tip="${k.tip}"><i class="swatch" style="background:var(--eg-${k.kind})"></i>${k.label}</button>`
+      `<button class="px-toggle" data-size="sm" data-kind="${k.kind}" aria-pressed="true" data-tip="${k.tip}" data-tip-side="top"><i class="swatch" style="background:var(--eg-${k.kind})"></i>${k.label}</button>`
   ).join("");
   const tools = TOOLS.map(
     (t) =>
@@ -111,8 +111,12 @@ ${uiCss}
     background: var(--px-primary); color: var(--px-primary-fg);
   }
   #changes[disabled] .count { display: none; }
-  /* Compact kind chips: a swatch, a word, one row. */
-  #kinds { gap: 6px; }
+  /* Compact kind chips: a swatch, a word, one row. They sit on the canvas
+     next to the zoom group, so they get the same translucent backing. */
+  #kinds {
+    gap: 4px; padding: 2px; border-radius: var(--px-radius);
+    background: color-mix(in oklch, var(--px-bg) 75%, transparent);
+  }
   #kinds .px-toggle { height: var(--px-h-sm); padding: 0 8px; gap: 5px; font-size: var(--px-text-sm); }
   #kinds .swatch { width: 12px; height: 12px; border-radius: 3px; display: inline-block; flex: 0 0 auto; }
   #kinds .px-toggle[aria-pressed="false"] { color: var(--px-muted-fg); }
@@ -306,11 +310,10 @@ ${uiCss}
       <button id="titleRaw" class="px-toggle" data-size="sm" aria-pressed="true" data-tip="Caption every card with its raw id (cultivation_scheme.101)" data-tip-wrap>Raw</button>
       <button id="titleLoc" class="px-toggle" data-size="sm" aria-pressed="false" data-tip="Caption every card with its localized title, falling back to the id where there is none" data-tip-wrap>Loc</button>
     </div>
+    <button id="toolBanner" class="tool px-btn" data-variant="ghost" data-size="icon-sm" aria-pressed="false" data-tip="Event background: draw each event's background illustration behind its card. A background that cannot be resolved gets a hatched placeholder that says so" data-tip-wrap>${icon("image")}</button>
     <div class="px-separator" data-orientation="vertical"></div>
     <button id="undo" class="px-btn" data-variant="ghost" data-size="icon-sm" data-tip="Nothing to undo" disabled>${icon("undo")}</button>
     <button id="redo" class="px-btn" data-variant="ghost" data-size="icon-sm" data-tip="Nothing to redo" disabled>${icon("redo")}</button>
-    <div class="px-separator" data-orientation="vertical"></div>
-    <div id="kinds" class="px-toggle-group" data-tip="Click a kind to dim it in the graph" data-tip-wrap>${kindToggles}</div>
     <span class="px-grow"></span>
     <button id="refresh" class="px-btn" data-variant="ghost" data-size="icon-sm" data-tip="Reload the current graph from the index">${icon("rotate")}</button>
     <button id="changes" class="px-btn" data-variant="ghost" data-size="sm" data-tip="No changes yet. Edits stay in this view until you save them" data-tip-wrap disabled>${icon("list")}<span class="count">0</span></button>
@@ -324,7 +327,6 @@ ${uiCss}
     <div id="rail" class="px-sidepanel" data-side="left">
       <div class="px-sidepanel-body">
         ${tools}
-        <button id="toolBanner" class="tool px-btn" data-variant="ghost" data-size="icon-sm" aria-pressed="false" data-tip="Event banner: draw each event's theme illustration behind its card. A theme whose picture cannot be resolved gets a hatched placeholder that says so" data-tip-side="right" data-tip-wrap>${icon("image")}</button>
       </div>
     </div>
     <div id="graphWrap">
@@ -339,6 +341,7 @@ ${uiCss}
           <button id="zoomIn" class="px-btn" data-variant="ghost" data-size="icon-sm" data-tip="Zoom in (+)" data-tip-side="top">${icon("zoomIn")}</button>
           <button id="zoomFit" class="px-btn" data-variant="ghost" data-size="icon-sm" data-tip="Fit the graph (0)" data-tip-side="top">${icon("maximize")}</button>
         </div>
+        <div id="kinds" class="px-toggle-group" data-tip="Click a kind to dim it in the graph" data-tip-side="top" data-tip-wrap>${kindToggles}</div>
         <span id="focusLine" class="px-muted px-xs"></span>
       </div>
       <button id="info" class="px-btn" data-variant="ghost" data-size="icon-sm" data-tip="" data-tip-side="top" data-tip-align="right" data-tip-wrap>${icon("info")}</button>

--- a/packages/vscode/src/webviews/eventGraph/html.ts
+++ b/packages/vscode/src/webviews/eventGraph/html.ts
@@ -320,7 +320,7 @@ ${uiCss}
     <button id="save" class="px-btn" data-variant="default" data-size="sm" data-tip="No changes to save yet. Edits stay in this view until you save them" data-tip-wrap disabled>${icon("save")}Save</button>
     <div class="px-separator" data-orientation="vertical"></div>
     <button id="export" class="px-btn" data-variant="ghost" data-size="icon-sm" data-tip="Export the graph as SVG" data-tip-side="left">${icon("download")}</button>
-    <button id="helpBtn" class="px-btn" data-variant="ghost" data-size="icon-sm" data-tip="How to read this view" data-tip-side="left">${icon("circleHelp")}</button>
+    <button id="helpBtn" class="px-btn" data-variant="ghost" data-size="icon-sm" data-tip="How this view works: reading, editing, saving, shortcuts" data-tip-side="left" data-tip-wrap>${icon("circleHelp")}</button>
     <button id="togglePanel" class="px-btn" data-variant="ghost" data-size="icon-sm" data-tip="Hide inspector" data-tip-side="left">${icon("panelRightClose")}</button>
   </div>
   <div id="main">

--- a/packages/vscode/src/webviews/eventGraph/panel.ts
+++ b/packages/vscode/src/webviews/eventGraph/panel.ts
@@ -75,7 +75,7 @@ export class EventGraphPanel {
 
     this.panel = vscode.window.createWebviewPanel(
       EventGraphPanel.viewType,
-      "Paradox Event Graph",
+      "Event Graph",
       vscode.ViewColumn.Active,
       {
         enableScripts: true,
@@ -145,7 +145,7 @@ export class EventGraphPanel {
     );
     if (answer === "Save") {
       const result = await this.applyEdits(pending);
-      if (result.error) void vscode.window.showErrorMessage(`Paradox Event Graph: ${result.error}`);
+      if (result.error) void vscode.window.showErrorMessage(`Event Graph: ${result.error}`);
       return;
     }
     if (answer === "Discard") return;
@@ -317,7 +317,7 @@ export class EventGraphPanel {
         selection: new vscode.Range(position, position),
       });
     } catch (err) {
-      void vscode.window.showErrorMessage(`Paradox Event Graph: cannot open ${file}: ${message(err)}`);
+      void vscode.window.showErrorMessage(`Event Graph: cannot open ${file}: ${message(err)}`);
     }
   }
 
@@ -332,7 +332,7 @@ export class EventGraphPanel {
       await vscode.workspace.fs.writeFile(target, Buffer.from(svg, "utf8"));
       void vscode.window.showInformationMessage(`Event graph exported to ${target.fsPath}`);
     } catch (err) {
-      void vscode.window.showErrorMessage(`Paradox Event Graph: export failed: ${message(err)}`);
+      void vscode.window.showErrorMessage(`Event Graph: export failed: ${message(err)}`);
     }
   }
 

--- a/packages/vscode/src/webviews/eventGraph/tokenize.ts
+++ b/packages/vscode/src/webviews/eventGraph/tokenize.ts
@@ -8,6 +8,12 @@
  * are its own flattened output (`key = value`, `key = {`, `}`, or a bare list
  * entry), so a scanner that never looks past the end of the line is enough,
  * and it cannot disagree with the parse the lines came from.
+ *
+ * SELF-CONTAINED ON PURPOSE: the event-sim panel ships this function by
+ * serializing it into its inline webview script (`tokenizeScriptLine.toString()`,
+ * the same trick it plays with `simulationSteps`), so every constant and helper
+ * lives INSIDE the function. A module-level constant would compile to an
+ * `exports.` reference that does not exist in the page.
  */
 
 export type ScriptTokenKind = "comment" | "key" | "op" | "string" | "number" | "bool" | "brace" | "text";
@@ -17,17 +23,21 @@ export interface ScriptToken {
   kind: ScriptTokenKind;
 }
 
-/** Characters that end a bare word. */
-const BREAK = /[\s{}"#=<>!?]/;
-const OPERATOR = "=<>!?";
-const NUMBER = /^-?\d+(\.\d+)?$/;
-
 /**
  * Split one line into colorable tokens. Every character of the input lands in
  * exactly one token, in order, so joining the texts returns the line unchanged
  * (whitespace included) and the renderer needs no separate spacing rules.
  */
 export function tokenizeScriptLine(line: string): ScriptToken[] {
+  /** Characters that end a bare word. */
+  const BREAK = /[\s{}"#=<>!?]/;
+  const OPERATOR = "=<>!?";
+  const NUMBER = /^-?\d+(\.\d+)?$/;
+  const valueKind = (word: string): ScriptTokenKind => {
+    if (NUMBER.test(word)) return "number";
+    if (word === "yes" || word === "no") return "bool";
+    return "text";
+  };
   const out: ScriptToken[] = [];
   const push = (text: string, kind: ScriptTokenKind): void => {
     if (text !== "") out.push({ text, kind });
@@ -79,10 +89,4 @@ export function tokenizeScriptLine(line: string): ScriptToken[] {
     i = j;
   }
   return out;
-}
-
-function valueKind(word: string): ScriptTokenKind {
-  if (NUMBER.test(word)) return "number";
-  if (word === "yes" || word === "no") return "bool";
-  return "text";
 }

--- a/packages/vscode/src/webviews/eventSim/panel.ts
+++ b/packages/vscode/src/webviews/eventSim/panel.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode";
 import type { EventDetail } from "@px-lsp/protocol/protocol";
 import { simulationSteps } from "./steps";
+import { tokenizeScriptLine } from "../eventGraph/tokenize";
 import uiCss from "../shared/ui.css";
 import { icon } from "../shared/icons";
 import { makeNonce } from "../nonce";
@@ -189,8 +190,10 @@ ${uiCss}
   .step { margin: 4px 0; }
   .step > .px-panel-title { padding-left: 4px; cursor: pointer; border-radius: var(--px-radius-md); transition: background-color var(--px-ease); }
   .step > .px-panel-title:hover { background: var(--px-muted); }
-  .step > .px-panel-title .caret { transition: transform var(--px-ease); color: var(--px-muted-fg); }
-  .step[data-collapsed] > .px-panel-title .caret { transform: rotate(-90deg); }
+  /* The caret is a button, and its tooltip is that button's ::after, so
+     rotating the button would turn the words on their side. Rotate the icon. */
+  .step > .px-panel-title .caret > svg { transition: transform var(--px-ease); color: var(--px-muted-fg); }
+  .step[data-collapsed] > .px-panel-title .caret > svg { transform: rotate(-90deg); }
   .step[data-collapsed] > .step-body { display: none; }
   .step > .px-panel-title .t { color: var(--px-fg); }
   .step > .px-panel-title .s { flex: 1 1 auto; min-width: 0; font-weight: 400; text-transform: none; letter-spacing: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
@@ -202,6 +205,13 @@ ${uiCss}
     transition: background-color var(--px-ease);
   }
   .script .ln:hover { background: var(--px-muted); }
+  .tok-key { color: var(--px-tok-key); }
+  .tok-op { color: var(--px-tok-op); }
+  .tok-string { color: var(--px-tok-string); }
+  .tok-number { color: var(--px-tok-number); }
+  .tok-bool { color: var(--px-tok-bool); }
+  .tok-comment { color: var(--px-tok-comment); font-style: italic; }
+  .tok-brace { color: var(--px-tok-brace); }
   .note, .more { padding: 4px 8px; color: var(--px-muted-fg); }
   .leads { padding: 4px 0 2px; }
   .target { display: flex; align-items: center; gap: 6px; min-height: 24px; padding: 0 8px; }
@@ -230,9 +240,14 @@ const vscode = acquireVsCodeApi();
 // === Shipped arrangement: exact source of the unit-tested simulationSteps ===
 const simulationSteps = ${stepsSource};
 
-const ICON_CARET = ${JSON.stringify(icon("chevronDown", "px-icon caret"))};
+// === Shipped tokenizer: exact source of the unit-tested tokenizeScriptLine
+// (self-contained by design; see tokenize.ts header) ===
+const tokenizeScriptLine = ${tokenizeScriptLine.toString()};
+
+const ICON_CARET = ${JSON.stringify(icon("chevronDown"))};
 const ICON_STEP = ${JSON.stringify(icon("cornerDownRight"))};
 const ICON_CRUMB = ${JSON.stringify(icon("chevronRight"))};
+const ICON_FILE = ${JSON.stringify(icon("fileText"))};
 
 const bodyEl = document.getElementById("body");
 const chainEl = document.getElementById("chain");
@@ -312,18 +327,25 @@ function renderTarget(container, target, indent) {
 function renderStep(detail, step) {
   const card = el("div", "step " + step.kind);
   const head = el("div", "px-panel-title");
-  head.innerHTML = ICON_CARET;
+  // The caret is a real button that folds the section; the rest of the header
+  // opens the source. A decorative caret that swallowed clicks was the bug.
+  const fold = el("button", "px-btn caret");
+  fold.dataset.variant = "ghost";
+  fold.dataset.size = "icon-xs";
+  fold.dataset.tip = "Fold this section";
+  fold.innerHTML = ICON_CARET;
+  fold.addEventListener("click", function (ev) {
+    ev.stopPropagation();
+    card.toggleAttribute("data-collapsed");
+    fold.dataset.tip = card.hasAttribute("data-collapsed") ? "Unfold this section" : "Fold this section";
+  });
+  head.appendChild(fold);
   head.appendChild(el("span", "t", step.title));
   head.appendChild(el("span", "s", step.subtitle));
   head.appendChild(el("span", "at", "line " + (step.line + 1)));
   head.dataset.tip = "Open " + detail.file + " at line " + (step.line + 1);
   head.dataset.tipWrap = "";
-  // The caret folds the section; the rest of the header opens the source.
-  head.addEventListener("click", function (ev) {
-    if (ev.target.closest(".caret")) {
-      card.toggleAttribute("data-collapsed");
-      return;
-    }
+  head.addEventListener("click", function () {
     vscode.postMessage({ type: "open", file: detail.file, line: step.line });
   });
   card.appendChild(head);
@@ -334,7 +356,10 @@ function renderStep(detail, step) {
   if (step.lines.length > 0) {
     const script = el("div", "script");
     for (const line of step.lines) {
-      const row = el("div", "ln", "  ".repeat(line.depth) + line.text);
+      const row = el("div", "ln");
+      for (const token of tokenizeScriptLine("  ".repeat(line.depth) + line.text)) {
+        row.appendChild(el("span", "tok-" + token.kind, token.text));
+      }
       row.title = "Open line " + (line.line + 1);
       row.addEventListener("click", function () {
         vscode.postMessage({ type: "open", file: detail.file, line: line.line });
@@ -398,7 +423,11 @@ function render(msg) {
   if (detail.type) badges.appendChild(badge(detail.type));
   if (detail.theme) badges.appendChild(badge("theme: " + detail.theme));
   if (detail.hidden) badges.appendChild(badge("hidden"));
-  badges.appendChild(openLink("Open source", detail.file, detail.line));
+  const source = linkButton("Open source", ICON_FILE);
+  source.addEventListener("click", function () {
+    vscode.postMessage({ type: "open", file: detail.file, line: detail.line || 0 });
+  });
+  badges.appendChild(source);
   bodyEl.appendChild(badges);
 
   const steps = simulationSteps(detail);

--- a/packages/vscode/src/webviews/flagBuilder/app/main.ts
+++ b/packages/vscode/src/webviews/flagBuilder/app/main.ts
@@ -20,7 +20,8 @@ import {
 import type { AppToHost, FlagDatabase, HostToApp, ModTarget, TextureKind, UiState } from "../messages";
 import { iconEl, type IconName } from "../../shared/icons";
 import { sidePanel } from "../../shared/sidePanel";
-import { confirmDialog, infoDialog, menu, toast, type MenuItem } from "../../shared/overlay";
+import { confirmDialog, menu, toast, type MenuItem } from "../../shared/overlay";
+import { helpDialog } from "../../shared/help";
 import { scrubbable } from "../../shared/scrub";
 import { colorPicker } from "../../shared/colorPicker";
 import { sortable } from "../../shared/sortable";
@@ -1395,32 +1396,103 @@ $("png").onclick = () => {
 };
 $("togglePanel").onclick = () => panel.toggle();
 $("help").onclick = () =>
-  infoDialog("How to build a flag", [
-    [
-      "Start",
-      "New gives you a solid flag with one color. Open shows every flag of the game and your mods as a preview; pick one to start from it. Paste reads a definition from the clipboard.",
+  helpDialog({
+    title: "Flag Builder",
+    intro:
+      "Builds a coat_of_arms definition — the game's own flag script — visually. What you see is rendered from the same textures the game uses, and Save writes real script into your mod.",
+    sections: [
+      {
+        title: "Starting a flag",
+        items: [
+          { lead: "New", text: "gives you a solid flag with one color to build on." },
+          {
+            lead: "Open",
+            text: "browses every flag of the game and your mods as previews; pick one to start from it. Saving it back under the same file name overrides the original.",
+          },
+          {
+            lead: "Paste",
+            text: "reads a coat_of_arms definition straight from the clipboard — handy for a snippet from a wiki or another mod.",
+          },
+        ],
+      },
+      {
+        title: "Pattern and flag colors",
+        items: [
+          {
+            lead: "The pattern",
+            text: "is the base texture. Its red, yellow and white areas are placeholders: they become color1, color2 and color3 of your flag.",
+          },
+          {
+            lead: "Change either",
+            text: "by selecting the Pattern row in the panel: the browser shows every pattern, and the color rows recolor the flag.",
+          },
+        ],
+      },
+      {
+        title: "Layers",
+        intro:
+          "A flag is the pattern plus layers drawn on top, in row order — later rows draw over earlier ones. Drag rows to reorder.",
+        items: [
+          {
+            lead: "Colored emblem:",
+            text: "a recolorable shape; its color1–3 can be a named game color, an rgb or hsv value, or “same as” one of the flag's colors.",
+          },
+          { lead: "Textured emblem:", text: "a texture drawn as-is, no recoloring." },
+          {
+            lead: "Sub flag:",
+            text: "another whole flag placed inside this one (how quartered arms are built).",
+          },
+          {
+            lead: "Mask",
+            text: "limits an emblem to the area one pattern color covers, so it follows the pattern's shape.",
+          },
+        ],
+      },
+      {
+        title: "Placing an emblem",
+        items: [
+          {
+            lead: "On the canvas:",
+            text: "click an emblem to select it, drag it to move it, and drag a corner to resize it (the aspect ratio stays).",
+          },
+          {
+            lead: "By numbers:",
+            text: "each layer has instances — position as a fraction of the flag (0.5 0.5 is the center), scale as a fraction of its size, rotation in degrees. Drag any number sideways to scrub it.",
+          },
+          {
+            lead: "Several instances",
+            text: "on one layer repeat the same emblem: one shape, stamped at several places.",
+          },
+          {
+            lead: "The camera:",
+            text: "the wheel zooms and the middle mouse button pans; the lock at the bottom left freezes the view, the button next to it recenters it.",
+          },
+        ],
+      },
+      {
+        title: "Saving",
+        items: [
+          {
+            lead: "Pick the mod",
+            text: "in the toolbar first: Save writes the script into that mod's coat_of_arms folder.",
+          },
+          {
+            lead: "Copy",
+            text: "puts the script on the clipboard instead, and Export PNG renders the preview to an image.",
+          },
+          { lead: "Undo and redo", text: "cover every step, including canvas drags." },
+        ],
+      },
+      {
+        title: "Keyboard",
+        shortcuts: [
+          { keys: ["Esc"], does: "Close the browser, else deselect the emblem" },
+          { keys: ["Ctrl", "Z"], does: "Undo" },
+          { keys: ["Ctrl", "Y"], does: "Redo (Ctrl+Shift+Z too)" },
+        ],
+      },
     ],
-    [
-      "Pattern and colors",
-      "The pattern is the base texture; its red, yellow and white areas become color1, color2 and color3 of the flag. Select the Pattern row to change it and the flag colors.",
-    ],
-    [
-      "Layers",
-      "Add a colored emblem (recolorable shape), a textured emblem (drawn as is) or a sub flag (another flag inside this one). Drag rows to change the draw order; later rows draw on top.",
-    ],
-    [
-      "Placing",
-      "Each layer has instances: position is a fraction of the flag (0.5 0.5 = center), scale a fraction of its size, rotation in degrees. Drag a number sideways to scrub it. On the canvas, click an emblem to select it, drag it to move it and drag a corner to resize it (the aspect ratio stays); Esc deselects. The wheel zooms and the middle mouse button pans until you freeze the view.",
-    ],
-    [
-      "Emblem colors",
-      "An emblem's color1..3 can be a named game color, an rgb or hsv value, or \"same as\" one of the flag's colors. Mask limits an emblem to one pattern color's area.",
-    ],
-    [
-      "Saving",
-      "Choose the mod in the toolbar, then Save writes the script into its coat_of_arms folder. Saving to the same file name as the opened flag overrides the game's flag. Copy puts the script on the clipboard; Export PNG renders the preview.",
-    ],
-  ]);
+  });
 $("addLayer").onclick = () =>
   menu(
     $("addLayer"),

--- a/packages/vscode/src/webviews/guiEditor/README.md
+++ b/packages/vscode/src/webviews/guiEditor/README.md
@@ -270,7 +270,7 @@ these ids: `canvas`, `stage`, `tree`, `layers`, `library`, `libraryOverlay`,
 `meta`, `fileName`, `zoomLabel`, `outlines`, `snap`, `grid`, `constraints`,
 `pulses`, `heatmap`, `heatmapMenu`, `libraryToggle`, `modeEdit`,
 `modeInteract`, `haloTabs`, `haloBody`, `refresh`, `undo`, `redo`, `save`,
-`changes` (with a `.count` child), `zoomOutBtn`, `zoomInBtn`, `zoomFitBtn`,
+`changes` (with a `.count` child), `zoomOutBtn`, `zoomInBtn`, `zoomFitBtn`, `helpBtn`,
 `dropTarget`, `textTip`, `clickTip`, `locResolved`, `locRaw`, `side`, `right`,
 `toggleSide`, `toggleRight`, and the four collapsible sections `sec-tree`,
 `sec-layers`, `sec-inspector`, `sec-devtools` (each a `.px-section` whose

--- a/packages/vscode/src/webviews/guiEditor/README.md
+++ b/packages/vscode/src/webviews/guiEditor/README.md
@@ -177,6 +177,12 @@ each has to actually do.
   WITH focus first, because VS Code's `undo` command acts on the active
   editor and a webview panel is not one, then runs the command; the changed
   text comes back down through the normal document-change `layout` push.
+- **`save` / `saved`** Write the source document to disk and answer whether it
+  reached it. Commits land in the in-memory document only, so this is how a
+  session's edits become a file. Each `layout` push carries `dirty`, which is
+  what enables the toolbar's Save button; the app also keeps a SESSION change
+  log (the Changes button) whose per-row undo is N requests for the document's
+  own undo, never a second history.
 - **`setUiState`** Store the inspector's value display mode, the side panels
   and the snap/grid toggles (each field optional: absent leaves the stored one
   alone) and answer NOTHING.
@@ -263,12 +269,15 @@ these ids: `canvas`, `stage`, `tree`, `layers`, `library`, `libraryOverlay`,
 `focusBar`, `inspector`, `status`, `statusBar`, `stats`, `visibilityBadge`,
 `meta`, `fileName`, `zoomLabel`, `outlines`, `snap`, `grid`, `constraints`,
 `pulses`, `heatmap`, `heatmapMenu`, `libraryToggle`, `modeEdit`,
-`modeInteract`, `haloTabs`, `haloBody`, `refresh`, `undo`, `redo`,
+`modeInteract`, `haloTabs`, `haloBody`, `refresh`, `undo`, `redo`, `save`,
+`changes` (with a `.count` child), `zoomOutBtn`, `zoomInBtn`, `zoomFitBtn`,
 `dropTarget`, `textTip`, `clickTip`, `locResolved`, `locRaw`, `side`, `right`,
 `toggleSide`, `toggleRight`, and the four collapsible sections `sec-tree`,
 `sec-layers`, `sec-inspector`, `sec-devtools` (each a `.px-section` whose
 `.px-section-head` button toggles `data-collapsed`; the devtools halo is "open"
-when its section is). `libraryOverlay` covers the stage and holds `library`;
+when its section is). `libraryOverlay` covers the whole editor area (`#main`,
+side panels included) and holds `library`; it must NOT live inside the stage,
+or its wheel events reach the canvas zoom handler;
 `clickTip` is the popover interact mode fills with what a click did.
 `modeEdit` / `modeInteract` are the tool mode toggle group. `locResolved` and `locRaw` are the two buttons of
 a px-toggle-group (the app sets their `aria-pressed`); `textTip` is a hidden

--- a/packages/vscode/src/webviews/guiEditor/app/library.ts
+++ b/packages/vscode/src/webviews/guiEditor/app/library.ts
@@ -119,6 +119,130 @@ export function libraryTip(entry: LibraryEntry): string {
   return `${entry.name}\n${entry.source}\n${what}`;
 }
 
+/**
+ * What each builtin widget type is FOR, in one sentence a new modder can act
+ * on: the same job the game's own GUI-overview window does by showing every
+ * element in use. Hand-written prose about the engine's own types (Jomini is
+ * shared across the games), never an invented name: a type not in this table
+ * simply shows no description.
+ */
+const WIDGET_DOCS: Record<string, string> = {
+  widget:
+    "The basic container: a rectangle with a size that holds children. Most windows are built from these.",
+  window: "A top-level container the game can open, close and drag. Use it for a whole screen or popup.",
+  container: "Groups children without a size of its own: it shrinks to fit whatever is inside.",
+  hbox: "Lays its children out in a row, left to right, sized to fit them.",
+  vbox: "Lays its children out in a column, top to bottom, sized to fit them.",
+  flowcontainer:
+    "Lays children one after another (set direction = vertical for a column); simpler than hbox/vbox, no resizing of children.",
+  fixedgridbox:
+    "A grid with fixed cell sizes: give it addcolumn/addrow sizes and it places children cell by cell.",
+  dynamicgridbox:
+    "A grid fed by a datamodel: one child template, repeated for every entry the game supplies.",
+  overlappingitembox: "Overlaps its datamodel items when space runs out (rows of trait icons, army stacks).",
+  scrollarea:
+    "A viewport with scrollbars: put one child inside that is larger than the area, and it scrolls.",
+  scrollbox:
+    "A scrollarea with the game's standard scrollbars already wired in. Prefer it over a bare scrollarea.",
+  textbox: "Shows text: set text = to a loc key or a [datafunction]. Use autoresize or give it a size.",
+  editbox: "A text field the player can type into; ontextchanged/ontextedited run script on input.",
+  button:
+    "A clickable area: give it a texture and an onclick. Use button_standard-style templates for the game's look.",
+  checkbutton: "A button with an on/off state (checked/unchecked frames); used for toggles and radio rows.",
+  icon: "Draws a texture at its size. The plain image element: frames, portraits and symbols are icons.",
+  background:
+    "A fill drawn behind the widget's own box, usually with `using` on a parent rather than standalone.",
+  progressbar: "A bar filled to `value` between min and max; set its texture for the game's bar looks.",
+  progresspie: "Like a progressbar, but fills radially as a pie.",
+  piechart: "Draws datamodel entries as pie slices; each entry supplies a value and a color.",
+  dropdown: "A collapsed list: a button that opens a list of options the player picks from.",
+  slider: "Drags a handle along a track to set a value between min and max.",
+  scrollbar: "The bar a scrollarea uses; rarely placed by hand outside scrollbar templates.",
+  portrait_button: "A button that renders a character portrait; used wherever a character can be clicked.",
+  tree: "Renders a node tree from a datamodel with connecting lines (dynasty trees, tech trees).",
+  minimap: "The map overview element; it renders the campaign map into its box.",
+  tooltipwidget:
+    "A widget shown as a tooltip: attach it with tooltipwidget = { ... } on the hovered element.",
+  margin_widget: "A widget that carves margins off its parent's box before placing children.",
+  overlappingbox: "Overlaps its plain children (not datamodel-fed) when they exceed the available width.",
+  text_occluder: "Hides the text under it; a technical helper for redacted or masked text.",
+  zoomarea: "A container whose contents the player can zoom and pan, like the lens pages.",
+};
+
+/** One-line kind explanations for the non-builtin cards. */
+export function libraryDoc(entry: LibraryEntry): string | undefined {
+  if (entry.kind === "saved")
+    return "A piece you saved from a document: inserting it pastes its stored text verbatim.";
+  if (entry.kind === "template") {
+    return entry.vocab?.local
+      ? "A template this file declares. Click to apply it to the selected widget with `using`."
+      : "A template from the store: a bundle of properties applied to a widget with `using`.";
+  }
+  if (entry.kind === "type") {
+    return entry.vocab?.local
+      ? `A type this file declares${entry.vocab.base ? `, based on ${entry.vocab.base}` : ""}: insert it to reuse the whole definition.`
+      : `A declared type${entry.vocab?.base ? ` based on ${entry.vocab.base}` : ""}.`;
+  }
+  return WIDGET_DOCS[entry.name.toLowerCase()];
+}
+
+/**
+ * The showcase group a widgets-section card belongs to, in display order: the
+ * grouping the game's GUI-overview window uses, so a designer looks where the
+ * element's JOB is rather than scanning an alphabet.
+ */
+export const WIDGET_GROUPS = [
+  "Containers & layout",
+  "Text",
+  "Buttons & input",
+  "Images & bars",
+  "Lists & data",
+  "Other widgets",
+] as const;
+export type WidgetGroup = (typeof WIDGET_GROUPS)[number];
+
+const GROUP_OF: Record<string, WidgetGroup> = {
+  widget: "Containers & layout",
+  window: "Containers & layout",
+  container: "Containers & layout",
+  hbox: "Containers & layout",
+  vbox: "Containers & layout",
+  flowcontainer: "Containers & layout",
+  margin_widget: "Containers & layout",
+  scrollarea: "Containers & layout",
+  scrollbox: "Containers & layout",
+  zoomarea: "Containers & layout",
+  textbox: "Text",
+  editbox: "Text",
+  text_occluder: "Text",
+  button: "Buttons & input",
+  checkbutton: "Buttons & input",
+  dropdown: "Buttons & input",
+  slider: "Buttons & input",
+  scrollbar: "Buttons & input",
+  portrait_button: "Buttons & input",
+  icon: "Images & bars",
+  background: "Images & bars",
+  progressbar: "Images & bars",
+  progresspie: "Images & bars",
+  piechart: "Images & bars",
+  fixedgridbox: "Lists & data",
+  dynamicgridbox: "Lists & data",
+  overlappingitembox: "Lists & data",
+  overlappingbox: "Lists & data",
+  tree: "Lists & data",
+  minimap: "Other widgets",
+  tooltipwidget: "Other widgets",
+};
+
+/** The group a card shows under. Non-builtin kinds have one group per kind. */
+export function libraryGroup(entry: LibraryEntry): string {
+  if (entry.kind === "saved") return "Saved components";
+  if (entry.kind === "template") return entry.vocab?.local ? "This file's templates" : "Templates";
+  if (entry.kind === "type") return "Declared types";
+  return GROUP_OF[entry.name.toLowerCase()] ?? "Other widgets";
+}
+
 /** Split a request into the batches the wire accepts. */
 export function chunk<T>(items: readonly T[], size: number): T[][] {
   const out: T[][] = [];

--- a/packages/vscode/src/webviews/guiEditor/app/main.ts
+++ b/packages/vscode/src/webviews/guiEditor/app/main.ts
@@ -82,6 +82,7 @@ import {
   toast as pxToast,
   type MenuItem,
 } from "../../shared/overlay";
+import { helpDialog } from "../../shared/help";
 import { scrubbable } from "../../shared/scrub";
 import { colorPicker, type Rgb } from "../../shared/colorPicker";
 import {
@@ -5423,6 +5424,8 @@ async function deleteSelectionConfirmed(): Promise<void> {
 // way to take back change i of n from a single linear history.
 const saveEl = document.getElementById("save") as HTMLButtonElement;
 const changesEl = document.getElementById("changes") as HTMLButtonElement;
+const undoBtn = document.getElementById("undo") as HTMLButtonElement;
+const redoBtn = document.getElementById("redo") as HTMLButtonElement;
 /** Labels of this panel's committed changes, oldest first, and the undone ones. */
 const sessionChanges: string[] = [];
 const undoneChanges: string[] = [];
@@ -5437,10 +5440,24 @@ function syncChanges(): void {
       ? "No changes yet this session"
       : `List the ${count} change${count === 1 ? "" : "s"} made here, newest last; each row can be undone`;
   if (count === 0 && isPopoverAnchor(changesEl)) closePopover();
+  // Undo and redo are SCOPED TO THIS PANEL'S SESSION: with nothing of ours to
+  // take back, the buttons are off, so the panel can never walk into the
+  // document's older history (edits made in the text editor before or beside
+  // this session stay that editor's to undo).
+  undoBtn.disabled = count === 0;
+  undoBtn.dataset.tip =
+    count === 0
+      ? "Nothing from this panel to undo. The text editor's own history stays its own"
+      : `Undo ${sessionChanges[count - 1]}`;
+  redoBtn.disabled = undoneChanges.length === 0;
+  redoBtn.dataset.tip =
+    undoneChanges.length === 0 ? "Nothing to redo" : `Redo ${undoneChanges[undoneChanges.length - 1]}`;
   saveEl.disabled = !docDirty;
-  saveEl.dataset.tip = docDirty
-    ? "Write the changes to the .gui file on disk (Ctrl+S)"
-    : "Nothing to save: the file on disk already matches";
+  saveEl.dataset.tip = !docDirty
+    ? "Nothing to save: the file on disk already matches"
+    : count > 0
+      ? "Write the changes to the .gui file on disk (Ctrl+S)"
+      : "Write the document to disk (Ctrl+S). Its unsaved changes were made outside this panel";
 }
 
 function recordChange(label: string): void {
@@ -5496,15 +5513,18 @@ saveEl.addEventListener("click", () => {
   host.send({ type: "save" });
 });
 
-document.getElementById("undo")!.addEventListener("click", () => {
-  // Best effort: the log cannot see edits typed in the text editor, so it
-  // tracks the toolbar's own undo and redo and stays a session log, not a truth.
-  if (sessionChanges.length > 0) undoneChanges.push(sessionChanges.pop()!);
+undoBtn.addEventListener("click", () => {
+  // Session-scoped: only a change this panel made is ever taken back, so the
+  // button never reaches the document's pre-session history. Best effort past
+  // that: the log cannot see keystrokes typed in the text editor in between.
+  if (sessionChanges.length === 0) return;
+  undoneChanges.push(sessionChanges.pop()!);
   syncChanges();
   host.send({ type: "undo" });
 });
-document.getElementById("redo")!.addEventListener("click", () => {
-  if (undoneChanges.length > 0) sessionChanges.push(undoneChanges.pop()!);
+redoBtn.addEventListener("click", () => {
+  if (undoneChanges.length === 0) return;
+  sessionChanges.push(undoneChanges.pop()!);
   syncChanges();
   host.send({ type: "redo" });
 });
@@ -5516,6 +5536,170 @@ document
   .getElementById("zoomInBtn")!
   .addEventListener("click", () => zoomToPoint(stage.clientWidth / 2, stage.clientHeight / 2, zoom * 1.25));
 document.getElementById("zoomFitBtn")!.addEventListener("click", fitView);
+
+document.getElementById("helpBtn")!.addEventListener("click", () =>
+  helpDialog({
+    title: "GUI Editor",
+    intro:
+      "Your .gui file laid out exactly as the game lays it out, and editable in place. The file stays the truth: every gesture becomes a real edit to the script, checked against the engine's own rules — an edit the engine would ignore or misread is refused, with the reason.",
+    sections: [
+      {
+        title: "Selecting",
+        items: [
+          {
+            lead: "Click",
+            text: "a widget to select and inspect it. Shift+click adds to the selection; dragging on empty canvas draws a marquee.",
+          },
+          {
+            lead: "Overlapping widgets:",
+            text: "Alt+click steps outward through everything under the pointer, one layer per click.",
+          },
+          {
+            lead: "From the keyboard:",
+            text: "Tab and Shift+Tab walk siblings, Enter descends into the first child, Shift+Enter climbs back out.",
+          },
+          {
+            lead: "Jump to the source",
+            text: "of the selected line with Ctrl+Shift+click; the tree and layers panels select the same widgets by row.",
+          },
+          { lead: "Esc", text: "clears the selection first, then leaves a focused subtree." },
+        ],
+      },
+      {
+        title: "Moving and resizing",
+        items: [
+          {
+            lead: "Drag",
+            text: "a widget to move it, or grab a corner or edge handle to resize; a multi-selection moves and resizes together as one change. If the engine would not honour the write, the gesture is refused before anything moves.",
+          },
+          {
+            lead: "Snapping:",
+            text: "the magnet snaps to sibling and parent edges, centres, equal gaps and equal sizes; the grid toggle adds an 8 px grid. Both live at the bottom left.",
+          },
+          {
+            lead: "Nudge",
+            text: "the selection with the arrow keys, one pixel at a time; hold Alt for one grid step.",
+          },
+          {
+            lead: "Duplicate in place",
+            text: "with Alt+drag: the copy is inserted next to the original and follows your pointer.",
+          },
+        ],
+      },
+      {
+        title: "Editing properties",
+        items: [
+          {
+            lead: "The inspector",
+            text: "lists the selected widget's properties. Type a value, drag a number sideways to scrub it, or use the anchor grid for parentanchor and widgetanchor.",
+          },
+          {
+            lead: "Add a property",
+            text: "with the row at the bottom: it completes from the properties the game's own files actually write on this widget type.",
+          },
+          {
+            lead: "Where a value comes from",
+            text: "is written under it when it is inherited from a template or type rather than set on this line.",
+          },
+        ],
+      },
+      {
+        title: "Saving and the change log",
+        intro:
+          "Edits land in the open document, not on disk: the editor and the text editor share one file and one undo history.",
+        items: [
+          {
+            lead: "Save",
+            text: "writes the document to disk; the button lights up whenever something is unsaved.",
+            keys: ["Ctrl", "S"],
+          },
+          {
+            lead: "The Changes button",
+            text: "lists every edit made from this panel this session, newest last. Each row's undo takes the document back to before that change (and the ones after it, since history is one line).",
+          },
+          {
+            lead: "Undo and redo",
+            text: "take back this panel's own changes, newest first. Underneath they run the document's real undo, but they never reach past what this session did: the file's older history stays the text editor's to undo.",
+          },
+        ],
+      },
+      {
+        title: "The element library",
+        items: [
+          {
+            lead: "Open it",
+            text: "with the Library button or L. Every element is shown as the game draws it, grouped by job, with a line on what it is for.",
+          },
+          {
+            lead: "Click a card",
+            text: "to insert it next to the selection (or into the first root); drag it onto the canvas to choose the container it drops into.",
+          },
+          {
+            lead: "Templates",
+            text: "are not widgets: clicking one applies it to the selected widget as `using = name`.",
+          },
+          {
+            lead: "A fresh widget has no size",
+            text: "and draws nothing until you give it one — the toast reminds you.",
+          },
+        ],
+      },
+      {
+        title: "Panels and devtools",
+        items: [
+          {
+            lead: "Tree:",
+            text: "the whole widget hierarchy. The focus button (or F) narrows the canvas to one subtree and back.",
+          },
+          {
+            lead: "Layers:",
+            text: "the selected container's children in draw order. Drag rows to reorder; the eye hides, the lock makes unclickable, solo dims everything else.",
+          },
+          {
+            lead: "Devtools:",
+            text: "why a widget is where it is (the placement trace), its textures frame by frame, conditional visibility, what script it reaches, the type and texture browsers, your saved components and presets, and a reference screenshot to calibrate against.",
+          },
+        ],
+      },
+      {
+        title: "The view",
+        items: [
+          {
+            lead: "Bottom left:",
+            text: "zoom buttons and percent, then the display toggles — outline every widget, snap, grid, the selected widget's constraints, and a flash on every widget a re-layout moved.",
+          },
+          {
+            lead: "Resolved / Raw",
+            text: "shows textboxes as the game would render them, or verbatim as the file writes them.",
+          },
+          {
+            lead: "Heatmap",
+            text: "tints the scene by one property of the tree (sizes, depths, …) to spot outliers.",
+          },
+        ],
+      },
+      {
+        title: "Keyboard",
+        shortcuts: [
+          { keys: ["L"], does: "Open and close the library" },
+          { keys: ["F"], does: "Focus the selected subtree, or leave the focus" },
+          { keys: ["Shift", "F"], does: "Fit the view to the selection" },
+          { keys: ["Ctrl", "0"], does: "Fit the reference viewport (Home too)" },
+          { keys: ["Ctrl", "+"], does: "Zoom in (Ctrl+− out; the wheel zooms, middle mouse pans)" },
+          { keys: ["Tab"], does: "Next sibling (Shift+Tab previous)" },
+          { keys: ["Enter"], does: "Into the first child (Shift+Enter to the parent)" },
+          { keys: ["←", "↑", "→", "↓"], does: "Nudge by 1 px (Alt: one grid step)" },
+          { keys: ["Ctrl", "C"], does: "Copy the selected blocks" },
+          { keys: ["Ctrl", "V"], does: "Paste into the selection" },
+          { keys: ["Ctrl", "D"], does: "Duplicate the selection" },
+          { keys: ["Del"], does: "Delete the selection (multi-deletes ask first)" },
+          { keys: ["Ctrl", "S"], does: "Save the document to disk" },
+          { keys: ["Esc"], does: "Cancel the drag, else clear selection, else leave the focus" },
+        ],
+      },
+    ],
+  })
+);
 
 // Fit means "fit what is on screen", and under a subtree focus that is the
 // subtree, not the 1920x1080 reference viewport around it. The wheel zooms;

--- a/packages/vscode/src/webviews/guiEditor/app/main.ts
+++ b/packages/vscode/src/webviews/guiEditor/app/main.ts
@@ -4614,13 +4614,7 @@ function renderUses(): void {
       const target = revealLink(chain.name, chain.file, chain.line);
       target.classList.add("name");
       entry.appendChild(target);
-      // A script value is denoted <SV> everywhere, and its tooltip leads with
-      // what that means, so the shorthand teaches itself.
-      const kindEl = el("span", "meta", chain.kind === "script_value" ? "<SV>" : chain.kind);
-      if (chain.kind === "script_value") {
-        kindEl.title = "Script Value: a number computed by script, defined under common/script_values.";
-      }
-      entry.appendChild(kindEl);
+      entry.appendChild(el("span", "meta", chain.kind));
       uses.appendChild(entry);
       if (chain.via.length > 0) uses.appendChild(el("div", "via sub", `via ${chain.via.join(" → ")}`));
     }

--- a/packages/vscode/src/webviews/guiEditor/app/main.ts
+++ b/packages/vscode/src/webviews/guiEditor/app/main.ts
@@ -76,6 +76,7 @@ import { sidePanel } from "../../shared/sidePanel";
 import {
   closePopover,
   confirmDialog,
+  isPopoverAnchor,
   menu,
   popover,
   toast as pxToast,
@@ -136,10 +137,13 @@ import {
   chunk,
   LIBRARY_PAGE,
   LIBRARY_SECTIONS,
+  libraryDoc,
   libraryEntries,
+  libraryGroup,
   libraryTiles,
   libraryTip,
   previewEntryFor,
+  WIDGET_GROUPS,
   type LibraryEntry,
   type LibrarySection,
 } from "./library";
@@ -968,9 +972,22 @@ interface Tile {
 }
 const tileEls = new Map<string, Tile>();
 let tileObserver: IntersectionObserver | null = null;
-/** The tile bitmap, in CSS pixels; the canvas is scaled by the device ratio. */
-const TILE_W = 112;
-const TILE_H = 72;
+/** The card bitmap, in CSS pixels; the canvas is scaled by the device ratio. */
+const TILE_W = 220;
+const TILE_H = 110;
+
+/** The showcase's group order: this file's own pieces first, then the widget groups, then the stores. */
+const LIBRARY_GROUP_ORDER = [
+  "This file's templates",
+  "Declared types",
+  ...WIDGET_GROUPS,
+  "Templates",
+  "Saved components",
+];
+function libraryGroupRank(group: string): number {
+  const at = LIBRARY_GROUP_ORDER.indexOf(group);
+  return at < 0 ? LIBRARY_GROUP_ORDER.length : at;
+}
 
 /**
  * Previews the host has answered for THIS document version, by tile key. A
@@ -1034,7 +1051,7 @@ function renderLibrary(): void {
     el(
       "span",
       "px-muted px-sm",
-      "Click a tile to add it to the selected container, or drag it onto the canvas"
+      "Every element previewed as the game draws it. Click a card to add it to the selected container, or drag it onto the canvas"
     )
   );
   titleRow.appendChild(el("span", "px-grow"));
@@ -1080,7 +1097,17 @@ function renderLibrary(): void {
     libraryEl.appendChild(el("div", "note", "No widget vocabulary for this game yet."));
     return;
   }
-  const tiles = libraryTiles(libraryEntries(vocabulary, components), librarySection, libraryQuery);
+  let tiles = libraryTiles(libraryEntries(vocabulary, components), librarySection, libraryQuery);
+  // The showcase groups elements by their job, like the game's own GUI
+  // overview window. A search keeps the match order instead: headers over two
+  // hits fragment more than they explain.
+  const grouped = libraryQuery.trim() === "";
+  if (grouped) {
+    tiles = tiles
+      .map((entry, i) => ({ entry, i, rank: libraryGroupRank(libraryGroup(entry)) }))
+      .sort((a, b) => a.rank - b.rank || a.i - b.i)
+      .map((t) => t.entry);
+  }
   if (tiles.length === 0) {
     libraryEl.appendChild(
       el(
@@ -1112,9 +1139,17 @@ function renderLibrary(): void {
   });
   tileObserver = observer;
   let shown = 0;
+  let lastGroup: string | null = null;
   const appendPage = (): void => {
     const end = Math.min(tiles.length, shown + LIBRARY_PAGE);
     for (; shown < end; shown++) {
+      if (grouped) {
+        const group = libraryGroup(tiles[shown]);
+        if (group !== lastGroup) {
+          lastGroup = group;
+          grid.appendChild(el("div", "groupHead", group));
+        }
+      }
       const tile = libraryTile(tiles[shown]);
       grid.appendChild(tile.node);
       observer.observe(tile.node);
@@ -1138,7 +1173,10 @@ function libraryTile(entry: LibraryEntry): Tile {
   const ratio = Math.min(window.devicePixelRatio || 1, 2);
   canvas.width = TILE_W * ratio;
   canvas.height = TILE_H * ratio;
-  node.append(canvas, el("div", "name", entry.name), el("div", "src", entry.source));
+  node.append(canvas, el("div", "name", entry.name));
+  const doc = libraryDoc(entry);
+  if (doc) node.appendChild(el("div", "desc", doc));
+  node.appendChild(el("div", "src", entry.source));
   node.addEventListener("pointerdown", (ev) => {
     if (ev.button !== 0 || committing) return;
     const ghost = el("div", "px-drag-ghost paletteGhost", entry.name);
@@ -2400,8 +2438,52 @@ function sendOps(
 
 function awaitVerdict(build: (id: number) => AppToHost, onVerdict: (verdict: EditVerdict) => void): void {
   const id = nextEditId++;
-  pendingEdits.set(id, onVerdict);
-  host.send(build(id));
+  const message = build(id);
+  // Every message that commits a document change funnels through here, so this
+  // is where the session change log records it (once the verdict says it went in).
+  const label = commitLabelOf(message);
+  pendingEdits.set(id, (verdict) => {
+    if (label !== null && !verdict.refused) recordChange(label);
+    onVerdict(verdict);
+  });
+  host.send(message);
+}
+
+/** The change-log label of a message that WRITES the document; null for checks and reads. */
+function commitLabelOf(message: AppToHost): string | null {
+  switch (message.type) {
+    case "applyEdit":
+      return message.properties.length === 1
+        ? `set ${message.properties[0].key}`
+        : `set ${message.properties.length} properties`;
+    case "reorder":
+      return "reorder children";
+    case "applyOps":
+      return describeOps(message.ops);
+    case "pasteInto":
+      return "paste from clipboard";
+    case "insertComponent":
+      return `insert ${message.name}`;
+    default:
+      return null;
+  }
+}
+
+function describeOps(ops: GuiSourceOp[]): string {
+  const verbs: Record<string, string> = {
+    setProperties: "edit",
+    insert: "insert",
+    insertRaw: "insert",
+    reorder: "reorder",
+    delete: "delete",
+    blockText: "read",
+  };
+  const counts = new Map<string, number>();
+  for (const op of ops) {
+    const verb = verbs[op.kind] ?? op.kind;
+    counts.set(verb, (counts.get(verb) ?? 0) + 1);
+  }
+  return [...counts].map(([verb, n]) => (n > 1 ? `${verb} ${n} widgets` : `${verb} a widget`)).join(", ");
 }
 
 // ---- selection -------------------------------------------------------------
@@ -2738,6 +2820,8 @@ const host = connectHost((message) => {
       // same law the server laid the widgets out with.
       setLineHeightRatio(message.lineHeightRatio);
       showSaveSource(message.save);
+      docDirty = message.dirty ?? false;
+      syncChanges();
       onLayout(
         message.result,
         message.textures,
@@ -2756,6 +2840,15 @@ const host = connectHost((message) => {
       return;
     case "reference":
       if (message.url) loadReference(message.name, message.url);
+      return;
+    case "saved":
+      if (message.ok) {
+        docDirty = false;
+        syncChanges();
+        toast(`Saved ${file}`, "info");
+      } else {
+        toast("The editor could not save the file.", "refused");
+      }
       return;
     case "widgetInfo": {
       const item = selectedItem();
@@ -4521,7 +4614,13 @@ function renderUses(): void {
       const target = revealLink(chain.name, chain.file, chain.line);
       target.classList.add("name");
       entry.appendChild(target);
-      entry.appendChild(el("span", "meta", chain.kind));
+      // A script value is denoted <SV> everywhere, and its tooltip leads with
+      // what that means, so the shorthand teaches itself.
+      const kindEl = el("span", "meta", chain.kind === "script_value" ? "<SV>" : chain.kind);
+      if (chain.kind === "script_value") {
+        kindEl.title = "Script Value: a number computed by script, defined under common/script_values.";
+      }
+      entry.appendChild(kindEl);
       uses.appendChild(entry);
       if (chain.via.length > 0) uses.appendChild(el("div", "via sub", `via ${chain.via.join(" → ")}`));
     }
@@ -5162,6 +5261,11 @@ window.addEventListener("keydown", (ev) => {
       else pasteIntoSelection();
       return;
     }
+    if (key === "s") {
+      ev.preventDefault();
+      saveEl.click();
+      return;
+    }
   }
   if ((ev.key === "Delete" || ev.key === "Backspace") && !chord) {
     ev.preventDefault();
@@ -5317,8 +5421,107 @@ async function deleteSelectionConfirmed(): Promise<void> {
 
 // ---- toolbar ---------------------------------------------------------------
 
-document.getElementById("undo")!.addEventListener("click", () => host.send({ type: "undo" }));
-document.getElementById("redo")!.addEventListener("click", () => host.send({ type: "redo" }));
+// The session change log and the Save button. Edits land in the in-memory
+// document only (rule one: the host owns the text, undo is the document's),
+// so Save is how a session reaches disk. The log lists what this panel
+// committed, and each row undoes back to before that change by running the
+// document's own undo the right number of times, which is the only honest
+// way to take back change i of n from a single linear history.
+const saveEl = document.getElementById("save") as HTMLButtonElement;
+const changesEl = document.getElementById("changes") as HTMLButtonElement;
+/** Labels of this panel's committed changes, oldest first, and the undone ones. */
+const sessionChanges: string[] = [];
+const undoneChanges: string[] = [];
+let docDirty = false;
+
+function syncChanges(): void {
+  const count = sessionChanges.length;
+  changesEl.disabled = count === 0;
+  changesEl.querySelector(".count")!.textContent = String(count);
+  changesEl.dataset.tip =
+    count === 0
+      ? "No changes yet this session"
+      : `List the ${count} change${count === 1 ? "" : "s"} made here, newest last; each row can be undone`;
+  if (count === 0 && isPopoverAnchor(changesEl)) closePopover();
+  saveEl.disabled = !docDirty;
+  saveEl.dataset.tip = docDirty
+    ? "Write the changes to the .gui file on disk (Ctrl+S)"
+    : "Nothing to save: the file on disk already matches";
+}
+
+function recordChange(label: string): void {
+  sessionChanges.push(label);
+  undoneChanges.length = 0;
+  docDirty = true;
+  syncChanges();
+}
+
+/** Undo the last `count` changes through the document's own history. */
+function undoBack(count: number): void {
+  for (let i = 0; i < count && sessionChanges.length > 0; i++) {
+    undoneChanges.push(sessionChanges.pop()!);
+    host.send({ type: "undo" });
+  }
+  syncChanges();
+}
+
+changesEl.addEventListener("click", () => {
+  if (isPopoverAnchor(changesEl)) {
+    closePopover();
+    return;
+  }
+  const list = el("div", "px-list");
+  list.id = "changeList";
+  sessionChanges.forEach((label, index) => {
+    const row = el("div", "px-item");
+    row.title = label;
+    const after = sessionChanges.length - 1 - index;
+    row.appendChild(el("span", "what", label));
+    row.appendChild(
+      button(
+        "",
+        () => {
+          closePopover();
+          undoBack(sessionChanges.length - index);
+        },
+        {
+          icon: "undo",
+          variant: "ghost",
+          size: "icon-xs",
+          tip: after === 0 ? "Undo this change" : `Undo this change and the ${after} after it`,
+        }
+      )
+    );
+    list.appendChild(row);
+  });
+  popover(changesEl, list);
+});
+
+saveEl.addEventListener("click", () => {
+  if (saveEl.disabled) return;
+  host.send({ type: "save" });
+});
+
+document.getElementById("undo")!.addEventListener("click", () => {
+  // Best effort: the log cannot see edits typed in the text editor, so it
+  // tracks the toolbar's own undo and redo and stays a session log, not a truth.
+  if (sessionChanges.length > 0) undoneChanges.push(sessionChanges.pop()!);
+  syncChanges();
+  host.send({ type: "undo" });
+});
+document.getElementById("redo")!.addEventListener("click", () => {
+  if (undoneChanges.length > 0) sessionChanges.push(undoneChanges.pop()!);
+  syncChanges();
+  host.send({ type: "redo" });
+});
+
+document
+  .getElementById("zoomOutBtn")!
+  .addEventListener("click", () => zoomToPoint(stage.clientWidth / 2, stage.clientHeight / 2, zoom / 1.25));
+document
+  .getElementById("zoomInBtn")!
+  .addEventListener("click", () => zoomToPoint(stage.clientWidth / 2, stage.clientHeight / 2, zoom * 1.25));
+document.getElementById("zoomFitBtn")!.addEventListener("click", fitView);
 
 // Fit means "fit what is on screen", and under a subtree focus that is the
 // subtree, not the 1920x1080 reference viewport around it. The wheel zooms;
@@ -5447,7 +5650,13 @@ let lastNodes: GuiLayoutNode[] = [];
 /** A click asked for a layout; the next push reports how many widgets it showed or hid. */
 let clickPending = false;
 
+// Interact mode is a deferred feature: hidden in the toolbar and inert here
+// until it is fleshed out (docs/deferred-features.md). A widened boolean, not
+// a literal `false`, so the mode comparisons below keep typechecking.
+const interactEnabled: boolean = false;
+
 function setMode(next: ToolMode): void {
+  if (next === "interact" && !interactEnabled) return;
   if (mode === next) return;
   mode = next;
   modeEditEl.setAttribute("aria-pressed", next === "edit" ? "true" : "false");

--- a/packages/vscode/src/webviews/guiEditor/html.ts
+++ b/packages/vscode/src/webviews/guiEditor/html.ts
@@ -35,9 +35,10 @@ export function guiEditorHtml(options: GuiEditorHtmlOptions): string {
     ? `@font-face { font-family: "PxGuiGameFont"; src: url("${fontDataUri}") format("opentype"); }`
     : "";
 
-  /** A checkbox dressed as a px-toggle: the app reads `.checked`, the page shows the pressed state. */
+  /** A checkbox dressed as a px-toggle: the app reads `.checked`, the page shows the pressed state.
+   *  They live in the stage's bottom-left strip, so their tooltips open upward. */
   const viewToggle = (id: string, name: IconName, tip: string, checked = false): string =>
-    `<label class="px-toggle" data-size="sm" data-tip="${tip}" data-tip-wrap><input id="${id}" type="checkbox"${checked ? " checked" : ""} />${icon(name)}</label>`;
+    `<label class="px-toggle" data-size="sm" data-tip="${tip}" data-tip-side="top" data-tip-wrap><input id="${id}" type="checkbox"${checked ? " checked" : ""} />${icon(name)}</label>`;
 
   /** A collapsible panel section: the header toggles `data-collapsed` on the section (main.ts wires it). */
   const section = (id: string, title: string, inner: string, collapsed = false): string =>
@@ -61,6 +62,21 @@ ${uiCss}
     padding: 6px 8px; border-bottom: 1px solid var(--px-border);
   }
   #toolbar .px-separator { height: 20px; align-self: center; }
+  /* Deferred features, hidden until they are fleshed out: the interact mode
+     and the save-game preview source. See docs/deferred-features.md. The
+     elements stay in the DOM because app/ queries their ids. */
+  #modeGroup[hidden], #saveSource[hidden] { display: none; }
+  /* The session-changes count rides the Changes button, like the event graph's. */
+  #changes .count {
+    min-width: 16px; height: 16px; padding: 0 4px; border-radius: 8px; flex: 0 0 auto;
+    display: inline-flex; align-items: center; justify-content: center;
+    font-size: 10px; line-height: 1; font-variant-numeric: tabular-nums;
+    background: var(--px-primary); color: var(--px-primary-fg);
+  }
+  #changes[disabled] .count { display: none; }
+  #changeList { display: flex; flex-direction: column; gap: 2px; width: 340px; max-height: 320px; overflow: auto; }
+  #changeList .px-item-kind { width: 62px; }
+  #changeList .what { flex: 1 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
   #fileName { font-weight: 600; max-width: 260px; }
   #fileName:empty::before { content: "GUI Editor"; color: var(--px-muted-fg); font-weight: 500; }
   /* A checkbox inside a toggle: hidden, its state shown on the label (the px-switch pattern). */
@@ -81,7 +97,9 @@ ${uiCss}
   #textTip .seg .arrow, #textTip .seg .note { color: var(--px-muted-fg); }
 
   /* ---- stage ---- */
-  #main { flex: 1 1 auto; display: flex; min-height: 0; }
+  /* Relative: the library overlay is positioned against it, so it can cover
+     the side panels as well as the stage. */
+  #main { flex: 1 1 auto; display: flex; min-height: 0; position: relative; }
   /* The canvas paints this same color under the world (render.ts CANVAS_BG), so a resize shows no flash. */
   #stage { flex: 1 1 auto; overflow: hidden; background: #101010; position: relative; min-width: 0; }
   #canvas { display: block; }
@@ -90,7 +108,8 @@ ${uiCss}
     padding: 2px; border-radius: var(--px-radius);
     background: color-mix(in oklch, var(--px-bg) 75%, transparent);
   }
-  #stageTools { left: 8px; }
+  #stageTools { left: 8px; gap: 4px; }
+  #stageTools .px-separator { height: 18px; }
   #stageInfo { right: 8px; }
   #zoomLabel { min-width: 44px; height: var(--px-h-sm); line-height: var(--px-h-sm); padding: 0 6px; text-align: center; font-variant-numeric: tabular-nums; cursor: default; }
   /* What a click did in interact mode (main.ts fills it). */
@@ -120,8 +139,11 @@ ${uiCss}
   #sec-tree[data-collapsed] ~ #sec-layers:not([data-collapsed]) { flex: 1 1 0; }
   #sec-devtools:not([data-collapsed]) { flex: 0 0 55%; }
   #sec-inspector[data-collapsed] ~ #sec-devtools:not([data-collapsed]) { flex: 1 1 0; }
-  /* ---- the library, over the stage ---- */
-  #libraryOverlay { position: absolute; inset: 0; z-index: 40; display: flex; flex-direction: column; background: color-mix(in oklch, var(--px-bg) 96%, transparent); }
+  /* ---- the library, over the whole editor ---- */
+  /* It covers #main (stage AND side panels), so the showcase always has the
+     full window's width; being outside #stage also keeps its wheel events off
+     the canvas zoom handler, which used to eat the library's own scrolling. */
+  #libraryOverlay { position: absolute; inset: 0; z-index: 40; display: flex; flex-direction: column; background: color-mix(in oklch, var(--px-bg) 97%, transparent); }
   #libraryOverlay[hidden] { display: none; }
   #libraryOverlay > #library { flex: 1 1 auto; min-height: 0; border-top: 0; }
   #info[data-warning] { color: var(--px-destructive); }
@@ -179,24 +201,36 @@ ${uiCss}
   #layers .row .layerTools .toggle:not([aria-pressed="true"]) { color: var(--px-muted-fg); }
   #layers .row[data-dragging] { opacity: 0.35; }
   #layers .row.hiddenWidget .label { text-decoration: line-through; opacity: 0.6; }
-  /* ---- the library's tiles ---- */
-  #library .tileGrid { display: grid; grid-template-columns: repeat(auto-fill, minmax(140px, 1fr)); gap: 6px; padding: 8px 12px; }
-  #library .tile {
-    display: flex; flex-direction: column; align-items: center; gap: 3px; padding: 6px 4px; min-width: 0;
-    border-radius: var(--px-radius-md); cursor: grab; transition: background-color var(--px-ease);
+  /* ---- the library's showcase cards ---- */
+  /* Modeled on the game's own GUI overview window: each element rendered at a
+     readable size, named, and explained, so a new modder learns what it IS
+     from the card rather than from trying it. */
+  #library .tileGrid { display: grid; grid-template-columns: repeat(auto-fill, minmax(250px, 1fr)); gap: 10px; padding: 10px 16px 18px; }
+  #library .groupHead {
+    grid-column: 1 / -1; padding: 14px 2px 0; color: var(--px-muted-fg);
+    font-size: var(--px-text-xs); font-weight: 600; letter-spacing: 0.04em; text-transform: uppercase;
   }
-  #library .tile:hover { background: var(--px-muted); }
+  #library .groupHead:first-child { padding-top: 2px; }
+  #library .tile {
+    display: flex; flex-direction: column; gap: 6px; padding: 10px; min-width: 0;
+    border: 1px solid var(--px-border); background: var(--px-bg);
+    border-radius: var(--px-radius-md); cursor: grab;
+    transition: background-color var(--px-ease), border-color var(--px-ease);
+  }
+  #library .tile:hover { background: var(--px-muted); border-color: color-mix(in oklch, var(--px-fg) 25%, var(--px-border)); }
   #library .tile[data-dragging] { opacity: 0.5; }
   #library .tile canvas {
-    width: 112px; height: 72px; max-width: 100%; border-radius: var(--px-radius-sm);
+    width: 220px; height: 110px; max-width: 100%; align-self: center; border-radius: var(--px-radius-sm);
     background: color-mix(in oklch, var(--px-bg), var(--px-fg) 8%); box-shadow: inset 0 0 0 1px var(--px-border);
   }
   #library .tile[data-empty] canvas { background: transparent; box-shadow: none; border: 1px dashed var(--px-border); box-sizing: border-box; }
-  #library .tile .name, #library .tile .src { width: 100%; text-align: center; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-  #library .tile .name { font-size: var(--px-text-sm); }
+  #library .tile .name, #library .tile .src { width: 100%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  #library .tile .name { font-size: var(--px-text-sm); font-weight: 600; }
+  #library .tile .desc { font-size: var(--px-text-xs); color: var(--px-muted-fg); white-space: normal; line-height: 1.45; }
   #library .tile .src { font-size: var(--px-text-xs); color: var(--px-muted-fg); }
   #library .tileMore { height: 1px; }
   #library .note.count { text-align: center; font-size: var(--px-text-xs); }
+  #library .head { padding: 10px 16px 4px; }
   /* The chip that follows a library drag, and the container it would drop into. */
   .paletteGhost { padding: 0 10px; height: var(--px-h-sm); line-height: var(--px-h-sm); border-radius: var(--px-radius-md); font-size: var(--px-text-sm); white-space: nowrap; }
   #dropTarget { position: absolute; pointer-events: none; box-sizing: border-box; border: 2px solid var(--px-primary); border-radius: 2px; }
@@ -318,25 +352,20 @@ ${uiCss}
     <span id="fileName" class="px-truncate"></span>
     <button id="refresh" class="px-btn" data-variant="ghost" data-size="icon-sm" data-tip="Lay the document out again">${icon("rotate")}</button>
     <div class="px-separator" data-orientation="vertical"></div>
-    <button id="undo" class="px-btn" data-variant="ghost" data-size="icon-sm" data-tip="Undo the last change to the .gui file (the text editor's own undo)">${icon("undo")}</button>
+    <button id="undo" class="px-btn" data-variant="ghost" data-size="icon-sm" data-tip="Undo the last change (Ctrl+Z; the document's own undo)">${icon("undo")}</button>
     <button id="redo" class="px-btn" data-variant="ghost" data-size="icon-sm" data-tip="Redo the change you just undid">${icon("redo")}</button>
+    <button id="changes" class="px-btn" data-variant="ghost" data-size="sm" data-tip="No changes yet this session" data-tip-wrap disabled>${icon("list")}<span class="count">0</span></button>
+    <button id="save" class="px-btn" data-variant="default" data-size="sm" data-tip="Nothing to save: the file on disk already matches" data-tip-wrap disabled>${icon("save")}Save</button>
     <div class="px-separator" data-orientation="vertical"></div>
-    <div class="px-toggle-group" id="modeGroup">
+    <div class="px-toggle-group" id="modeGroup" hidden>
       <button id="modeEdit" class="px-toggle" data-size="sm" aria-pressed="true" data-tip="Edit: select, drag, resize and write to the file (V)" data-tip-wrap>${icon("mousePointer")}Edit</button>
       <button id="modeInteract" class="px-toggle" data-size="sm" aria-pressed="false" data-tip="Interact: click buttons and scroll lists as in game. Variable-driven tabs and windows react; nothing is written (I)" data-tip-wrap>${icon("hand")}Interact</button>
     </div>
     <span class="px-grow"></span>
     <div class="px-toggle-group">
-      ${viewToggle("outlines", "squareDashed", "Outline every widget")}
-      ${viewToggle("snap", "magnet", "Snap a drag to sibling and parent edges, centres, equal gaps and equal sizes", true)}
-      ${viewToggle("grid", "grid", "Draw an 8 px grid and snap a drag to it (Alt+arrow nudges by one step)")}
-      ${viewToggle("constraints", "ruler", "Show the selected widget's parent box, its anchors and the offset between them")}
-      ${viewToggle("pulses", "activity", "Flash the widgets each re-layout moved")}
-    </div>
-    <div class="px-toggle-group">
       <button id="locResolved" class="px-toggle" data-size="sm" aria-pressed="true" data-tip="Show textboxes as the game would: localization keys as their text, [datafunctions] as what the preview can know" data-tip-wrap>Resolved</button>
       <button id="locRaw" class="px-toggle" data-size="sm" aria-pressed="false" data-tip="Show textboxes as the file has them: the text = value verbatim" data-tip-wrap>Raw</button>
-      <button id="saveSource" class="px-btn px-dropdown" data-variant="outline" data-size="sm" style="width:auto;max-width:260px" data-tip="Real values for [datafunctions] from a save game (plain text, not ironman)" data-tip-wrap>${icon("fileText")}<span class="px-truncate">No save</span>${icon("chevronDown")}</button>
+      <button id="saveSource" class="px-btn px-dropdown" data-variant="outline" data-size="sm" style="width:auto;max-width:260px" data-tip="Real values for [datafunctions] from a save game (plain text, not ironman)" data-tip-wrap hidden>${icon("fileText")}<span class="px-truncate">No save</span>${icon("chevronDown")}</button>
     </div>
     <select id="heatmap"></select>
     <button id="heatmapMenu" class="px-btn px-dropdown" data-variant="outline" data-size="sm" data-tip="Tint the scene by one property of the widget tree" data-tip-wrap>${icon("flame")}<span class="px-truncate"></span>${icon("chevronDown")}</button>
@@ -359,13 +388,21 @@ ${uiCss}
       <div id="textTip" class="px-popover" hidden></div>
       <div id="clickTip" class="px-popover" hidden></div>
       <div id="stageTools">
+        <button id="zoomOutBtn" class="px-btn" data-variant="ghost" data-size="icon-sm" data-tip="Zoom out (Ctrl+−)" data-tip-side="top">${icon("zoomOut")}</button>
+        <button id="zoomInBtn" class="px-btn" data-variant="ghost" data-size="icon-sm" data-tip="Zoom in (Ctrl++)" data-tip-side="top">${icon("zoomIn")}</button>
+        <button id="zoomFitBtn" class="px-btn" data-variant="ghost" data-size="icon-sm" data-tip="Fit the view (Ctrl+0)" data-tip-side="top">${icon("maximize")}</button>
         <span id="zoomLabel" class="px-muted px-xs" data-tip="Wheel zooms, middle mouse pans. Ctrl+0 fits the 1920x1080 viewport, Shift+F the selection" data-tip-side="top" data-tip-wrap>100%</span>
+        <div class="px-separator" data-orientation="vertical"></div>
+        <div class="px-toggle-group">
+          ${viewToggle("outlines", "squareDashed", "Outline every widget")}
+          ${viewToggle("snap", "magnet", "Snap a drag to sibling and parent edges, centres, equal gaps and equal sizes", true)}
+          ${viewToggle("grid", "grid", "Draw an 8 px grid and snap a drag to it (Alt+arrow nudges by one step)")}
+          ${viewToggle("constraints", "ruler", "Show the selected widget's parent box, its anchors and the offset between them")}
+          ${viewToggle("pulses", "activity", "Flash the widgets each re-layout moved")}
+        </div>
       </div>
       <div id="stageInfo">
         <button id="info" class="px-btn" data-variant="ghost" data-size="icon-sm" data-tip="" data-tip-side="top" data-tip-align="right" data-tip-wrap>${icon("info")}</button>
-      </div>
-      <div id="libraryOverlay" hidden>
-        <div id="library" hidden></div>
       </div>
     </div>
     <div id="right" class="px-sidepanel" data-side="right">
@@ -374,6 +411,9 @@ ${uiCss}
         ${section("inspector", "Inspector", `<div id="inspector"></div>`)}
         ${section("devtools", "Devtools", `<div id="halo"><div id="haloTabs" class="px-tabs" data-variant="line"></div><div id="haloBody"></div></div>`, true)}
       </div>
+    </div>
+    <div id="libraryOverlay" hidden>
+      <div id="library" hidden></div>
     </div>
   </div>
   <div id="statusBar">

--- a/packages/vscode/src/webviews/guiEditor/html.ts
+++ b/packages/vscode/src/webviews/guiEditor/html.ts
@@ -143,7 +143,7 @@ ${uiCss}
   /* It covers #main (stage AND side panels), so the showcase always has the
      full window's width; being outside #stage also keeps its wheel events off
      the canvas zoom handler, which used to eat the library's own scrolling. */
-  #libraryOverlay { position: absolute; inset: 0; z-index: 40; display: flex; flex-direction: column; background: color-mix(in oklch, var(--px-bg) 97%, transparent); }
+  #libraryOverlay { position: absolute; inset: 0; z-index: 40; display: flex; flex-direction: column; background: var(--px-bg); }
   #libraryOverlay[hidden] { display: none; }
   #libraryOverlay > #library { flex: 1 1 auto; min-height: 0; border-top: 0; }
   #info[data-warning] { color: var(--px-destructive); }

--- a/packages/vscode/src/webviews/guiEditor/html.ts
+++ b/packages/vscode/src/webviews/guiEditor/html.ts
@@ -352,8 +352,8 @@ ${uiCss}
     <span id="fileName" class="px-truncate"></span>
     <button id="refresh" class="px-btn" data-variant="ghost" data-size="icon-sm" data-tip="Lay the document out again">${icon("rotate")}</button>
     <div class="px-separator" data-orientation="vertical"></div>
-    <button id="undo" class="px-btn" data-variant="ghost" data-size="icon-sm" data-tip="Undo the last change (Ctrl+Z; the document's own undo)">${icon("undo")}</button>
-    <button id="redo" class="px-btn" data-variant="ghost" data-size="icon-sm" data-tip="Redo the change you just undid">${icon("redo")}</button>
+    <button id="undo" class="px-btn" data-variant="ghost" data-size="icon-sm" data-tip="Nothing from this panel to undo. The text editor's own history stays its own" data-tip-wrap disabled>${icon("undo")}</button>
+    <button id="redo" class="px-btn" data-variant="ghost" data-size="icon-sm" data-tip="Nothing to redo" disabled>${icon("redo")}</button>
     <button id="changes" class="px-btn" data-variant="ghost" data-size="sm" data-tip="No changes yet this session" data-tip-wrap disabled>${icon("list")}<span class="count">0</span></button>
     <button id="save" class="px-btn" data-variant="default" data-size="sm" data-tip="Nothing to save: the file on disk already matches" data-tip-wrap disabled>${icon("save")}Save</button>
     <div class="px-separator" data-orientation="vertical"></div>
@@ -372,6 +372,7 @@ ${uiCss}
     <div class="px-separator" data-orientation="vertical"></div>
     <button id="libraryToggle" class="px-toggle" data-size="sm" aria-pressed="false" data-tip="The element library: the widgets, templates and saved pieces you can add to the canvas, with previews (L)" data-tip-wrap>${icon("shapes")}Library</button>
     <div class="px-separator" data-orientation="vertical"></div>
+    <button id="helpBtn" class="px-btn" data-variant="ghost" data-size="icon-sm" data-tip="How this editor works: selecting, editing, saving, the library, shortcuts" data-tip-side="left" data-tip-wrap>${icon("circleHelp")}</button>
     <button id="toggleRight" class="px-btn" data-variant="ghost" data-size="icon-sm" data-tip="Hide the inspector" data-tip-side="left">${icon("panelRightClose")}</button>
   </div>
   <div id="main">

--- a/packages/vscode/src/webviews/guiEditor/messages.ts
+++ b/packages/vscode/src/webviews/guiEditor/messages.ts
@@ -373,6 +373,14 @@ export type AppToHost =
   | { type: "undo" }
   | { type: "redo" }
   /**
+   * Write the source document to disk. Every edit the editor commits lands in
+   * the in-memory document only (that is what makes undo the document's own),
+   * so the toolbar's Save is how a session's work reaches the file. The host
+   * answers `saved`; the `dirty` flag on each `layout` push is what enables
+   * the button.
+   */
+  | { type: "save" }
+  /**
    * Read one loc key through the host's index (a widget's `tooltip`, which
    * the layout never resolves). The host answers `loc` with the value, null
    * when no definition exists.
@@ -437,6 +445,11 @@ export type HostToApp =
       previewValues?: Record<string, string>;
       /** The save the preview values partly come from, when one is chosen. */
       save?: { name: string; date: string; file: string } | null;
+      /**
+       * The source document holds unsaved changes. Drives the toolbar's Save
+       * button; absent is read as false (older hosts).
+       */
+      dirty?: boolean;
     }
   /**
    * Answer to `requestWidgetInfo`. `line` is echoed so the app can drop an
@@ -516,6 +529,8 @@ export type HostToApp =
   | { type: "userData"; components: SavedComponent[]; presets: SavedPreset[] }
   | { type: "loc"; key: string; value: string | null }
   | { type: "reference"; name: string; url: string | null }
+  /** The answer to `save`: the document reached disk, or why it did not. */
+  | { type: "saved"; ok: boolean }
   /** Layout failed; the message is shown as-is. */
   | { type: "error"; message: string };
 

--- a/packages/vscode/src/webviews/guiEditor/panel.ts
+++ b/packages/vscode/src/webviews/guiEditor/panel.ts
@@ -354,6 +354,7 @@ export class GuiEditorPanel {
           : this.state.get<string>(SAVE_KEY)
             ? null
             : undefined,
+        dirty: source.isDirty,
         lineHeightRatio: this.meta.guiTextMetrics
           ? this.meta.guiTextMetrics.lineHeight / this.meta.guiTextMetrics.baseFontsize
           : undefined,
@@ -913,6 +914,15 @@ export class GuiEditorPanel {
       }
       case "clearPreviewValue": {
         await this.updatePreviewValues(message.expression, undefined);
+        return;
+      }
+      case "save": {
+        // The commits landed in the in-memory document; this is the one step
+        // that writes it to disk. The save event triggers a layout push whose
+        // `dirty: false` resets the button.
+        const doc = await vscode.workspace.openTextDocument(this.sourceUri);
+        const ok = doc.isDirty ? await doc.save() : true;
+        this.post({ type: "saved", ok });
         return;
       }
       case "undo":

--- a/packages/vscode/src/webviews/shared/help.ts
+++ b/packages/vscode/src/webviews/shared/help.ts
@@ -1,0 +1,130 @@
+/**
+ * The ? button's tutorial, shared by the app webviews (event graph, GUI
+ * editor, flag builder) so every view teaches itself the same way: one modal,
+ * scannable sections, a bold lead-in per row, kbd chips for the keys.
+ *
+ * Content is data, not markup: a view declares what it wants said (HelpSpec)
+ * and this renders it, so the tutorials cannot drift apart in look and a
+ * section reads the same in every view. Browser code, styled by ui.css
+ * (`.px-help*`), closed by its button, Escape, the X or the backdrop.
+ */
+import { iconEl } from "./icons";
+
+export interface HelpItem {
+  /** Bold lead-in naming the action ("Move a card"). */
+  lead?: string;
+  /** The explanation that follows it, plain prose. */
+  text: string;
+  /** Keys rendered as chips after the text, joined with +. */
+  keys?: string[];
+}
+
+export interface HelpSection {
+  title: string;
+  /** One or two framing sentences under the title. */
+  intro?: string;
+  items?: HelpItem[];
+  /** A compact keys -> action table; `keys` chips are joined with +. */
+  shortcuts?: { keys: string[]; does: string }[];
+}
+
+export interface HelpSpec {
+  title: string;
+  /** What this view IS, in a sentence or two: the first thing a new user reads. */
+  intro: string;
+  sections: HelpSection[];
+}
+
+function el(tag: string, cls?: string, text?: string): HTMLElement {
+  const node = document.createElement(tag);
+  if (cls) node.className = cls;
+  if (text !== undefined) node.textContent = text;
+  return node;
+}
+
+/** "Ctrl", "Z" -> chips with a small + between them. */
+function keyChips(keys: readonly string[]): HTMLElement {
+  const holder = el("span", "keys");
+  keys.forEach((key, i) => {
+    if (i > 0) holder.appendChild(el("span", "plus", "+"));
+    holder.appendChild(el("kbd", "px-kbd", key));
+  });
+  return holder;
+}
+
+/** Open the tutorial. One at a time; a second call replaces the first. */
+export function helpDialog(spec: HelpSpec): void {
+  document.querySelector(".px-help-backdrop")?.remove();
+
+  const backdrop = el("div", "px-dialog-backdrop px-help-backdrop");
+  const dialog = el("div", "px-dialog px-help");
+  dialog.setAttribute("role", "dialog");
+  dialog.setAttribute("aria-label", spec.title);
+
+  const head = el("div", "px-help-head");
+  const heading = el("div", "px-grow");
+  heading.appendChild(el("div", "px-help-title", spec.title));
+  heading.appendChild(el("div", "px-help-intro", spec.intro));
+  head.appendChild(heading);
+  const close = el("button", "px-btn") as HTMLButtonElement;
+  close.dataset.variant = "ghost";
+  close.dataset.size = "icon-sm";
+  close.setAttribute("aria-label", "Close");
+  close.appendChild(iconEl("x"));
+  head.appendChild(close);
+  dialog.appendChild(head);
+
+  const body = el("div", "px-help-body");
+  for (const section of spec.sections) {
+    const box = el("div", "px-help-section");
+    box.appendChild(el("div", "px-help-section-title", section.title));
+    if (section.intro) box.appendChild(el("div", "px-help-prose", section.intro));
+    for (const item of section.items ?? []) {
+      const row = el("div", "px-help-item");
+      if (item.lead) row.appendChild(el("span", "lead", item.lead + " "));
+      row.appendChild(document.createTextNode(item.text));
+      if (item.keys && item.keys.length > 0) {
+        row.appendChild(document.createTextNode(" "));
+        row.appendChild(keyChips(item.keys));
+      }
+      box.appendChild(row);
+    }
+    if (section.shortcuts && section.shortcuts.length > 0) {
+      const table = el("div", "px-help-keysGrid");
+      for (const row of section.shortcuts) {
+        table.appendChild(keyChips(row.keys));
+        table.appendChild(el("span", "does", row.does));
+      }
+      box.appendChild(table);
+    }
+    body.appendChild(box);
+  }
+  dialog.appendChild(body);
+
+  const foot = el("div", "px-help-foot");
+  const ok = el("button", "px-btn") as HTMLButtonElement;
+  ok.dataset.variant = "default";
+  ok.textContent = "Got it";
+  foot.appendChild(ok);
+  dialog.appendChild(foot);
+
+  backdrop.appendChild(dialog);
+  const done = (): void => {
+    document.removeEventListener("keydown", onKey, true);
+    backdrop.remove();
+  };
+  const onKey = (ev: KeyboardEvent): void => {
+    if (ev.key !== "Escape") return;
+    // Capture + stop, so the view behind does not also clear its selection.
+    ev.stopPropagation();
+    done();
+  };
+  close.onclick = done;
+  ok.onclick = done;
+  backdrop.onclick = (ev) => {
+    if (ev.target === backdrop) done();
+  };
+  document.addEventListener("keydown", onKey, true);
+  document.body.appendChild(backdrop);
+  ok.focus();
+}

--- a/packages/vscode/src/webviews/shared/overlay.ts
+++ b/packages/vscode/src/webviews/shared/overlay.ts
@@ -296,55 +296,5 @@ export function confirmDialog(o: ConfirmOptions): Promise<boolean> {
   });
 }
 
-/** A read-only dialog of titled paragraphs (a quick tutorial), closed by its button, Escape or the backdrop. */
-export function infoDialog(title: string, sections: [string, string][]): void {
-  const backdrop = document.createElement("div");
-  backdrop.className = "px-dialog-backdrop";
-  const dialog = document.createElement("div");
-  dialog.className = "px-dialog px-dialog-wide";
-  dialog.setAttribute("role", "dialog");
-  const h = document.createElement("div");
-  h.className = "px-dialog-title";
-  h.textContent = title;
-  dialog.append(h);
-  const body = document.createElement("div");
-  body.className = "px-dialog-sections";
-  for (const [heading, text] of sections) {
-    const sec = document.createElement("div");
-    const hh = document.createElement("div");
-    hh.className = "px-dialog-section-title";
-    hh.textContent = heading;
-    const p = document.createElement("div");
-    p.className = "px-dialog-description";
-    p.textContent = text;
-    sec.append(hh, p);
-    body.append(sec);
-  }
-  dialog.append(body);
-  const actions = document.createElement("div");
-  actions.className = "px-dialog-actions";
-  const ok = document.createElement("button");
-  ok.className = "px-btn";
-  ok.dataset.variant = "default";
-  ok.textContent = "Got it";
-  actions.append(ok);
-  dialog.append(actions);
-  backdrop.append(dialog);
-  const done = (): void => {
-    document.removeEventListener("keydown", onKey, true);
-    backdrop.remove();
-  };
-  const onKey = (ev: KeyboardEvent): void => {
-    if (ev.key === "Escape" || ev.key === "Enter") {
-      ev.stopPropagation();
-      done();
-    }
-  };
-  ok.onclick = done;
-  backdrop.onclick = (e) => {
-    if (e.target === backdrop) done();
-  };
-  document.addEventListener("keydown", onKey, true);
-  document.body.append(backdrop);
-  ok.focus();
-}
+// The ? button's tutorial dialog moved to help.ts (helpDialog): structured
+// sections with lead-ins and key chips replaced the plain titled paragraphs.

--- a/packages/vscode/src/webviews/shared/ui.css
+++ b/packages/vscode/src/webviews/shared/ui.css
@@ -858,12 +858,17 @@ body:not(.vscode-light) .px-tab[aria-selected="true"] {
   overflow: hidden;
   text-overflow: ellipsis;
 }
+/* Two-line rows breathe: without the padding and the description's own
+   margin, one row's description sat flush against the next row's label and
+   the list read as alternating unrelated lines rather than as pairs. */
 .px-menu-item[data-two-line] {
-  padding-top: 4px;
-  padding-bottom: 4px;
+  padding-top: 6px;
+  padding-bottom: 6px;
 }
 .px-menu-item > .px-grow > .px-menu-description {
   display: block;
+  margin-top: 2px;
+  line-height: 1.35;
   font-size: var(--px-text-xs);
   color: var(--px-muted-fg);
   overflow: hidden;

--- a/packages/vscode/src/webviews/shared/ui.css
+++ b/packages/vscode/src/webviews/shared/ui.css
@@ -987,25 +987,93 @@ body:not(.vscode-light) .px-tab[aria-selected="true"] {
 .px-dialog-description {
   color: var(--px-muted-fg);
 }
-.px-dialog-wide {
-  width: min(560px, calc(100vw - 32px));
-  max-height: calc(100vh - 32px);
-}
-.px-dialog-sections {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-  overflow: auto;
-  min-height: 0;
-}
-.px-dialog-section-title {
-  font-weight: 600;
-  margin-bottom: 2px;
-}
 .px-dialog-actions {
   display: flex;
   justify-content: flex-end;
   gap: 6px;
+}
+
+/* -------------------------------------------------- help tutorial (help.ts) --- */
+
+.px-help {
+  width: min(680px, calc(100vw - 32px));
+  max-height: calc(100vh - 48px);
+  gap: 0;
+  padding: 0;
+}
+.px-help-head {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 16px 16px 12px;
+  border-bottom: 1px solid var(--px-border);
+}
+.px-help-title {
+  font-weight: 600;
+  font-size: 15px;
+}
+.px-help-intro {
+  margin-top: 3px;
+  color: var(--px-muted-fg);
+  line-height: 1.55;
+}
+.px-help-body {
+  overflow: auto;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 14px 16px 4px;
+}
+.px-help-section {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.px-help-section + .px-help-section {
+  border-top: 1px solid var(--px-border);
+  padding-top: 14px;
+}
+.px-help-section-title {
+  font-weight: 600;
+}
+.px-help-prose,
+.px-help-item {
+  line-height: 1.6;
+  color: var(--px-muted-fg);
+}
+.px-help-item > .lead {
+  color: var(--px-fg);
+  font-weight: 600;
+}
+.px-help .keys {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  white-space: nowrap;
+}
+.px-help .keys .plus {
+  color: var(--px-muted-fg);
+  font-size: var(--px-text-xs);
+}
+.px-help-keysGrid {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 5px 14px;
+  align-items: baseline;
+  margin-top: 2px;
+}
+.px-help-keysGrid > .keys {
+  justify-self: start;
+}
+.px-help-keysGrid > .does {
+  color: var(--px-muted-fg);
+  line-height: 1.5;
+}
+.px-help-foot {
+  display: flex;
+  justify-content: flex-end;
+  padding: 12px 16px 16px;
 }
 @keyframes px-fade {
   from {

--- a/packages/vscode/test/guiEditorSmoke.test.ts
+++ b/packages/vscode/test/guiEditorSmoke.test.ts
@@ -2677,11 +2677,31 @@ describe("keyboard navigation", () => {
 });
 
 describe("the toolbar, increment 1", () => {
-  it("undo and redo are requests for the host's own history", () => {
-    openGroup();
+  it("undo and redo are session-scoped requests for the host's own history", () => {
+    const layout = openGroup();
+    // Nothing committed from this panel yet: the buttons are disabled, so a
+    // click sends nothing and the document's pre-session history stays safe.
+    const before = editor.sent.length;
     editor.document.getElementById("undo")!.click();
     editor.document.getElementById("redo")!.click();
-    expect(editor.sent.slice(-2)).toEqual([{ type: "undo" }, { type: "redo" }]);
+    expect(editor.sent.length).toBe(before);
+
+    // One committed drag arms them: undo sends the host request, and taking
+    // it back arms redo.
+    withoutGuides();
+    const at = centreOf(layout, "px_g5_a");
+    editor.press(at.x, at.y);
+    serveEdits();
+    editor.move(at.x + 40, at.y + 20);
+    editor.up(at.x + 40, at.y + 20);
+    serveEdits();
+    editor.document.getElementById("undo")!.click();
+    expect(editor.sent[editor.sent.length - 1]).toEqual({ type: "undo" });
+    editor.document.getElementById("redo")!.click();
+    expect(editor.sent[editor.sent.length - 1]).toEqual({ type: "redo" });
+    // The session log is empty again: both buttons are off.
+    expect((editor.document.getElementById("undo") as HTMLButtonElement).disabled).toBe(false);
+    expect((editor.document.getElementById("redo") as HTMLButtonElement).disabled).toBe(true);
   });
 
   it("the snap and grid toggles are remembered by the host and boot the next panel", () => {

--- a/packages/vscode/test/guiEditorSmoke.test.ts
+++ b/packages/vscode/test/guiEditorSmoke.test.ts
@@ -1904,45 +1904,17 @@ describe("the canvas devtools", () => {
 });
 
 describe("conditional visibility", () => {
-  it("interact mode: a click runs the variable half of an onclick and the checks follow", () => {
-    const text = [
-      "window = {",
-      "\tname = px_i",
-      "\tsize = { 400 300 }",
-      "\tbutton = {",
-      "\t\tname = px_i_btn",
-      "\t\tsize = { 40 40 }",
-      "\t\tonclick = \"[GetVariableSystem.Set('px_tab', 'b')]\"",
-      "\t\tonclick = \"[GetPlayer.MakeScope.ExecuteEffect('px_fx')]\"",
-      "\t}",
-      "\twidget = {",
-      "\t\tname = px_i_panel",
-      "\t\tposition = { 100 100 }",
-      "\t\tsize = { 40 40 }",
-      "\t\tvisible = \"[GetVariableSystem.HasValue('px_tab', 'b')]\"",
-      "\t}",
-      "}",
-    ].join("\n");
-    const layout = openDoc(text, "px_i.gui");
+  it("interact mode is deferred: the toggle is hidden and the mode cannot be entered", () => {
+    // docs/deferred-features.md: interact mode is hidden until it is fleshed
+    // out. The elements stay in the DOM (the id contract), but neither the
+    // button nor the I shortcut may reach the mode.
+    openDoc(["window = {", "\tname = px_i", "\tsize = { 400 300 }", "}"].join("\n"), "px_i.gui");
+    expect(editor.document.getElementById("modeGroup")!.hasAttribute("hidden")).toBe(true);
     editor.document.getElementById("modeInteract")!.click();
-    const at = centreOf(layout, "px_i_btn");
-    editor.click(at.x, at.y);
-    // One message, the evaluate assignment the variable decides; nothing written.
-    expect(lastOfType(editor, "setVisibility")).toEqual({
-      type: "setVisibility",
-      mode: "evaluate",
-      checks: { "[GetVariableSystem.HasValue('px_tab', 'b')]": true },
-    });
-    expect(editor.sent.some((m) => m.type === "checkEdit" || m.type === "applyEdit")).toBe(false);
-    const tip = editor.document.getElementById("clickTip")!;
-    expect(tip.hasAttribute("hidden")).toBe(false);
-    expect(tip.textContent).toContain("set px_tab = b");
-    expect(tip.textContent).toContain("ExecuteEffect('px_fx')");
-    // Esc closes the tip first, then leaves interact mode.
-    editor.key("Escape");
-    expect(tip.hasAttribute("hidden")).toBe(true);
-    editor.key("Escape");
     expect(editor.document.getElementById("modeEdit")!.getAttribute("aria-pressed")).toBe("true");
+    editor.key("i");
+    expect(editor.document.getElementById("modeEdit")!.getAttribute("aria-pressed")).toBe("true");
+    expect(editor.document.getElementById("modeInteract")!.getAttribute("aria-pressed")).toBe("false");
   });
 
   it("a mode change is one message, the layout is the answer, and the badge says so", () => {


### PR DESCRIPTION
﻿Rebased onto main after #16 landed; the diff is the UX round alone.

## Release plumbing
- The Discord release announcement is a plain message now, not an embed. Notes are cut at 1600 chars on a line boundary (content caps at 2000), and both URLs are wrapped in `<>` so Discord does not attach its own preview embed.

## Event graph
- Renamed from "Paradox Event Graph" to "Event Graph" (tab title and every error message).
- The Center tool is now **Cluster**: it keeps only the cards connected to the selected one (client-side connected component, no round trip). It is a history step, so undo brings the full graph back; right-click re-centre (server refocus) is unchanged.
- The 4 kind-filter chips moved to the bottom-left strip next to the zoom buttons; the background toggle moved to the topbar.
- The "Around X / Namespace X / All nodes" line is gone (the query box already says it); the bottom line only flags truncation or an active cluster.
- Event backgrounds are the real ones now: `override_background` on the event wins over its theme, and the resolver also takes a bare `event_background` name or a direct texture path.
- Two-line dropdown rows (Add field, etc.) got vertical breathing room: the description no longer sits flush against the next row's label.
- Script values are denoted `<SV>`; the tooltip leads with "Script Value" and says what that is.

## Event simulator panel (Simulate from a script)
- Script lines are colored with the shared tokenizer, same as the graph's floating sim window.
- The fold carets are real buttons that collapse/expand sections.
- "Open source" carries the same file icon the event graph uses.

## GUI editor
- **Save button in the topbar** (Ctrl+S works in the panel): edits land in the in-memory document only, and Save is what writes the file. `layout` pushes carry a `dirty` flag that drives the button.
- **Session change log**: the Changes button lists every edit committed from this panel, newest last, and each row undoes back to before it (the document's own undo run N times, never a second history).
- **Element library rework**, modeled on the game's own GUI overview window:
  - opens over the whole editor (side panels included), so it always has room;
  - scrolling it no longer zooms the canvas behind it (the overlay left `#stage`, whose wheel handler ate the events);
  - cards are grouped by job (Containers & layout, Text, Buttons & input, Images & bars, Lists & data, this file's own types/templates, saved pieces) with bigger previews and a hand-written one-sentence "what this is for" per builtin type.
- Zoom in/out/fit buttons sit next to the scale percent, and the five view toggles (outline, snap, grid, constraints, pulses) moved down there with them.
- **Interact mode and the save-game preview source are hidden** as deferred features until they are fleshed out; `docs/deferred-features.md` (now tracked) records where the off switches are.

Tests: full vitest suite green (the two heavy corpus tests pass on an idle machine; they time out only under parallel load). Typecheck and lint green. Test vsix built and installed.

､・Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Deliver the UX refresh across the Event Graph, event simulator, GUI Editor, Flag Builder, release announcements, and shared webview guidance.

New Features:
- Add client-side Event Graph clustering with undoable history and improved event background resolution.
- Add GUI Editor save controls, session change tracking, and a full-window element library showcase.
- Add shared, structured help tutorials to the Event Graph, GUI Editor, and Flag Builder.
- Improve event simulation readability with syntax highlighting, collapsible sections, and source-link icons.

Bug Fixes:
- Prevent Discord release announcements from creating embeds and safely truncate UTF-8 release notes within Discord message limits.
- Prevent GUI library scrolling from zooming the editor canvas.

Enhancements:
- Refresh Event Graph terminology, layout, controls, status messaging, and script-value presentation.
- Improve GUI Editor zoom and view controls, library grouping and documentation, and defer unfinished interact and save-game preview features.
- Improve spacing for two-line dropdown rows and centralize help-dialog presentation.

Documentation:
- Document the deferred GUI Editor features and update GUI Editor protocol and element-library documentation.

Tests:
- Update GUI Editor smoke tests for deferred interact mode and session-scoped undo/redo behavior.