### PR TITLE
npm packages: publishable @px-lsp/protocol + @px-lsp/server at 0.1.0, bin DX

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,11 @@ file. Do not let that happen again:
 - The user-facing feature story lives in `packages/vscode/README.md` (the
   Marketplace listing). When a release adds a user-visible feature, check that
   README's Highlights and the root README's short list still tell the truth.
+- The wiki mirrors two repo docs: `docs/EMBEDDING.md` -> wiki "Embedding" and
+  `docs/PROTOCOL.md` -> wiki "Protocol Reference" (repo copies are canonical).
+  Whenever you change either repo doc, port the change to the wiki page in the
+  same session (clone `paradox-modding-toolkit.wiki.git`, edit, push). Joel
+  does not want to do this by hand.
 
 ## Test builds (automatic)
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ localization workflow no other tool has.
 [![License: GPL-3.0-or-later](https://img.shields.io/badge/license-GPL--3.0--or--later-blue.svg)](LICENSE)
 ![Status: beta](https://img.shields.io/badge/status-beta-orange.svg)
 [![VS Code extension](https://img.shields.io/badge/VS%20Code-Paradox%20Modding%20Toolkit-007ACC.svg?logo=visualstudiocode)](https://marketplace.visualstudio.com/items?itemName=JDeffner.px-toolkit)
+[![npm @px-lsp/server](https://img.shields.io/npm/v/@px-lsp/server?logo=npm&label=%40px-lsp%2Fserver)](https://www.npmjs.com/package/@px-lsp/server)
 ![Editor agnostic](https://img.shields.io/badge/also-any%20LSP%20client-brightgreen.svg)
 
 [Install](#install) · [What you get](#what-you-get) ·
@@ -113,10 +114,17 @@ per-game limits, the detection ladder and the EU5 honesty note are on
 ## Not just VS Code
 
 The language server is standard LSP over `--stdio` and runs from neovim, Zed,
-Helix or your own application. Grab `px-lsp-server-<version>.tar.gz` from the
-[releases](https://github.com/JDeffner/paradox-modding-toolkit/releases), or
-`px-lsp-win-x64-<version>.zip` for one download that already contains Node and a
-launcher.
+Helix or your own application. It is on npm:
+
+```bash
+npm install -g @px-lsp/server
+px-lsp                       # stdio is the default transport
+```
+
+The [releases](https://github.com/JDeffner/paradox-modding-toolkit/releases)
+page carries the same payload for people who would rather not use npm:
+`px-lsp-server-<version>.tar.gz`, or `px-lsp-win-x64-<version>.zip` for one
+download that already contains Node and a launcher.
 
 - [`packages/server/README.md`](packages/server/README.md) covers standalone
   setup and the per-language capability table.
@@ -134,8 +142,8 @@ a separate server process, and everything game-specific sits behind one
 | Package | |
 |---|---|
 | [`packages/vscode`](packages/vscode) | The **Paradox Modding Toolkit** extension, the primary client. Its [README](packages/vscode/README.md) is the user-facing one. |
-| [`packages/server`](packages/server) | `@px-lsp/server`: parser, index, scope engine, features, per-game profiles, bundled data. Speaks node-ipc and `--stdio`. |
-| [`packages/protocol`](packages/protocol) | `@px-lsp/protocol`: the wire contract and the helpers shared between server and clients. |
+| [`packages/server`](packages/server) | [`@px-lsp/server`](https://www.npmjs.com/package/@px-lsp/server) on npm: parser, index, scope engine, features, per-game profiles, bundled data. Speaks node-ipc and `--stdio`. |
+| [`packages/protocol`](packages/protocol) | [`@px-lsp/protocol`](https://www.npmjs.com/package/@px-lsp/protocol) on npm: the wire contract and the helpers shared between server and clients. |
 
 ## Development
 

--- a/docs/EMBEDDING.md
+++ b/docs/EMBEDDING.md
@@ -29,9 +29,10 @@ not an API call:
 | `--socket=<port>` (or `--socket <port>`) | TCP: the server connects out to `127.0.0.1:<port>`, so the host listens. |
 | `--pipe=<name>` (or `--pipe <name>`) | Named pipe / unix domain socket, same direction. |
 
-With none of them the process throws on startup instead of guessing, so a
-missing `--stdio` shows up immediately rather than as a client that never
-connects.
+With none of them, the server defaults to `--stdio` (unless it was forked over
+node IPC, which it detects from `process.send`), so a bare `px-lsp` behaves
+like `px-lsp --stdio`. `px-lsp --version` prints the server version and exits
+without a handshake, for install scripts and health checks.
 
 ```
 node /path/to/px-lsp-server-0.3.0/dist/server.js --stdio

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -12,19 +12,20 @@ next to this file is the guide for that: the process contract, the
 initialization options worth sending, URI and document-sync conventions, and
 the in-tree reference clients. This document stays the per-method reference.
 
-**Versioning**: the protocol is versioned with the packages (lockstep with
-the extension). Treat any change here as an API change; additions are
-backward-compatible, renames/removals are called out in the changelog.
-Current as of 0.3.0 (the Paradox Toolkit rebrand and the three game
-profiles; `paradox/*` has been the method prefix since 0.1.2). Four additions
-are in the repository but not yet in a release: `serverInfo` in the
-`initialize` result, the `client` capability object superseding
-`clientCommands`, `paradox/scopeAt`, and `dataDir`. All four are additive:
-a client written against 0.3.0 keeps working unchanged.
+**Versioning**: the protocol is versioned with `@px-lsp/protocol` (its own
+version, independent of the extension since extension 0.3.3; first npm
+release 0.1.0). Treat any change here as an API change: additions are
+backward-compatible, renames/removals are called out in the package's
+`CHANGELOG.md`. Current as of `@px-lsp/protocol` 0.1.0, which carries the
+full contract below including `serverInfo` in the `initialize` result, the
+`client` capability object superseding `clientCommands`, `paradox/scopeAt`,
+and `dataDir` (`paradox/*` has been the method prefix since extension
+0.1.2).
 
 ## Transport and lifecycle
 
-- Transports: `--stdio` (auto-detected from argv; what external clients use)
+- Transports: `--stdio` (what external clients use; also the default when no
+  transport argument is given and the process was not forked over IPC)
   and node-ipc (VSCode). `--socket=<port>` and `--pipe=<name>` are accepted by
   the underlying library, but nothing ships using them. Standard JSON-RPC 2.0
   LSP framing. The process-level contract around this (the `processId` orphan

--- a/packages/protocol/CHANGELOG.md
+++ b/packages/protocol/CHANGELOG.md
@@ -1,10 +1,13 @@
 # @px-lsp/protocol changelog
 
-The protocol has its own version since 0.3.3 of the extension: it only gets a
-bump when the wire contract or the shared helpers change. Up to and including
-0.3.2 it moved in lockstep with the extension; see the extension changelog
-(`packages/vscode/CHANGELOG.md`) for that history.
+The protocol has its own version, separate from the extension: it starts at
+0.1.0 for its first npm release and only gets a bump when the wire contract or
+the shared helpers change. Before the split it moved inside the extension's
+version (up to 0.3.2); that history is in the extension changelog
+(`packages/vscode/CHANGELOG.md`).
 
-## 0.3.2
+## 0.1.0
 
-Last lockstep version. No changes of its own in the 0.3.3 extension release.
+First npm release. The wire contract (custom `paradox/*` requests and
+notifications, settings types) and the shared helpers, compiled to CommonJS
+with type declarations.

--- a/packages/protocol/README.md
+++ b/packages/protocol/README.md
@@ -6,14 +6,14 @@ initialization-option shapes, plus a few pure helpers shared between the
 server and its clients (tiger report parsing, `.mod` descriptor parsing,
 diagnostic suppression, localization helpers).
 
-The package ships plain TypeScript sources (`exports` maps `./*` to
-`./src/*.ts`), so consume it from a bundler/TS toolchain, e.g.:
+The published package ships compiled JavaScript with type declarations, so it
+works from plain Node and from any bundler:
 
 ```ts
 import { modOverviewRequest, type ModOverview } from "@px-lsp/protocol/protocol";
 ```
 
-Non-TypeScript clients should code against the documented contract instead:
+Clients in other languages should code against the documented contract instead:
 see [`docs/PROTOCOL.md`](https://github.com/JDeffner/paradox-modding-toolkit/blob/main/docs/PROTOCOL.md)
 in the repository. Changes to the wire contract are treated as API changes
 and versioned with the packages.

--- a/packages/protocol/README.md
+++ b/packages/protocol/README.md
@@ -10,7 +10,11 @@ The published package ships compiled JavaScript with type declarations, so it
 works from plain Node and from any bundler:
 
 ```ts
-import { modOverviewRequest, type ModOverview } from "@px-lsp/protocol/protocol";
+// The root export is the wire contract (request/notification names + payload types):
+import { modOverviewRequest, type ModOverview } from "@px-lsp/protocol";
+// The helpers live in named modules:
+import { parseTigerJson } from "@px-lsp/protocol/tigerParser";
+import { parseDescriptor } from "@px-lsp/protocol/descriptorMod";
 ```
 
 Clients in other languages should code against the documented contract instead:

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -15,11 +15,24 @@
   },
   "files": [
     "src",
+    "dist",
     "README.md",
     "LICENSE"
   ],
-  "private": true,
   "exports": {
     "./*": "./src/*.ts"
+  },
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      "./*": {
+        "types": "./dist/*.d.ts",
+        "default": "./dist/*.js"
+      }
+    }
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "prepack": "tsc -p tsconfig.build.json"
   }
 }

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@px-lsp/protocol",
-  "version": "0.3.2",
+  "version": "0.1.0",
   "license": "GPL-3.0-or-later",
   "description": "Wire contract (custom LSP requests/notifications, settings types) and shared helpers for the px-lsp language server and its clients.",
   "keywords": [
@@ -20,11 +20,18 @@
     "LICENSE"
   ],
   "exports": {
+    ".": "./src/protocol.ts",
+    "./package.json": "./package.json",
     "./*": "./src/*.ts"
   },
   "publishConfig": {
     "access": "public",
     "exports": {
+      ".": {
+        "types": "./dist/protocol.d.ts",
+        "default": "./dist/protocol.js"
+      },
+      "./package.json": "./package.json",
       "./*": {
         "types": "./dist/*.d.ts",
         "default": "./dist/*.js"

--- a/packages/protocol/tsconfig.build.json
+++ b/packages/protocol/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "moduleResolution": "Node10",
+    "types": ["node"],
+    "declaration": true,
+    "sourceMap": false,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -1,11 +1,13 @@
 # @px-lsp/server changelog
 
-The server has its own version since 0.3.3 of the extension: it only gets a
-bump when the server itself changes. Up to and including 0.3.2 it moved in
-lockstep with the extension; see the extension changelog
-(`packages/vscode/CHANGELOG.md`) for that history.
+The server has its own version, separate from the extension: it starts at
+0.1.0 for its first npm release and only gets a bump when the server itself
+changes. Before the split it moved inside the extension's version (up to
+0.3.2); that history is in the extension changelog
+(`packages/vscode/CHANGELOG.md`).
 
-## 0.3.2
+## 0.1.0
 
-Last lockstep version. No changes of its own in the 0.3.3 extension release
-(the tiger download fix lives in the VS Code client).
+First npm release. The full language server (parser, index, scope engine,
+features, per-game profiles, bundled data) with the `px-lsp` bin, usable over
+`--stdio` from any LSP client or over node-ipc.

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -30,9 +30,20 @@ mirror in the log. Nothing has to be configured for that.
 
 ## Install
 
-The release tarball is the distribution. This package is not on npm: inside the
-repository its `exports` point at TypeScript sources, which the bundler consumes
-directly and a published package could not.
+### From npm
+
+```bash
+npm install -g @px-lsp/server
+px-lsp --stdio
+```
+
+The npm package carries the same payload as the release tarball: the bundled
+`dist/server.js` (the `px-lsp` bin), the `data/` fallbacks, and the TypeScript
+sources. The sources exist for bundler consumers (esbuild, Vite) that import
+pieces like `@px-lsp/server/parser` directly; plain Node cannot import them,
+use the bin or the wire protocol instead.
+
+### The release tarball
 
 Download `px-lsp-server-<version>.tar.gz` from the
 [GitHub releases](https://github.com/JDeffner/paradox-modding-toolkit/releases)

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -34,7 +34,8 @@ mirror in the log. Nothing has to be configured for that.
 
 ```bash
 npm install -g @px-lsp/server
-px-lsp --stdio
+px-lsp --version   # prints the server version
+px-lsp             # runs over stdio (--stdio is the default transport)
 ```
 
 The npm package carries the same payload as the release tarball: the bundled

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -28,7 +28,9 @@
     "LICENSE",
     "THIRD-PARTY-NOTICES.md"
   ],
-  "private": true,
+  "publishConfig": {
+    "access": "public"
+  },
   "exports": {
     "./dds": "./src/dds/index.ts",
     "./parser": "./src/parser/index.ts",
@@ -36,7 +38,8 @@
   },
   "scripts": {
     "compile": "esbuild src/server.ts --bundle --outfile=dist/server.js --format=cjs --platform=node --target=node18 --banner:js=\"#!/usr/bin/env node\"",
-    "watch": "esbuild src/server.ts --bundle --outfile=dist/server.js --format=cjs --platform=node --target=node18 --watch"
+    "watch": "esbuild src/server.ts --bundle --outfile=dist/server.js --format=cjs --platform=node --target=node18 --watch",
+    "prepack": "pnpm run compile"
   },
   "dependencies": {
     "@px-lsp/protocol": "workspace:*",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@px-lsp/server",
-  "version": "0.3.2",
+  "version": "0.1.0",
   "license": "GPL-3.0-or-later",
   "description": "Language server for Paradox script (Crusader Kings III first), usable over node-ipc or stdio from any LSP client.",
   "keywords": [
@@ -32,6 +32,7 @@
     "access": "public"
   },
   "exports": {
+    "./package.json": "./package.json",
     "./dds": "./src/dds/index.ts",
     "./parser": "./src/parser/index.ts",
     "./*": "./src/*.ts"

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -173,6 +173,25 @@ import { computeEventBanner } from "./overview/eventBanner";
 import { computeDependencies } from "./overview/dependencies";
 import { wordRangeAt } from "./wordAt";
 
+// The px-lsp bin, before the connection claims stdio:
+//  - `px-lsp --version` answers and exits, so health checks and install
+//    scripts do not need an LSP handshake.
+//  - A bare `px-lsp` defaults to --stdio instead of dying with a stack trace
+//    ("Connection input stream is not set"). Editors that spawn over node-ipc
+//    (the VS Code client) pass --node-ipc themselves, and an ipc fork is
+//    recognizable by process.send, so the default cannot misfire there.
+if (process.argv.includes("--version") || process.argv.includes("-v")) {
+  process.stdout.write(SERVER_VERSION + "\n");
+  process.exit(0);
+}
+const TRANSPORT_FLAGS = ["--node-ipc", "--stdio", "--socket", "--pipe"];
+if (
+  !process.send &&
+  !process.argv.some((arg) => TRANSPORT_FLAGS.some((flag) => arg === flag || arg.startsWith(flag + "=")))
+) {
+  process.argv.push("--stdio");
+}
+
 const connection = createConnection(ProposedFeatures.all);
 const documents = new TextDocuments(TextDocument);
 


### PR DESCRIPTION
Prepares both packages for npm so they can back external consumers (first target: the Jomini coding tutorial website).

## What changed
- Both packages: `private: true` removed, `publishConfig.access: public` added.
- **protocol**: new `tsconfig.build.json` emits CommonJS + `.d.ts` into `dist/` (prepack hook). In-repo `exports` still point at TS sources; `publishConfig.exports` swaps the published package to `dist/`.
- **server**: `prepack` runs the esbuild compile, so a stale or missing `dist/server.js` cannot ship.

## Round 2 (2026-08-26)
- **Versions are 0.1.0**, not 0.3.2: neither package has had a release, so they start at the beginning and version independently of the extension from here (per the policy in PR #22). Each package now has its own CHANGELOG.md; RELEASING.md updated.
- **DX**: a bare `px-lsp` now defaults to `--stdio` instead of dying with a stack trace ("Connection input stream is not set"); `px-lsp --version` prints the version and exits; `import ... from "@px-lsp/protocol"` (root) resolves to the wire contract; `<pkg>/package.json` is export-mapped so `require.resolve` works for bin-path discovery.
- Branch includes a merge of the 0.3.3 release branch (#22), so merge #22 first; this PR then squashes to only its own delta.

## Verified (round 2, against the packed tarballs in scratch projects)
- protocol standalone from plain Node: root import + `tigerParser`/`descriptorMod` helpers run, `.d.ts` present next to every compiled module.
- server standalone: `px-lsp --version` prints 0.1.0; bare `px-lsp` speaks stdio; full initialize handshake returns serverInfo 0.1.0 + capability set; the repo's stdioSmoke suite (3/3) run against the installed package; bundled CK3 data resolves from the npm layout (4624 tokens).
- A complete embedding example (spawn + vscode-jsonrpc + `@px-lsp/protocol`) runs end to end; it is published on the wiki as "npm Packages".
- Gates: typecheck, eslint + prettier, server+protocol suites 1134 passed.

## What publishing still needs from Joel
1. `npm login` (never done on this machine).
2. The `px-lsp` scope on npmjs.com must be free/yours on first publish.
3. From each package dir: `pnpm publish` (pnpm, not npm, so the workspace dep gets rewritten), protocol first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Prepare the protocol and language server for independent 0.1.0 npm releases with reliable packaged artifacts and improved command-line usability.

New Features:
- Publish @px-lsp/protocol and @px-lsp/server as public 0.1.0 npm packages for external consumers.
- Provide plain Node-compatible protocol imports with compiled JavaScript and type declarations.
- Improve the px-lsp command-line experience with stdio as the default transport and a version query option.

Bug Fixes:
- Ensure published server packages always contain a freshly compiled language-server bundle.

Enhancements:
- Version the protocol and server independently from the VS Code extension and document their initial releases.
- Expose package metadata for reliable binary discovery and update installation and embedding guidance for npm consumers.

Build:
- Add protocol package build and prepack configuration for distributable CommonJS modules and declarations.
- Add server prepack compilation to package creation.

Documentation:
- Update project, package, protocol, and embedding documentation to describe npm installation, package usage, independent versioning, and command behavior.

Chores:
- Add per-package changelog entries for the 0.1.0 npm releases and publish metadata.