### PR TITLE
One color picker style everywhere, alpha simulated but never editable

### DIFF
--- a/packages/server/src/features/colors.ts
+++ b/packages/server/src/features/colors.ts
@@ -187,11 +187,19 @@ export function provideDocumentColors(document: TextDocument): ColorSite[] {
 
 const FORMATS: readonly ColorFormat[] = ["rgb", "hsv", "hsv360", "hex", "float", "int"];
 
-export function renderColor(color: Color, format: ColorFormat, alpha: boolean): string {
+/**
+ * `alpha` is the SOURCE's fourth component (null = the source spelled none),
+ * not the picker's: the editor's opacity slider always exists and cannot be
+ * hidden, so presentations pin alpha to what the file already says. A color
+ * with alpha keeps exactly that alpha, a color without one never gains one —
+ * script colors are not meant to grow alpha channels from a stray drag.
+ */
+export function renderColor(color: Color, format: ColorFormat, alpha: number | null): string {
   const i = (n: number) => Math.round(n * 255);
   const f = (n: number) => String(Math.round(n * 1000) / 1000);
-  const withAlpha = alpha || color.alpha < 1;
-  const { red: r, green: g, blue: b, alpha: a } = color;
+  const withAlpha = alpha !== null;
+  const { red: r, green: g, blue: b } = color;
+  const a = alpha ?? 1;
   switch (format) {
     case "rgb":
       return `rgb { ${i(r)} ${i(g)} ${i(b)}${withAlpha ? ` ${i(a)}` : ""} }`;
@@ -228,7 +236,8 @@ export function provideColorPresentations(
     (s) => s.range.start.line === range.start.line && s.range.start.character === range.start.character
   );
   const own = site?.format ?? "rgb";
-  const alpha = site?.alpha ?? false;
+  // The source's own alpha, never the picker's: the opacity slider is inert.
+  const alpha = site?.alpha ? site.color.alpha : null;
   return [own, ...FORMATS.filter((f) => f !== own)].map((format) => ({
     label: renderColor(color, format, alpha),
   }));

--- a/packages/server/test/colors.test.ts
+++ b/packages/server/test/colors.test.ts
@@ -90,4 +90,17 @@ describe("colorPresentation, the multi-format cycle", () => {
     expect(provideColorPresentations(d, a.color, a.range)[0].label).toBe("{ 0.5 0.5 0.5 0.25 }");
     expect(provideColorPresentations(d, b.color, b.range)[0].label).toBe("{ 128 128 128 }");
   });
+
+  it("the opacity slider is inert: alpha stays what the source spelled", () => {
+    const d = doc("color = { 0.5 0.5 0.5 0.25 }\ncolor = { 128 128 128 }");
+    const [a, b] = provideDocumentColors(d);
+    // The picker hands back a dragged alpha; the presentation keeps the file's.
+    expect(provideColorPresentations(d, { ...a.color, alpha: 0.9 }, a.range)[0].label).toBe(
+      "{ 0.5 0.5 0.5 0.25 }"
+    );
+    // A color without alpha never gains a fourth component from the slider.
+    const labels = provideColorPresentations(d, { ...b.color, alpha: 0.5 }, b.range).map((p) => p.label);
+    expect(labels[0]).toBe("{ 128 128 128 }");
+    expect(labels).toContain("rgb { 128 128 128 }");
+  });
 });

--- a/packages/vscode/src/webviews/flagBuilder/app/main.ts
+++ b/packages/vscode/src/webviews/flagBuilder/app/main.ts
@@ -23,7 +23,7 @@ import { sidePanel } from "../../shared/sidePanel";
 import { confirmDialog, menu, toast, type MenuItem } from "../../shared/overlay";
 import { helpDialog } from "../../shared/help";
 import { scrubbable } from "../../shared/scrub";
-import { colorPicker } from "../../shared/colorPicker";
+import { colorPicker, hsvToRgb, type ColorValueFormat } from "../../shared/colorPicker";
 import { sortable } from "../../shared/sortable";
 import { clearRenderCaches, previewThumb, renderFlag, textureKeys } from "./render";
 import {
@@ -131,6 +131,13 @@ function parseColorText(text: string): { kind: "rgb" | "hsv360"; value: [number,
   if (tag === "hsv360") return { kind: "hsv360", value: [n[0], n[1], n[2]] };
   const rgb = n.every((x) => x <= 1) ? n.map((x) => Math.round(x * 255)) : n.map(Math.round);
   return { kind: "rgb", value: [rgb[0], rgb[1], rgb[2]] };
+}
+
+/** The same liberal reading, resolved to plain rgb for the picker's field. */
+function parseColorRgb(text: string): Rgb | null {
+  const p = parseColorText(text);
+  if (!p) return null;
+  return p.kind === "rgb" ? p.value : hsvToRgb(p.value[0], p.value[1] / 100, p.value[2] / 100);
 }
 
 // ---------------------------------------------------------------------------
@@ -342,11 +349,6 @@ function numberInput(value: number, step: number, onChange: (v: number) => void)
   return i;
 }
 
-/** A number field with a short prefix inside it ("h", "s", "v"). */
-function labeled(prefix: string, input: HTMLInputElement): HTMLElement {
-  return el("label", "px-labeled", el("span", undefined, prefix), input);
-}
-
 function field(label: string, ...value: (HTMLElement | string)[]): HTMLElement {
   const v = el("div", "px-row", ...value);
   v.style.minWidth = "0";
@@ -556,7 +558,6 @@ function colorEditor(colors: CoaColor[], title: string): HTMLElement {
 
     const value = el("div", "px-row");
     value.style.minWidth = "0";
-    let values: HTMLElement | null = null;
     const copyText = (text: string): void => send({ type: "copy", text });
     const pasteColor = async (): Promise<void> => {
       const parsed = parseColorText(await readClipboard());
@@ -568,6 +569,31 @@ function colorEditor(colors: CoaColor[], title: string): HTMLElement {
       colors[i] = { name: color.name, ...parsed };
       refresh();
     };
+    /** The swatch is the preview; the values live in its tooltip and in the picker. */
+    const tipText = (): string => {
+      const c = colorToRgb(color, db!.namedColors, flag.colors);
+      if (!c) return "unresolved color";
+      switch (color.kind) {
+        case "rgb":
+          return `rgb { ${color.value.join(" ")} } · ${rgbHex(c)}`;
+        case "hsv360":
+          return `hsv360 { ${color.value.map(Math.round).join(" ")} } · ${rgbHex(c)}`;
+        case "named":
+          return `${color.value} · rgb { ${c.join(" ")} }`;
+        case "ref":
+          return `same as ${color.value} · rgb { ${c.join(" ")} }`;
+      }
+    };
+    const copyValue = (): string => {
+      if (color.kind === "rgb") return `rgb { ${color.value.join(" ")} }`;
+      if (color.kind === "hsv360") return `hsv360 { ${color.value.map(Math.round).join(" ")} }`;
+      const c = colorToRgb(color, db!.namedColors, flag.colors);
+      return c ? `rgb { ${c.join(" ")} }` : "";
+    };
+    sw.removeAttribute("title");
+    sw.dataset.tip = tipText();
+    sw.dataset.tipSide = "left";
+
     if (color.kind === "named") {
       value.append(
         dropdown(
@@ -580,63 +606,7 @@ function colorEditor(colors: CoaColor[], title: string): HTMLElement {
           { small: true, search: true }
         )
       );
-    } else if (color.kind === "rgb") {
-      const text = el("span", "px-mono px-truncate");
-      const show = (): void => {
-        text.textContent = `R ${color.value[0]}  G ${color.value[1]}  B ${color.value[2]}`;
-      };
-      show();
-      const edit = button(
-        "",
-        () =>
-          colorPicker(edit, color.value, {
-            onChange: (rgb) => {
-              color.value = rgb;
-              sw.style.setProperty("--px-swatch", rgbHex(rgb));
-              show();
-              draw();
-            },
-            onClose: commit,
-          }),
-        { icon: "pencil", size: "icon-xs", tip: "Pick a color" }
-      );
-      values = el(
-        "div",
-        "color-values",
-        text,
-        edit,
-        button("", () => copyText(`rgb { ${color.value.join(" ")} }`), {
-          icon: "copy",
-          size: "icon-xs",
-          tip: "Copy rgb { r g b }",
-        }),
-        button("", () => void pasteColor(), { icon: "paste", size: "icon-xs", tip: "Paste a color" })
-      );
-    } else if (color.kind === "hsv360") {
-      const v = color.value;
-      values = el(
-        "div",
-        "color-values",
-        labeled(
-          "h",
-          numberInput(v[0], 1, (x) => (v[0] = x))
-        ),
-        labeled(
-          "s",
-          numberInput(v[1], 1, (x) => (v[1] = x))
-        ),
-        labeled(
-          "v",
-          numberInput(v[2], 1, (x) => (v[2] = x))
-        ),
-        button("", () => copyText(`hsv360 { ${v.map(Math.round).join(" ")} }`), {
-          icon: "copy",
-          size: "icon-xs",
-          tip: "Copy hsv360 { h s v }",
-        }),
-        button("", () => void pasteColor(), { icon: "paste", size: "icon-xs", tip: "Paste a color" })
-      );
-    } else {
+    } else if (color.kind === "ref") {
       const bases = flag.colors.filter((b) => !(colors === flag.colors && b.name === color.name));
       value.append(
         dropdown(
@@ -654,25 +624,52 @@ function colorEditor(colors: CoaColor[], title: string): HTMLElement {
         )
       );
     }
-    wrap.append(
-      el(
-        "div",
-        "color-row",
-        el("span", "px-muted px-sm", color.name),
-        sw,
-        kind,
-        value,
-        button(
-          "",
-          () => {
-            colors.splice(colors.indexOf(color), 1);
-            refresh();
-          },
-          { icon: "x", size: "icon-xs", tip: "Remove color" }
-        )
+
+    const tools = el("div", "color-tools", sw);
+    if (color.kind === "rgb" || color.kind === "hsv360") {
+      const literal = color;
+      const format: ColorValueFormat =
+        literal.kind === "rgb"
+          ? { write: (c) => `rgb { ${c.join(" ")} }`, parse: parseColorRgb }
+          : { write: (c) => `hsv360 { ${rgbToHsv360(c).join(" ")} }`, parse: parseColorRgb };
+      const edit = button(
+        "",
+        () =>
+          colorPicker(edit, colorToRgb(literal, db!.namedColors, flag.colors) ?? [255, 255, 255], {
+            format,
+            onCopy: copyText,
+            onChange: (c) => {
+              literal.value = literal.kind === "rgb" ? c : rgbToHsv360(c);
+              sw.style.setProperty("--px-swatch", rgbHex(c));
+              sw.removeAttribute("data-missing");
+              sw.dataset.tip = tipText();
+              draw();
+            },
+            // No refresh here: a rebuild mid-close would eat the click that
+            // lands on another control. The row repaints itself in onChange.
+            onClose: commit,
+          }),
+        { icon: "pencil", size: "icon-xs", tip: "Pick a color" }
+      );
+      tools.append(edit);
+    }
+    tools.append(
+      button("", () => copyText(copyValue()), {
+        icon: "copy",
+        size: "icon-xs",
+        tip: color.kind === "hsv360" ? "Copy hsv360 { h s v }" : "Copy rgb { r g b }",
+      }),
+      button("", () => void pasteColor(), { icon: "paste", size: "icon-xs", tip: "Paste a color" }),
+      button(
+        "",
+        () => {
+          colors.splice(colors.indexOf(color), 1);
+          refresh();
+        },
+        { icon: "x", size: "icon-xs", tip: "Remove color" }
       )
     );
-    if (values) wrap.append(values);
+    wrap.append(el("div", "color-row", el("span", "px-muted px-sm", color.name), kind, value, tools));
   }
   return wrap;
 }

--- a/packages/vscode/src/webviews/flagBuilder/app/main.ts
+++ b/packages/vscode/src/webviews/flagBuilder/app/main.ts
@@ -140,6 +140,18 @@ function parseColorRgb(text: string): Rgb | null {
   return p.kind === "rgb" ? p.value : hsvToRgb(p.value[0], p.value[1] / 100, p.value[2] / 100);
 }
 
+/** The hsv360 field shows bare values, so bare numbers ARE hsv360 there;
+ *  tagged or hex text still reads in its own notation. */
+function parseHsv360Values(text: string): Rgb | null {
+  const t = text.trim();
+  if (/^[\d.\s,]+$/.test(t)) {
+    const n = t.split(/[\s,]+/).map(Number);
+    if (n.length !== 3 || n.some((x) => !Number.isFinite(x))) return null;
+    return hsvToRgb(n[0], n[1] / 100, n[2] / 100);
+  }
+  return parseColorRgb(t);
+}
+
 // ---------------------------------------------------------------------------
 // History
 // ---------------------------------------------------------------------------
@@ -630,8 +642,18 @@ function colorEditor(colors: CoaColor[], title: string): HTMLElement {
       const literal = color;
       const format: ColorValueFormat =
         literal.kind === "rgb"
-          ? { write: (c) => `rgb { ${c.join(" ")} }`, parse: parseColorRgb }
-          : { write: (c) => `hsv360 { ${rgbToHsv360(c).join(" ")} }`, parse: parseColorRgb };
+          ? {
+              label: "rgb",
+              writeValues: (c) => c.join(" "),
+              write: (c) => `rgb { ${c.join(" ")} }`,
+              parse: parseColorRgb,
+            }
+          : {
+              label: "hsv360",
+              writeValues: (c) => rgbToHsv360(c).join(" "),
+              write: (c) => `hsv360 { ${rgbToHsv360(c).join(" ")} }`,
+              parse: parseHsv360Values,
+            };
       const edit = button(
         "",
         () =>

--- a/packages/vscode/src/webviews/flagBuilder/html.ts
+++ b/packages/vscode/src/webviews/flagBuilder/html.ts
@@ -55,9 +55,9 @@ ${uiCss}
   #origin:empty { display: none; }
   #inspector { padding: 4px 10px 12px; display: flex; flex-direction: column; gap: 8px; }
   .colors { display: flex; flex-direction: column; gap: 4px; }
-  .color-row { display: grid; grid-template-columns: 44px 18px 92px minmax(0, 1fr) 24px; align-items: center; gap: 6px; }
-  .color-values { display: flex; align-items: center; gap: 4px; padding-left: 68px; min-width: 0; }
-  .color-values .px-mono { flex: 1 1 auto; font-size: var(--px-text-sm); }
+  .color-row { display: grid; grid-template-columns: 44px 92px minmax(0, 1fr) auto; align-items: center; gap: 6px; }
+  .color-tools { display: flex; align-items: center; gap: 2px; }
+  .color-tools > .px-swatch { margin-right: 4px; }
   .instance { display: flex; flex-direction: column; gap: 4px; padding: 2px 0; }
   .instance + .instance { border-top: 1px solid var(--px-border); }
   .instance > .subhead { cursor: pointer; user-select: none; }

--- a/packages/vscode/src/webviews/guiEditor/app/main.ts
+++ b/packages/vscode/src/webviews/guiEditor/app/main.ts
@@ -2334,7 +2334,12 @@ function colorCell(input: HTMLInputElement, rgb: Rgb, alpha: string | null): HTM
   swatch.addEventListener("click", () => {
     const start = input.value;
     colorPicker(swatch, rgb, {
-      format: { write, parse: parseColorValue },
+      format: {
+        label: "rgb",
+        writeValues: (c) => c.map((v) => round(v / 255)).join(" "),
+        write,
+        parse: parseColorValue,
+      },
       alpha: alpha === null ? undefined : Number(alpha),
       onChange: (next) => {
         rgb = next;

--- a/packages/vscode/src/webviews/guiEditor/app/main.ts
+++ b/packages/vscode/src/webviews/guiEditor/app/main.ts
@@ -84,7 +84,7 @@ import {
 } from "../../shared/overlay";
 import { helpDialog } from "../../shared/help";
 import { scrubbable } from "../../shared/scrub";
-import { colorPicker, type Rgb } from "../../shared/colorPicker";
+import { colorPicker, paintSwatch, type Rgb } from "../../shared/colorPicker";
 import {
   applyScrollOffsets,
   buildScene,
@@ -2317,6 +2317,10 @@ function rowInput(row: InspectorRow, line: number): HTMLInputElement {
  * color picker. A color is written the way the engine reads one, `{ r g b a }`
  * in 0..1, and the picker's close is the commit, so a drag through the square
  * is one write and one undo step.
+ *
+ * A source alpha rides along verbatim and is SIMULATED in the swatch and the
+ * picker's preview; the picker offers no way to adjust it. Script colors are
+ * not meant to grow alpha channels by accident.
  */
 function colorCell(input: HTMLInputElement, rgb: Rgb, alpha: string | null): HTMLElement {
   const wrap = el("span", "valRow");
@@ -2324,14 +2328,18 @@ function colorCell(input: HTMLInputElement, rgb: Rgb, alpha: string | null): HTM
   swatch.className = "px-swatch";
   swatch.dataset.tip = "Pick a color";
   swatch.dataset.tipSide = "left";
-  swatch.style.setProperty("--px-swatch", `rgb(${rgb.join(" ")})`);
+  paintSwatch(swatch, rgb, alpha === null ? undefined : Number(alpha));
+  const write = (c: Rgb): string =>
+    `{ ${c.map((v) => round(v / 255)).join(" ")}${alpha === null ? "" : ` ${alpha}`} }`;
   swatch.addEventListener("click", () => {
     const start = input.value;
     colorPicker(swatch, rgb, {
+      format: { write, parse: parseColorValue },
+      alpha: alpha === null ? undefined : Number(alpha),
       onChange: (next) => {
         rgb = next;
-        swatch.style.setProperty("--px-swatch", `rgb(${next.join(" ")})`);
-        input.value = `{ ${next.map((v) => round(v / 255)).join(" ")}${alpha === null ? "" : ` ${alpha}`} }`;
+        paintSwatch(swatch, next, alpha === null ? undefined : Number(alpha));
+        input.value = write(next);
       },
       onClose: () => {
         if (input.value !== start) input.dispatchEvent(new Event("change"));
@@ -2341,6 +2349,16 @@ function colorCell(input: HTMLInputElement, rgb: Rgb, alpha: string | null): HTM
   wrap.appendChild(input);
   wrap.appendChild(swatch);
   return wrap;
+}
+
+/** A pasted or typed color for the picker's field: `{ r g b [a] }` floats, a
+ *  0..255 triple, or hex. A pasted alpha is dropped; the source's is kept. */
+function parseColorValue(text: string): Rgb | null {
+  const m = /^\{?\s*([\d.]+)[\s,]+([\d.]+)[\s,]+([\d.]+)(?:[\s,]+[\d.]+)?\s*\}?$/.exec(text.trim());
+  if (!m) return null;
+  const n = [Number(m[1]), Number(m[2]), Number(m[3])];
+  const k = n.every((x) => x <= 1) ? 255 : 1;
+  return [0, 1, 2].map((i) => Math.max(0, Math.min(255, Math.round(n[i] * k)))) as Rgb;
 }
 
 /** `{ r g b [a] }` in 0..1 on a `*color*` property, as the picker's 0..255 triple plus the alpha text. */

--- a/packages/vscode/src/webviews/guiEditor/app/main.ts
+++ b/packages/vscode/src/webviews/guiEditor/app/main.ts
@@ -84,7 +84,7 @@ import {
 } from "../../shared/overlay";
 import { helpDialog } from "../../shared/help";
 import { scrubbable } from "../../shared/scrub";
-import { colorPicker, paintSwatch, type Rgb } from "../../shared/colorPicker";
+import { colorPicker, hexToRgb, paintSwatch, type Rgb } from "../../shared/colorPicker";
 import {
   applyScrollOffsets,
   buildScene,
@@ -2357,11 +2357,15 @@ function colorCell(input: HTMLInputElement, rgb: Rgb, alpha: string | null): HTM
 }
 
 /** A pasted or typed color for the picker's field: `{ r g b [a] }` floats, a
- *  0..255 triple, or hex. A pasted alpha is dropped; the source's is kept. */
+ *  0..255 triple (optionally `rgb`-tagged), or hex. A pasted alpha is dropped;
+ *  the source's is kept. */
 function parseColorValue(text: string): Rgb | null {
-  const m = /^\{?\s*([\d.]+)[\s,]+([\d.]+)[\s,]+([\d.]+)(?:[\s,]+[\d.]+)?\s*\}?$/.exec(text.trim());
+  const hex = hexToRgb(text);
+  if (hex) return hex;
+  const m = /^(?:rgb\s*)?\{?\s*([\d.]+)[\s,]+([\d.]+)[\s,]+([\d.]+)(?:[\s,]+[\d.]+)?\s*\}?$/i.exec(text.trim());
   if (!m) return null;
   const n = [Number(m[1]), Number(m[2]), Number(m[3])];
+  if (!n.every(Number.isFinite)) return null;
   const k = n.every((x) => x <= 1) ? 255 : 1;
   return [0, 1, 2].map((i) => Math.max(0, Math.min(255, Math.round(n[i] * k)))) as Rgb;
 }

--- a/packages/vscode/src/webviews/guiEditor/app/main.ts
+++ b/packages/vscode/src/webviews/guiEditor/app/main.ts
@@ -2362,7 +2362,9 @@ function colorCell(input: HTMLInputElement, rgb: Rgb, alpha: string | null): HTM
 function parseColorValue(text: string): Rgb | null {
   const hex = hexToRgb(text);
   if (hex) return hex;
-  const m = /^(?:rgb\s*)?\{?\s*([\d.]+)[\s,]+([\d.]+)[\s,]+([\d.]+)(?:[\s,]+[\d.]+)?\s*\}?$/i.exec(text.trim());
+  const m = /^(?:rgb\s*)?\{?\s*([\d.]+)[\s,]+([\d.]+)[\s,]+([\d.]+)(?:[\s,]+[\d.]+)?\s*\}?$/i.exec(
+    text.trim()
+  );
   if (!m) return null;
   const n = [Number(m[1]), Number(m[2]), Number(m[3])];
   if (!n.every(Number.isFinite)) return null;

--- a/packages/vscode/src/webviews/shared/colorPicker.ts
+++ b/packages/vscode/src/webviews/shared/colorPicker.ts
@@ -1,14 +1,17 @@
 /**
- * A color picker in a popover: saturation/value square, hue bar, and a value
- * field in the color's OWN notation (hex when the caller has none), with copy
- * and liberal paste. The same shape as VS Code's editor color picker, so it
- * reads as the one the toolkit already uses on `rgb { }` literals in script
- * files (which cannot be summoned inside a webview). Browser code, styled by
- * ui.css (`.px-picker`).
+ * A color picker in a popover, mirroring VS Code's editor color picker (the
+ * one on `rgb { }` literals in script files, which cannot be summoned inside
+ * a webview and cannot be restyled): a value header on top, then the
+ * saturation/value square with vertical opacity and hue strips beside it.
+ * The header field holds the BARE component values in the color's own
+ * notation ("216 50 70" under an "hsv360" label; hex when the caller has
+ * none), with copy and liberal paste. Browser code, styled by ui.css
+ * (`.px-picker`).
  *
  * Alpha is SIMULATED, never edited: a source that spells a fourth component
- * shows it blended over a checkerboard, but there is no slider for it. Script
- * colors are not meant to grow alpha channels by accident.
+ * shows it blended over a checkerboard and marked on a display-only opacity
+ * strip, but nothing here adjusts it. Script colors are not meant to grow
+ * alpha channels by accident.
  */
 import { iconEl } from "./icons";
 import { popover } from "./overlay";
@@ -17,9 +20,14 @@ export type Rgb = [number, number, number];
 
 /** The color's own notation for the picker's value field. */
 export interface ColorValueFormat {
-  /** The value text for the current color, e.g. `hsv360 { 216 50 70 }`. */
+  /** The notation's name, shown as a label before the field ("rgb", "hsv360"). */
+  label: string;
+  /** The bare component values for the field, e.g. `216 50 70` — no braces. */
+  writeValues: (rgb: Rgb) => string;
+  /** The full script form the copy button yields, e.g. `hsv360 { 216 50 70 }`. */
   write: (rgb: Rgb) => string;
-  /** Typed or pasted text back to a color; null while it is not one. */
+  /** Typed or pasted text back to a color; null while it is not one. Bare
+   *  numbers are read in THIS notation, tagged or hex text in its own. */
   parse: (text: string) => Rgb | null;
 }
 
@@ -99,18 +107,10 @@ export function paintSwatch(swatch: HTMLElement, rgb: Rgb, alpha?: number): void
 export function colorPicker(anchor: HTMLElement, initial: Rgb, options: ColorPickerOptions): void {
   let [h, s, v] = rgbToHsv(initial);
 
+  // The same shape as the editor's native picker on script literals: a header
+  // with the value, then the square with vertical opacity and hue strips.
   const root = document.createElement("div");
   root.className = "px-picker";
-  const square = document.createElement("div");
-  square.className = "px-picker-square";
-  const squareThumb = document.createElement("div");
-  squareThumb.className = "px-picker-thumb";
-  square.append(squareThumb);
-  const hue = document.createElement("div");
-  hue.className = "px-picker-hue";
-  const hueThumb = document.createElement("div");
-  hueThumb.className = "px-picker-thumb";
-  hue.append(hueThumb);
   const row = document.createElement("div");
   row.className = "px-row";
   const preview = document.createElement("span");
@@ -119,9 +119,17 @@ export function colorPicker(anchor: HTMLElement, initial: Rgb, options: ColorPic
   value.className = "px-input px-mono";
   value.dataset.size = "sm";
   value.spellcheck = false;
-  row.append(preview, value);
+  row.append(preview);
+  if (options.format) {
+    const label = document.createElement("span");
+    label.className = "px-picker-label px-mono";
+    label.textContent = options.format.label;
+    row.append(label);
+  }
+  row.append(value);
 
-  const write = options.format?.write ?? rgbToHex;
+  const writeValues = options.format?.writeValues ?? rgbToHex;
+  const writeFull = options.format?.write ?? rgbToHex;
   // The hex form always parses, whatever notation the field displays.
   const parse = (text: string): Rgb | null => options.format?.parse(text) ?? hexToRgb(text);
   if (!options.format) value.maxLength = 7;
@@ -131,22 +139,53 @@ export function colorPicker(anchor: HTMLElement, initial: Rgb, options: ColorPic
     copy.className = "px-btn";
     copy.dataset.variant = "ghost";
     copy.dataset.size = "icon-xs";
-    copy.dataset.tip = "Copy the value";
+    copy.dataset.tip = options.format ? `Copy ${options.format.label} { … }` : "Copy the value";
     copy.append(iconEl("copy"));
-    copy.onclick = () => options.onCopy!(write(current()));
+    copy.onclick = () => options.onCopy!(writeFull(current()));
     row.append(copy);
   }
-  root.append(square, hue, row);
+
+  const body = document.createElement("div");
+  body.className = "px-picker-body";
+  const square = document.createElement("div");
+  square.className = "px-picker-square";
+  const squareThumb = document.createElement("div");
+  squareThumb.className = "px-picker-thumb";
+  square.append(squareThumb);
+  body.append(square);
+  // The locked alpha, shown where the native picker puts its opacity strip.
+  // Display only: the thumb marks the source's value and nothing drags.
+  let alphaFill: HTMLElement | null = null;
+  if (options.alpha !== undefined) {
+    const alpha = document.createElement("div");
+    alpha.className = "px-picker-alpha";
+    alpha.title = "Alpha comes from the script; edit the text to change it.";
+    alphaFill = document.createElement("div");
+    alphaFill.className = "px-picker-alpha-fill";
+    const alphaThumb = document.createElement("div");
+    alphaThumb.className = "px-picker-thumb";
+    alphaThumb.style.top = `${(1 - options.alpha) * 100}%`;
+    alpha.append(alphaFill, alphaThumb);
+    body.append(alpha);
+  }
+  const hue = document.createElement("div");
+  hue.className = "px-picker-hue";
+  const hueThumb = document.createElement("div");
+  hueThumb.className = "px-picker-thumb";
+  hue.append(hueThumb);
+  body.append(hue);
+  root.append(row, body);
 
   const current = (): Rgb => hsvToRgb(h, s, v);
   const paint = (): void => {
     square.style.background = `linear-gradient(to top, #000, transparent), linear-gradient(to right, #fff, hsl(${h} 100% 50%))`;
     squareThumb.style.left = `${s * 100}%`;
     squareThumb.style.top = `${(1 - v) * 100}%`;
-    hueThumb.style.left = `${(h / 360) * 100}%`;
+    hueThumb.style.top = `${(h / 360) * 100}%`;
     const rgb = current();
     paintSwatch(preview, rgb, options.alpha);
-    if (document.activeElement !== value) value.value = write(rgb);
+    if (alphaFill) alphaFill.style.background = `linear-gradient(to bottom, ${rgbToHex(rgb)}, transparent)`;
+    if (document.activeElement !== value) value.value = writeValues(rgb);
   };
   const emit = (): void => {
     paint();
@@ -178,8 +217,8 @@ export function colorPicker(anchor: HTMLElement, initial: Rgb, options: ColorPic
     s = x;
     v = 1 - y;
   });
-  drag(hue, (x) => {
-    h = x * 360;
+  drag(hue, (_x, y) => {
+    h = y * 360;
   });
   value.oninput = () => {
     const rgb = parse(value.value);

--- a/packages/vscode/src/webviews/shared/colorPicker.ts
+++ b/packages/vscode/src/webviews/shared/colorPicker.ts
@@ -1,17 +1,16 @@
 /**
- * A color picker in a popover, mirroring VS Code's editor color picker (the
- * one on `rgb { }` literals in script files, which cannot be summoned inside
- * a webview and cannot be restyled): a value header on top, then the
- * saturation/value square with vertical opacity and hue strips beside it.
- * The header field holds the BARE component values in the color's own
- * notation ("216 50 70" under an "hsv360" label; hex when the caller has
- * none), with copy and liberal paste. Browser code, styled by ui.css
- * (`.px-picker`).
+ * A color picker in a popover: saturation/value square, hue bar, and a value
+ * row whose field holds the BARE component values in the color's own notation
+ * ("216 50 70" under an "hsv360" label; hex when the caller has none), with
+ * copy and liberal paste. The editor's native picker on `rgb { }` literals in
+ * script files cannot be summoned inside a webview nor restyled, so this is
+ * the toolkit's own shape, kept by Joel's preference. Browser code, styled by
+ * ui.css (`.px-picker`).
  *
  * Alpha is SIMULATED, never edited: a source that spells a fourth component
- * shows it blended over a checkerboard and marked on a display-only opacity
- * strip, but nothing here adjusts it. Script colors are not meant to grow
- * alpha channels by accident.
+ * shows it blended over a checkerboard in the preview swatch, but nothing
+ * here adjusts it. Script colors are not meant to grow alpha channels by
+ * accident.
  */
 import { iconEl } from "./icons";
 import { popover } from "./overlay";
@@ -107,10 +106,18 @@ export function paintSwatch(swatch: HTMLElement, rgb: Rgb, alpha?: number): void
 export function colorPicker(anchor: HTMLElement, initial: Rgb, options: ColorPickerOptions): void {
   let [h, s, v] = rgbToHsv(initial);
 
-  // The same shape as the editor's native picker on script literals: a header
-  // with the value, then the square with vertical opacity and hue strips.
   const root = document.createElement("div");
   root.className = "px-picker";
+  const square = document.createElement("div");
+  square.className = "px-picker-square";
+  const squareThumb = document.createElement("div");
+  squareThumb.className = "px-picker-thumb";
+  square.append(squareThumb);
+  const hue = document.createElement("div");
+  hue.className = "px-picker-hue";
+  const hueThumb = document.createElement("div");
+  hueThumb.className = "px-picker-thumb";
+  hue.append(hueThumb);
   const row = document.createElement("div");
   row.className = "px-row";
   const preview = document.createElement("span");
@@ -145,46 +152,16 @@ export function colorPicker(anchor: HTMLElement, initial: Rgb, options: ColorPic
     row.append(copy);
   }
 
-  const body = document.createElement("div");
-  body.className = "px-picker-body";
-  const square = document.createElement("div");
-  square.className = "px-picker-square";
-  const squareThumb = document.createElement("div");
-  squareThumb.className = "px-picker-thumb";
-  square.append(squareThumb);
-  body.append(square);
-  // The locked alpha, shown where the native picker puts its opacity strip.
-  // Display only: the thumb marks the source's value and nothing drags.
-  let alphaFill: HTMLElement | null = null;
-  if (options.alpha !== undefined) {
-    const alpha = document.createElement("div");
-    alpha.className = "px-picker-alpha";
-    alpha.title = "Alpha comes from the script; edit the text to change it.";
-    alphaFill = document.createElement("div");
-    alphaFill.className = "px-picker-alpha-fill";
-    const alphaThumb = document.createElement("div");
-    alphaThumb.className = "px-picker-thumb";
-    alphaThumb.style.top = `${(1 - options.alpha) * 100}%`;
-    alpha.append(alphaFill, alphaThumb);
-    body.append(alpha);
-  }
-  const hue = document.createElement("div");
-  hue.className = "px-picker-hue";
-  const hueThumb = document.createElement("div");
-  hueThumb.className = "px-picker-thumb";
-  hue.append(hueThumb);
-  body.append(hue);
-  root.append(row, body);
+  root.append(square, hue, row);
 
   const current = (): Rgb => hsvToRgb(h, s, v);
   const paint = (): void => {
     square.style.background = `linear-gradient(to top, #000, transparent), linear-gradient(to right, #fff, hsl(${h} 100% 50%))`;
     squareThumb.style.left = `${s * 100}%`;
     squareThumb.style.top = `${(1 - v) * 100}%`;
-    hueThumb.style.top = `${(h / 360) * 100}%`;
+    hueThumb.style.left = `${(h / 360) * 100}%`;
     const rgb = current();
     paintSwatch(preview, rgb, options.alpha);
-    if (alphaFill) alphaFill.style.background = `linear-gradient(to bottom, ${rgbToHex(rgb)}, transparent)`;
     if (document.activeElement !== value) value.value = writeValues(rgb);
   };
   const emit = (): void => {
@@ -217,8 +194,8 @@ export function colorPicker(anchor: HTMLElement, initial: Rgb, options: ColorPic
     s = x;
     v = 1 - y;
   });
-  drag(hue, (_x, y) => {
-    h = y * 360;
+  drag(hue, (x) => {
+    h = x * 360;
   });
   value.oninput = () => {
     const rgb = parse(value.value);

--- a/packages/vscode/src/webviews/shared/colorPicker.ts
+++ b/packages/vscode/src/webviews/shared/colorPicker.ts
@@ -1,18 +1,39 @@
 /**
- * A color picker in a popover: saturation/value square, hue bar, hex field.
- * The same shape as VS Code's editor color picker, so it reads as the one the
- * toolkit already uses on `rgb { }` literals in script files (which cannot be
- * summoned inside a webview). Browser code, styled by ui.css (`.px-picker`).
+ * A color picker in a popover: saturation/value square, hue bar, and a value
+ * field in the color's OWN notation (hex when the caller has none), with copy
+ * and liberal paste. The same shape as VS Code's editor color picker, so it
+ * reads as the one the toolkit already uses on `rgb { }` literals in script
+ * files (which cannot be summoned inside a webview). Browser code, styled by
+ * ui.css (`.px-picker`).
+ *
+ * Alpha is SIMULATED, never edited: a source that spells a fourth component
+ * shows it blended over a checkerboard, but there is no slider for it. Script
+ * colors are not meant to grow alpha channels by accident.
  */
+import { iconEl } from "./icons";
 import { popover } from "./overlay";
 
 export type Rgb = [number, number, number];
+
+/** The color's own notation for the picker's value field. */
+export interface ColorValueFormat {
+  /** The value text for the current color, e.g. `hsv360 { 216 50 70 }`. */
+  write: (rgb: Rgb) => string;
+  /** Typed or pasted text back to a color; null while it is not one. */
+  parse: (text: string) => Rgb | null;
+}
 
 export interface ColorPickerOptions {
   /** Every change while dragging. */
   onChange: (rgb: Rgb) => void;
   /** When the picker closes (the undo step). */
   onClose?: () => void;
+  /** The value field's notation; a plain hex field when absent. */
+  format?: ColorValueFormat;
+  /** A source alpha in 0..1, blended into the preview. Not adjustable here. */
+  alpha?: number;
+  /** Routes the copy button's text; webview hosts own the clipboard. */
+  onCopy?: (text: string) => void;
 }
 
 export function rgbToHsv(rgb: Rgb): [number, number, number] {
@@ -64,6 +85,17 @@ export function hexToRgb(hex: string): Rgb | null {
   return [(n >> 16) & 255, (n >> 8) & 255, n & 255];
 }
 
+/** Paint a swatch element, blending a locked alpha over the checkerboard. */
+export function paintSwatch(swatch: HTMLElement, rgb: Rgb, alpha?: number): void {
+  if (alpha !== undefined && alpha < 1) {
+    swatch.setAttribute("data-checker", "");
+    swatch.style.setProperty("--px-swatch", `rgb(${rgb.join(" ")} / ${alpha})`);
+  } else {
+    swatch.removeAttribute("data-checker");
+    swatch.style.setProperty("--px-swatch", rgbToHex(rgb));
+  }
+}
+
 export function colorPicker(anchor: HTMLElement, initial: Rgb, options: ColorPickerOptions): void {
   let [h, s, v] = rgbToHsv(initial);
 
@@ -83,12 +115,27 @@ export function colorPicker(anchor: HTMLElement, initial: Rgb, options: ColorPic
   row.className = "px-row";
   const preview = document.createElement("span");
   preview.className = "px-swatch";
-  const hex = document.createElement("input");
-  hex.className = "px-input px-mono";
-  hex.dataset.size = "sm";
-  hex.spellcheck = false;
-  hex.maxLength = 7;
-  row.append(preview, hex);
+  const value = document.createElement("input");
+  value.className = "px-input px-mono";
+  value.dataset.size = "sm";
+  value.spellcheck = false;
+  row.append(preview, value);
+
+  const write = options.format?.write ?? rgbToHex;
+  // The hex form always parses, whatever notation the field displays.
+  const parse = (text: string): Rgb | null => options.format?.parse(text) ?? hexToRgb(text);
+  if (!options.format) value.maxLength = 7;
+
+  if (options.onCopy) {
+    const copy = document.createElement("button");
+    copy.className = "px-btn";
+    copy.dataset.variant = "ghost";
+    copy.dataset.size = "icon-xs";
+    copy.dataset.tip = "Copy the value";
+    copy.append(iconEl("copy"));
+    copy.onclick = () => options.onCopy!(write(current()));
+    row.append(copy);
+  }
   root.append(square, hue, row);
 
   const current = (): Rgb => hsvToRgb(h, s, v);
@@ -98,8 +145,8 @@ export function colorPicker(anchor: HTMLElement, initial: Rgb, options: ColorPic
     squareThumb.style.top = `${(1 - v) * 100}%`;
     hueThumb.style.left = `${(h / 360) * 100}%`;
     const rgb = current();
-    preview.style.setProperty("--px-swatch", rgbToHex(rgb));
-    if (document.activeElement !== hex) hex.value = rgbToHex(rgb);
+    paintSwatch(preview, rgb, options.alpha);
+    if (document.activeElement !== value) value.value = write(rgb);
   };
   const emit = (): void => {
     paint();
@@ -134,8 +181,8 @@ export function colorPicker(anchor: HTMLElement, initial: Rgb, options: ColorPic
   drag(hue, (x) => {
     h = x * 360;
   });
-  hex.oninput = () => {
-    const rgb = hexToRgb(hex.value);
+  value.oninput = () => {
+    const rgb = parse(value.value);
     if (!rgb) return;
     [h, s, v] = rgbToHsv(rgb);
     emit();

--- a/packages/vscode/src/webviews/shared/ui.css
+++ b/packages/vscode/src/webviews/shared/ui.css
@@ -954,6 +954,13 @@ body:not(.vscode-light) .px-tab[aria-selected="true"] {
 .px-picker-hue > .px-picker-thumb {
   top: 50%;
 }
+.px-picker .px-input {
+  flex: 1 1 0;
+  min-width: 0;
+}
+.px-picker .px-btn {
+  flex: 0 0 auto;
+}
 
 /* --------------------------------------------------------------- dialog --- */
 
@@ -1267,6 +1274,12 @@ body:not(.vscode-light) .px-tab[aria-selected="true"] {
 }
 .px-swatch[data-missing] {
   background: repeating-linear-gradient(45deg, var(--px-destructive) 0 3px, transparent 3px 6px);
+}
+/* A translucent color over a checkerboard: alpha is shown, never hidden. */
+.px-swatch[data-checker] {
+  background:
+    linear-gradient(var(--px-swatch, transparent), var(--px-swatch, transparent)),
+    repeating-conic-gradient(rgba(127, 127, 127, 0.45) 0% 25%, transparent 0% 50%) 0 0 / 10px 10px;
 }
 button.px-swatch {
   border: none;

--- a/packages/vscode/src/webviews/shared/ui.css
+++ b/packages/vscode/src/webviews/shared/ui.css
@@ -924,22 +924,41 @@ body:not(.vscode-light) .px-tab[aria-selected="true"] {
   display: flex;
   flex-direction: column;
   gap: 10px;
-  width: 220px;
+  width: 240px;
+}
+/* The editor's native picker shape: square, then vertical opacity + hue strips. */
+.px-picker-body {
+  display: flex;
+  gap: 8px;
+  height: 140px;
 }
 .px-picker-square {
   position: relative;
-  height: 140px;
+  flex: 1 1 auto;
   border-radius: var(--px-radius-md);
   cursor: crosshair;
   touch-action: none;
 }
 .px-picker-hue {
   position: relative;
-  height: 12px;
+  width: 12px;
   border-radius: 999px;
-  background: linear-gradient(to right, #f00, #ff0, #0f0, #0ff, #00f, #f0f, #f00);
-  cursor: ew-resize;
+  background: linear-gradient(to bottom, #f00, #ff0, #0f0, #0ff, #00f, #f0f, #f00);
+  cursor: ns-resize;
   touch-action: none;
+}
+/* Display only: marks the source's alpha, drags nowhere. */
+.px-picker-alpha {
+  position: relative;
+  width: 12px;
+  border-radius: 999px;
+  background: repeating-conic-gradient(rgba(127, 127, 127, 0.45) 0% 25%, transparent 0% 50%) 0 0 / 8px 8px;
+  cursor: not-allowed;
+}
+.px-picker-alpha-fill {
+  position: absolute;
+  inset: 0;
+  border-radius: 999px;
 }
 .px-picker-thumb {
   position: absolute;
@@ -951,8 +970,14 @@ body:not(.vscode-light) .px-tab[aria-selected="true"] {
   transform: translate(-50%, -50%);
   pointer-events: none;
 }
-.px-picker-hue > .px-picker-thumb {
-  top: 50%;
+.px-picker-hue > .px-picker-thumb,
+.px-picker-alpha > .px-picker-thumb {
+  left: 50%;
+}
+.px-picker-label {
+  flex: 0 0 auto;
+  font-size: var(--px-text-sm);
+  color: var(--px-muted-fg);
 }
 .px-picker .px-input {
   flex: 1 1 0;

--- a/packages/vscode/src/webviews/shared/ui.css
+++ b/packages/vscode/src/webviews/shared/ui.css
@@ -926,39 +926,20 @@ body:not(.vscode-light) .px-tab[aria-selected="true"] {
   gap: 10px;
   width: 240px;
 }
-/* The editor's native picker shape: square, then vertical opacity + hue strips. */
-.px-picker-body {
-  display: flex;
-  gap: 8px;
-  height: 140px;
-}
 .px-picker-square {
   position: relative;
-  flex: 1 1 auto;
+  height: 140px;
   border-radius: var(--px-radius-md);
   cursor: crosshair;
   touch-action: none;
 }
 .px-picker-hue {
   position: relative;
-  width: 12px;
+  height: 12px;
   border-radius: 999px;
-  background: linear-gradient(to bottom, #f00, #ff0, #0f0, #0ff, #00f, #f0f, #f00);
-  cursor: ns-resize;
+  background: linear-gradient(to right, #f00, #ff0, #0f0, #0ff, #00f, #f0f, #f00);
+  cursor: ew-resize;
   touch-action: none;
-}
-/* Display only: marks the source's alpha, drags nowhere. */
-.px-picker-alpha {
-  position: relative;
-  width: 12px;
-  border-radius: 999px;
-  background: repeating-conic-gradient(rgba(127, 127, 127, 0.45) 0% 25%, transparent 0% 50%) 0 0 / 8px 8px;
-  cursor: not-allowed;
-}
-.px-picker-alpha-fill {
-  position: absolute;
-  inset: 0;
-  border-radius: 999px;
 }
 .px-picker-thumb {
   position: absolute;
@@ -970,9 +951,8 @@ body:not(.vscode-light) .px-tab[aria-selected="true"] {
   transform: translate(-50%, -50%);
   pointer-events: none;
 }
-.px-picker-hue > .px-picker-thumb,
-.px-picker-alpha > .px-picker-thumb {
-  left: 50%;
+.px-picker-hue > .px-picker-thumb {
+  top: 50%;
 }
 .px-picker-label {
   flex: 0 0 auto;


### PR DESCRIPTION
Stacked on #17 (base: feat/ux-round-2026-08-24) so only the color work shows in the diff.

## What

**Alpha policy, everywhere a color can carry one.** A color that already spells a fourth component is simulated (blended over a checkerboard in swatches and picker previews) but never adjustable. In script files the editor's native picker cannot hide its opacity slider, so the LSP color presentations now pin alpha to what the source spells: dragging the slider writes nothing, and a color without alpha never gains one. Inexperienced modders cannot add alpha channels by accident.

**One picker style.** The shared popover picker (flag builder + GUI editor) now shows the color in its own notation, like the native picker on script literals:
- flag builder: `rgb { 174 169 166 }` or `hsv360 { 216 50 70 }`
- GUI editor: `{ 0.9 0.2 0.2 0.5 }` engine floats, source alpha kept verbatim

The field accepts liberal paste (any tag, bare triple, hex) and a copy button routes through the host clipboard. hsv360 flag colors gain an edit picker they never had.

**Flag colors preview.** Each row is now `name · format dropdown · (value dropdown for named/ref) · swatch · edit/copy/paste/remove`. The inline value text and h/s/v inputs are gone; hovering the swatch shows the current values (`hsv360 { 216 50 70 } · #597db3`) as a tooltip.

## Numbers

- 1573 tests green (10 in colors.test.ts, incl. a new inert-opacity-slider case), typecheck and lint clean.
- Verified in a static harness page: row layout, tooltip live-updates during a pick, format field parses `hsv360 { 10 90 80 }` and `#ff8800` pastes, GUI editor picker preserves ` 0.5` alpha through retypes, no popover overflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Unify color editing and enforce source-controlled alpha behavior across script, GUI, and flag color workflows.

New Features:
- Standardize the shared color picker across flag-builder and GUI-editor workflows with format-aware values, liberal parsing, and host-routed copying.
- Add picker support for editing hsv360 flag colors and previewing locked alpha over a checkerboard.

Bug Fixes:
- Prevent color presentations from changing or adding source alpha when the native opacity slider is moved.
- Preserve GUI/script source alpha verbatim while updating only RGB values.

Enhancements:
- Simplify flag color rows around format controls, swatches, tooltips, and edit/copy/paste/remove actions.
- Improve color picker layout and swatch feedback for translucent colors.

Tests:
- Add coverage confirming opacity-slider changes cannot alter or introduce alpha components.