### PR TITLE
perf: find and fix the real cause of large-workspace lag (profiled)

### DIFF
--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -93,34 +93,43 @@ The toolkit's index never reads binary files: the definition scan walks the
 schema folders with an extension filter (`.txt`, `.yml`, `.gui`), and the file
 watchers glob the same extensions. A `.dds` never enters it.
 
-VS Code's own machinery is a different story. The built-in file watcher and
-search walk every workspace folder whole, and most of a game install is
-textures, meshes and audio. **`Paradox: Reduce VS Code Indexing Load`** (also
-a button on the big-workspace warning) writes workspace-scoped
-`files.watcherExclude` and `search.exclude` patterns for the asset trees
-(`gfx/`, `map_data/`, `music/`, `sound/`, `soundtrack/`, `dlc/`, `binaries/`,
-plus loose `.dds`/`.tga`/`.mesh`/`.anim` for the watcher). The write is
-additive — your existing patterns survive, and a pattern you set to `false`
-stays `false` — and the confirmation offers one-click Undo. The visible
-trade: search and Quick Open stop listing files under those folders.
+VS Code's own machinery is a different story. The built-in search and file
+watcher walk every workspace folder whole, and 62% of a game install plus a
+total conversion is textures, meshes and audio.
+**`Paradox: Reduce VS Code Indexing Load`** (also a button on the
+big-workspace warning) writes workspace-scoped `search.exclude` and
+`files.watcherExclude` patterns for binary EXTENSIONS: `.dds`, `.tga`,
+`.mesh`, `.anim`, `.png`, `.bk2`, `.bank`, `.wav`, `.ttf`, `.otf`. The write
+is additive — your existing patterns survive, and a pattern you set to
+`false` stays `false` — and the confirmation offers one-click Undo.
 
 Measured 2026-08-27 on the CK3 install (48,481 files) plus AGOT (21,431
-files), warm cache, NVMe, VS Code 1.134 on Windows:
+files), NVMe, VS Code 1.134 on Windows:
 
-- The patterns remove 51,834 of the 69,912 files (74%).
-- **Find in Files across the workspace: ~110 s without the excludes, ~30 s
-  with them** (ripgrep, the engine VS Code search runs, with the same
-  globs). This is the number that changes daily life. Quick Open
-  enumeration barely moves (250 ms → 80 ms).
-- The file watcher does NOT get cheaper on Windows: its process sat at
-  123 MB vs 124 MB with the excludes, and the initial crawl cost ~0.4 s of
-  CPU either way, because Windows watches a whole root with one recursive
-  OS handle. The watcher half of the command is for Linux, where every
-  directory costs an inotify watch and the game tree can blow the system
-  limit, and for event churn when Steam updates the game mid-session.
+| Find in Files, whole workspace | without | with |
+|---|---|---|
+| binaries warm in the OS cache | 1.7 s | 0.65 s |
+| binaries evicted (the normal case) | up to 106 s | 0.65 s |
 
-So on Windows this command is a search lever, not a memory lever. The memory
-levers are the mod-index settings above, and fewer windows.
+The patterns skip 43,067 of 69,912 files, and search never opens them, so the
+time is stable instead of depending on what the cache happens to hold.
+
+**Extensions, never directories.** Excluding whole asset trees looks
+equivalent and is not: `gfx/`, `music/`, `map_data/` and `dlc/` hold real
+script. CK3 maps seven schema folders under `gfx/` alone (portrait modifiers,
+court scene, scripted illustrations), and game + AGOT hold 584 script files
+under `gfx/`, 47 under `music/` and 3,537 under `dlc/`. A directory exclude
+would hide those from search and, because VS Code applies
+`files.watcherExclude` to recursive watchers including the extension's own,
+would stop a save in them from re-indexing. A test
+(`editorExcludesSafety.test.ts`) fails the build if a directory pattern ever
+comes back.
+
+The watcher half is not a memory lever on Windows: the watcher process
+measured 123 MB without the excludes and 124 MB with them, because Windows
+watches a root with a single recursive handle. It earns its place by keeping
+a Steam update that rewrites 27k textures from becoming 27k events, and on
+Linux, where inotify costs one watch per directory.
 
 ## Reporting a slow session
 

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -62,6 +62,14 @@ In rough order of effect:
   biggest lever: excluding one total conversion you are not editing gives back
   roughly a gigabyte per window. The sidebar's *Workspace Mods* group has an
   **Exclude Mods from Indexing** picker for it.
+- **Read-only context** is the middle ground the picker offers after you
+  exclude: listing an excluded mod in `px.parentMods` indexes it like a
+  dependency parent — definitions only, so completion, hover and
+  go-to-definition still see its content, but none of the reference index,
+  which is the expensive half (a reference costs ~149 B and big mods hold
+  millions). A mod you load but never edit — an unofficial patch, a framework
+  mod, anything that carries copies of vanilla files — belongs here, not in
+  the full index.
 - **Fewer windows.** Windows multiply everything above. One window per mod you
   are actually editing, not one per folder you might look at.
 - **`px.parentMods`** should list only the dependencies your mod really builds
@@ -78,6 +86,24 @@ The extension warns once on activation when a workspace passes 6 indexed mod
 roots or 10,000 script files. That warning names `px.excludedMods` and offers
 the picker as a button, and it names `px.tigerRunOn` only when you have set it
 to `"save"`.
+
+## What VS Code itself indexes
+
+The toolkit's index never reads binary files: the definition scan walks the
+schema folders with an extension filter (`.txt`, `.yml`, `.gui`), and the file
+watchers glob the same extensions. A `.dds` never enters it.
+
+VS Code's own machinery is a different story. The built-in file watcher and
+search walk every workspace folder whole, and a game install is ~100k files
+of mostly textures, meshes and audio; a workspace with the game plus dozens
+of mods multiplies that. **`Paradox: Reduce VS Code Indexing Load`** (also a
+button on the big-workspace warning) writes workspace-scoped
+`files.watcherExclude` and `search.exclude` patterns for the asset trees
+(`gfx/`, `map_data/`, `music/`, `sound/`, `soundtrack/`, `dlc/`, `binaries/`,
+plus loose `.dds`/`.tga`/`.mesh`/`.anim` for the watcher). The write is
+additive — your existing patterns survive, and a pattern you set to `false`
+stays `false` — and the confirmation offers one-click Undo. The visible
+trade: search and Quick Open stop listing files under those folders.
 
 ## Reporting a slow session
 

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -94,16 +94,33 @@ schema folders with an extension filter (`.txt`, `.yml`, `.gui`), and the file
 watchers glob the same extensions. A `.dds` never enters it.
 
 VS Code's own machinery is a different story. The built-in file watcher and
-search walk every workspace folder whole, and a game install is ~100k files
-of mostly textures, meshes and audio; a workspace with the game plus dozens
-of mods multiplies that. **`Paradox: Reduce VS Code Indexing Load`** (also a
-button on the big-workspace warning) writes workspace-scoped
+search walk every workspace folder whole, and most of a game install is
+textures, meshes and audio. **`Paradox: Reduce VS Code Indexing Load`** (also
+a button on the big-workspace warning) writes workspace-scoped
 `files.watcherExclude` and `search.exclude` patterns for the asset trees
 (`gfx/`, `map_data/`, `music/`, `sound/`, `soundtrack/`, `dlc/`, `binaries/`,
 plus loose `.dds`/`.tga`/`.mesh`/`.anim` for the watcher). The write is
 additive — your existing patterns survive, and a pattern you set to `false`
 stays `false` — and the confirmation offers one-click Undo. The visible
 trade: search and Quick Open stop listing files under those folders.
+
+Measured 2026-08-27 on the CK3 install (48,481 files) plus AGOT (21,431
+files), warm cache, NVMe, VS Code 1.134 on Windows:
+
+- The patterns remove 51,834 of the 69,912 files (74%).
+- **Find in Files across the workspace: ~110 s without the excludes, ~30 s
+  with them** (ripgrep, the engine VS Code search runs, with the same
+  globs). This is the number that changes daily life. Quick Open
+  enumeration barely moves (250 ms → 80 ms).
+- The file watcher does NOT get cheaper on Windows: its process sat at
+  123 MB vs 124 MB with the excludes, and the initial crawl cost ~0.4 s of
+  CPU either way, because Windows watches a whole root with one recursive
+  OS handle. The watcher half of the command is for Linux, where every
+  directory costs an inotify watch and the game tree can blow the system
+  limit, and for event churn when Steam updates the game mid-session.
+
+So on Windows this command is a search lever, not a memory lever. The memory
+levers are the mod-index settings above, and fewer windows.
 
 ## Reporting a slow session
 

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -48,10 +48,46 @@ workspace: while the index is building there, a single completion request can
 take over a minute, and everything queued behind it (semantic tokens, hover)
 waits with it. It is also most of why that workspace's "time to indexed" reads
 547 s: the scanning is a minority of that and the interactive requests served
-in between are the rest. On the same workspace the first completion after the
-build finished cost 78 s once, after which saves and highlighting were back to
-milliseconds. This is the remaining known cost, it is not fixed, and it is why
-a big workspace feels dead for its first minutes.
+in between are the rest.
+
+### Where that time actually went (2026-08-27)
+
+The row above was measured, not explained. Profiling the server with
+`--cpu-prof` on game + AGOT named three causes, all now fixed:
+
+- **A completion cost seconds because of config resolution, not ranking.**
+  Aggregating the scopes a scripted effect is called from asked "which schema
+  folder is this file in?" once per REFERENCE — 4,124,139 times for 3,944
+  distinct answers — and each miss rebuilt the content-root list (parent mods,
+  playset probes) and walked every schema entry. It is memoized per file now.
+- **That aggregation also scanned the whole reference index** to find the 4%
+  of references that are call sites with a key chain. Those are tracked
+  separately now, and each distinct (root scope, chain) pair is resolved once
+  instead of once per site.
+- **The scan read one file at a time.** A cold read costs about 10 ms per
+  file no matter how big it is, because the cost is the round trip, not the
+  bytes; 80% of a cold startup was spent inside `readFileUtf8` waiting. Batches
+  are read with several reads in flight now.
+
+| operation (game + AGOT) | before | after |
+|---|---|---|
+| completion, first after an index change | 4314 ms | 800 ms |
+| completion, first after a **save** | 4180 ms | 606 ms |
+| completion, cache warm | 20 ms | 18 ms |
+| time to indexed, warm file cache | 32 s | 25 s |
+| time to indexed, cold file cache | 82 s | 70 s |
+
+The save row is the one that decided how the extension felt: the caches above
+are keyed on the index revision, every save changes it, so the next completion
+paid full price EVERY time. Semantic highlighting was never itself slow (1 ms
+throughout) — it was queued behind that completion on the server's single
+thread, which is what "the text stays white for a while" was.
+
+The two cold-cache numbers come from an A/B under the same partial cache
+eviction. A first-ever open on a machine where nothing is cached is colder than
+that and was measured once at 185 s before the change; there is no way to
+reproduce that state on demand, so the honest claim is the 82 → 70 s A/B, with
+the per-file measurements suggesting a larger gap the colder the cache is.
 
 ## Configuring a big workspace
 

--- a/packages/server/src/index/references.ts
+++ b/packages/server/src/index/references.ts
@@ -430,6 +430,16 @@ export class ReferenceIndex {
   private byFile = new Map<string, Reference[]>();
   /** Per-name count of non-call references (the §C2 ranking signal). */
   private rankCounts = new Map<string, number>();
+  /**
+   * Call sites carrying a key chain, per file — the ONLY references the scope
+   * aggregation (buildCallSiteScopes) reads (perf round 2).
+   *
+   * It runs on every index change, i.e. every save, and used to iterate the
+   * whole reference index to find them: measured on game + AGOT, 4,124,139
+   * references of which 175,373 (4%) are chained call sites, so 96% of the
+   * walk was `continue`. Same shape as DefinitionIndex.trackedNames (§B2).
+   */
+  private chainedCallsByFile = new Map<string, Reference[]>();
   revision = 0;
 
   addAll(refs: Reference[]): void {
@@ -442,8 +452,18 @@ export class ReferenceIndex {
       let flist = this.byFile.get(fkey);
       if (!flist) this.byFile.set(fkey, (flist = []));
       flist.push(ref);
+      if (ref.call && ref.chain !== undefined) {
+        let clist = this.chainedCallsByFile.get(fkey);
+        if (!clist) this.chainedCallsByFile.set(fkey, (clist = []));
+        clist.push(ref);
+      }
     }
     if (refs.length > 0) this.revision++;
+  }
+
+  /** Every chained call site, the input buildCallSiteScopes actually wants. */
+  *chainedCalls(): IterableIterator<Reference> {
+    for (const list of this.chainedCallsByFile.values()) yield* list;
   }
 
   /**
@@ -460,6 +480,7 @@ export class ReferenceIndex {
     const refs = this.byFile.get(fkey);
     if (!refs) return;
     this.byFile.delete(fkey);
+    this.chainedCallsByFile.delete(fkey);
     const dropped = new Map<string, Set<Reference>>();
     for (const ref of refs) {
       let set = dropped.get(ref.name);
@@ -524,6 +545,7 @@ export class ReferenceIndex {
     this.byName.clear();
     this.byFile.clear();
     this.rankCounts.clear();
+    this.chainedCallsByFile.clear();
     this.revision++;
   }
 }

--- a/packages/server/src/scopes/varTypes.ts
+++ b/packages/server/src/scopes/varTypes.ts
@@ -117,7 +117,9 @@ export function callSiteScopes(
   const revision = `${data.index.revision}:${data.refIndex.revision}`;
   const cached = callSiteCache.get(data);
   if (cached && cached.revision === revision) return cached.map;
-  const map = buildCallSiteScopes(data.refIndex.all(), data.scopeModel, rootScopesForFile);
+  // chainedCalls(), not all(): the builder skips everything else anyway, and on
+  // a big workspace that skip was 96% of a 4.1M-reference walk (perf round 2).
+  const map = buildCallSiteScopes(data.refIndex.chainedCalls(), data.scopeModel, rootScopesForFile);
   callSiteCache.set(data, { revision, map });
   return map;
 }
@@ -136,9 +138,41 @@ export function buildCallSiteScopes(
   rootScopesForFile: (file: string) => Set<Scope> | null
 ): Map<string, Set<Scope>> {
   const map = new Map<string, Set<Scope>>();
+  /**
+   * (root scopes, chain) → resolution, for the length of this build.
+   *
+   * Call sites repeat their chain relentlessly: an `immediate` or
+   * `option.effect` chain occurs in every event file of a mod, and every file
+   * of one schema folder shares one root-scope Set. Resolving each one from
+   * scratch allocates several Sets per call site, and on game + AGOT that is
+   * 175,373 resolutions collapsing to a few hundred distinct pairs.
+   *
+   * Keyed on the Set's IDENTITY, which is sound because rootScopesForFile
+   * memoizes per file and hands back the same instance (server.ts). A caller
+   * that returned fresh Sets would only lose the sharing, never correctness.
+   * The cached Set is never handed out: both branches below copy it.
+   */
+  const byRoot = new Map<Set<Scope> | null, Map<string, Set<Scope> | null>>();
+  // Call sites arrive grouped by file (ReferenceIndex.chainedCalls), so
+  // remembering the last one answers for a whole file at a time: the lookup
+  // itself has to lower-case a long path, and that measured 1.1 s of a request
+  // when it ran per reference. Correct for ungrouped input too, just slower.
+  let lastFile: string | undefined;
+  let lastRootScopes: Set<Scope> | null = null;
   for (const ref of refs) {
     if (!ref.call || ref.chain === undefined) continue;
-    const resolved = resolveKeyChainScopes(ref.chain.split("."), model, rootScopesForFile(ref.file));
+    if (ref.file !== lastFile) {
+      lastFile = ref.file;
+      lastRootScopes = rootScopesForFile(ref.file);
+    }
+    const rootScopes = lastRootScopes;
+    let byChain = byRoot.get(rootScopes);
+    if (!byChain) byRoot.set(rootScopes, (byChain = new Map()));
+    let resolved = byChain.get(ref.chain);
+    if (resolved === undefined) {
+      resolved = resolveKeyChainScopes(ref.chain.split("."), model, rootScopes);
+      byChain.set(ref.chain, resolved);
+    }
     if (!resolved || resolved.size === 0) continue;
     const prev = map.get(ref.name);
     if (prev) for (const s of resolved) prev.add(s);

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -347,9 +347,42 @@ function readPlaysetCached(modRoot: string): string[] {
   return v;
 }
 
-/** Content roots in precedence order: mod, parents, vanilla. */
+/**
+ * Content roots in precedence order: mod, parents, vanilla.
+ *
+ * Memoized with playsetCache (same lifetime, same clear): this is called once
+ * per REFERENCE by the scope aggregation below, and rebuilding two arrays plus
+ * a playset probe per mod, 4.1M times, was measured as seconds per request
+ * (perf round 2).
+ */
+let contentRootsCache: string[] | null = null;
 function contentRoots(): string[] {
-  return [settings.modPath, ...parentRoots(), settings.gamePath].filter((r): r is string => r !== null);
+  if (contentRootsCache) return contentRootsCache;
+  return (contentRootsCache = [settings.modPath, ...parentRoots(), settings.gamePath].filter(
+    (r): r is string => r !== null
+  ));
+}
+
+/**
+ * Root scopes per FILE, memoized (perf round 2).
+ *
+ * `buildCallSiteScopes` asks for every reference's file, and a mod holds
+ * millions of references across thousands of files: the AGOT corpus measures
+ * 4,124,139 usage sites in 3,944 files, a 1000:1 ratio of calls to distinct
+ * answers. Each miss walks contentRoots, then every schema entry
+ * (classifyFile), then allocates a Set. Cleared with playsetCache, so a
+ * settings or schema change cannot serve a stale answer.
+ *
+ * The cached Set is shared, never copied per call. Safe because the only
+ * consumer, resolveKeyChainScopes, copies it before touching it.
+ */
+const fileRootScopesCache = new Map<string, Set<string> | null>();
+
+/** Drop everything derived from the current settings/schema (reindex path). */
+function clearPathCaches(): void {
+  playsetCache.clear();
+  contentRootsCache = null;
+  fileRootScopesCache.clear();
 }
 
 /** Engine-layer roots shipped next to `<game>`, lowest content priority
@@ -393,11 +426,19 @@ function schemaEntryForFile(fsPath: string): SchemaEntry | null {
   return null;
 }
 
-/** Schema-declared root scopes for the folder a file lives in (AD-5 seed). */
+/** Schema-declared root scopes for the folder a file lives in (AD-5 seed).
+ *  Memoized per file: see fileRootScopesCache. */
 function rootScopesForFile(fsPath: string): Set<string> | null {
+  const key = process.platform === "win32" ? fsPath.toLowerCase() : fsPath;
+  const hit = fileRootScopesCache.get(key);
+  if (hit !== undefined) return hit;
   const entry = schemaEntryForFile(fsPath);
-  if (!entry?.rootScopes || entry.rootScopes.length === 0) return null;
-  return new Set(entry.rootScopes.map((s) => s.toLowerCase()));
+  const scopes =
+    !entry?.rootScopes || entry.rootScopes.length === 0
+      ? null
+      : new Set(entry.rootScopes.map((s) => s.toLowerCase()));
+  fileRootScopesCache.set(key, scopes);
+  return scopes;
 }
 // Static variable-type resolution (scopes/varTypes.ts) resolves root-anchored
 // set_variable values through the set-file's schema root scopes.
@@ -699,6 +740,43 @@ function readFileStripBom(file: string): string | null {
 }
 
 /**
+ * Read a batch of files with several reads in flight (perf round 2).
+ *
+ * The scan used readFileSync per file, so exactly one read was ever
+ * outstanding and every file cost a full disk round trip. That is the whole
+ * difference between a cold and a warm first open: measured on game + AGOT,
+ * time-to-indexed was 185 s cold against 32 s warm, and a CPU profile
+ * attributed 157 s of the cold run (80% of the process) to readFileUtf8
+ * waiting. Reads issued together let the drive overlap them: on a 3,852-file
+ * mod, 437 ms serial against 239 ms with this, warm, where there is no
+ * latency left to hide.
+ *
+ * Bounded by libuv's thread pool (4 by default), so the concurrency here is
+ * an upper bound, not a promise. Order is preserved and a failed read is
+ * `null`, exactly like the serial version it replaces.
+ */
+async function readBatchStripBom(files: string[]): Promise<Array<string | null>> {
+  const out = new Array<string | null>(files.length);
+  let next = 0;
+  const workers = Math.min(16, files.length);
+  await Promise.all(
+    Array.from({ length: workers }, async () => {
+      for (;;) {
+        const i = next++;
+        if (i >= files.length) return;
+        try {
+          const content = await fs.promises.readFile(files[i], "utf8");
+          out[i] = content.replace(/^﻿/, "");
+        } catch {
+          out[i] = null;
+        }
+      }
+    })
+  );
+  return out;
+}
+
+/**
  * Chunked schema-driven folder scan: yields to the event loop between file
  * batches so requests keep flowing, reports progress and aborts when a newer
  * scan supersedes it.
@@ -742,9 +820,11 @@ async function scanRootChunked(
     for (let i = 0; i < files.length; i += BATCH) {
       if (generation !== scanGeneration) return null; // superseded
       const batch = files.slice(i, i + BATCH);
-      for (const file of batch) {
-        const content = readFileStripBom(file);
-        if (content !== null) pushAll(defs, extractDefinitions(content, entry, file, source));
+      const contents = await readBatchStripBom(batch);
+      if (generation !== scanGeneration) return null; // superseded while reading
+      for (let k = 0; k < batch.length; k++) {
+        const content = contents[k];
+        if (content !== null) pushAll(defs, extractDefinitions(content, entry, batch[k], source));
       }
       done += batch.length;
       onProgress?.(totalFiles === 0 ? 100 : Math.round((done / totalFiles) * 100), entry.path);
@@ -782,9 +862,13 @@ async function scanModReferences(
   let refCount = 0;
   for (let i = 0; i < files.length; i += BATCH) {
     if (generation !== scanGeneration) return false;
-    for (const file of files.slice(i, i + BATCH)) {
-      const content = readFileStripBom(file);
+    const batch = files.slice(i, i + BATCH);
+    const contents = await readBatchStripBom(batch);
+    if (generation !== scanGeneration) return false; // superseded while reading
+    for (let k = 0; k < batch.length; k++) {
+      const content = contents[k];
       if (content === null) continue;
+      const file = batch[k];
       const extracted = extractReferences(content, file, source, schema, isEngineToken);
       data.refIndex.addAll(extracted.references);
       if (extracted.implicitDefs.length > 0) data.index.addAll(extracted.implicitDefs);
@@ -836,7 +920,7 @@ function readPlayset(modPath: string): string[] {
 async function buildIndex(): Promise<void> {
   const tBuild = Date.now();
   const generation = ++scanGeneration;
-  playsetCache.clear();
+  clearPathCaches();
   schema = loadSchema([...(settings.modPath ? [settings.modPath] : []), ...workspaceModRoots()], log);
   data.completableKinds = new Set([
     ...schema.entries.filter((e) => e.completable !== false).map((e) => e.kind),

--- a/packages/server/test/perf/indexScaling.test.ts
+++ b/packages/server/test/perf/indexScaling.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Where does a request's time go on a BIG index? (perf round 2)
+ *
+ * The §A3 bench measures the whole server; this one isolates the data
+ * structure, so a fix can be judged in seconds instead of the 9-minute
+ * recipe-2 run. It builds a DefinitionIndex at field scale and times the
+ * primitives the request path actually calls.
+ *
+ * Gated on PX_PERF_SCALING=1: it allocates well over a gigabyte.
+ *   PX_PERF_SCALING=1 npx vitest run packages/server/test/perf/indexScaling.test.ts
+ */
+import { describe, expect, it } from "vitest";
+import { DefinitionIndex } from "../../src/index/indexer";
+import type { Definition, DefSource } from "@px-lsp/protocol/types";
+
+const RUN = process.env.PX_PERF_SCALING === "1";
+
+/**
+ * A synthetic index shaped like the field one: recipe 2 measures 1.36M
+ * definitions, and a mod/parent copy of a vanilla file gives many names more
+ * than one definition (that is what shadow resolution exists for).
+ */
+function buildIndex(defCount: number): { index: DefinitionIndex; names: string[] } {
+  const index = new DefinitionIndex();
+  const kinds = [
+    "loc_key",
+    "event",
+    "trait",
+    "scripted_effect",
+    "scripted_trigger",
+    "decision",
+    "culture",
+    "scripted_list",
+  ];
+  const sources: DefSource[] = ["vanilla", "parent", "mod"];
+  const names: string[] = [];
+  const batch: Definition[] = [];
+  for (let i = 0; i < defCount; i++) {
+    // Every 5th definition re-uses an earlier name (the shadowing case).
+    const nameIdx = i % 5 === 0 && names.length > 0 ? i % names.length : names.length;
+    const name = names[nameIdx] ?? `def_name_${i}`;
+    if (nameIdx === names.length) names.push(name);
+    batch.push({
+      name,
+      kind: kinds[i % kinds.length],
+      file: `C:/root${i % 40}/common/file${i % 900}.txt`,
+      line: i % 500,
+      source: sources[i % 3],
+    });
+    if (batch.length >= 50_000) {
+      index.addAll(batch);
+      batch.length = 0;
+    }
+  }
+  if (batch.length > 0) index.addAll(batch);
+  return { index, names };
+}
+
+function time(label: string, fn: () => number): { label: string; ms: number; produced: number } {
+  const t0 = performance.now();
+  const produced = fn();
+  const ms = performance.now() - t0;
+  return { label, ms: Math.round(ms), produced };
+}
+
+describe.skipIf(!RUN)("index scaling (PX_PERF_SCALING=1)", () => {
+  it(
+    "times the primitives a completion request calls on a field-scale index",
+    { timeout: 15 * 60_000 },
+    () => {
+      const DEFS = 1_400_000;
+      const t0 = performance.now();
+      const { index, names } = buildIndex(DEFS);
+      const buildMs = Math.round(performance.now() - t0);
+      const stats = index.stats();
+      console.log(
+        `built ${stats.total} definitions over ${names.length} distinct names in ${buildMs}ms`
+      );
+
+      const rows: Array<{ label: string; ms: number; produced: number }> = [];
+
+      // What itemsFor() does: entries() with a kind filter, several times.
+      rows.push(
+        time("entries(scripted_list) — one call", () => {
+          let n = 0;
+          for (const _ of index.entries((d) => d.kind === "scripted_list")) n++;
+          return n;
+        })
+      );
+      rows.push(
+        time("entries(scripted_effect|trigger|modifier) — one call", () => {
+          let n = 0;
+          for (const _ of index.entries(
+            (d) =>
+              d.kind === "scripted_effect" ||
+              d.kind === "scripted_trigger" ||
+              d.kind === "scripted_modifier"
+          ))
+            n++;
+          return n;
+        })
+      );
+      rows.push(
+        time("entries(loc_key, mod only) — one call", () => {
+          let n = 0;
+          for (const _ of index.entries((d) => d.kind === "loc_key" && d.source === "mod")) n++;
+          return n;
+        })
+      );
+      // §B2's tracked-kind fast path, for comparison: same answer, only the
+      // names that carry one are visited.
+      rows.push(
+        time("scriptedLists() — the §B2 tracked-name path", () => {
+          let n = 0;
+          for (const _ of index.scriptedLists()) n++;
+          return n;
+        })
+      );
+      // The pure lookup path, which is NOT a full walk.
+      rows.push(
+        time("lookup() x 10,000", () => {
+          let n = 0;
+          for (let i = 0; i < 10_000; i++) n += index.lookup(names[i % names.length]).length;
+          return n;
+        })
+      );
+
+      for (const r of rows) console.log(`  ${r.label.padEnd(52)} ${String(r.ms).padStart(7)} ms  → ${r.produced} items`);
+
+      // A completion request calls entries() SEVEN times (completion.ts).
+      const oneWalk = rows[1].ms;
+      console.log(`\n  7 entries() walks (one completion request) ≈ ${oneWalk * 7} ms`);
+
+      expect(stats.total).toBe(DEFS);
+    }
+  );
+});

--- a/packages/server/test/perf/indexScaling.test.ts
+++ b/packages/server/test/perf/indexScaling.test.ts
@@ -73,9 +73,7 @@ describe.skipIf(!RUN)("index scaling (PX_PERF_SCALING=1)", () => {
       const { index, names } = buildIndex(DEFS);
       const buildMs = Math.round(performance.now() - t0);
       const stats = index.stats();
-      console.log(
-        `built ${stats.total} definitions over ${names.length} distinct names in ${buildMs}ms`
-      );
+      console.log(`built ${stats.total} definitions over ${names.length} distinct names in ${buildMs}ms`);
 
       const rows: Array<{ label: string; ms: number; produced: number }> = [];
 
@@ -92,9 +90,7 @@ describe.skipIf(!RUN)("index scaling (PX_PERF_SCALING=1)", () => {
           let n = 0;
           for (const _ of index.entries(
             (d) =>
-              d.kind === "scripted_effect" ||
-              d.kind === "scripted_trigger" ||
-              d.kind === "scripted_modifier"
+              d.kind === "scripted_effect" || d.kind === "scripted_trigger" || d.kind === "scripted_modifier"
           ))
             n++;
           return n;
@@ -125,7 +121,8 @@ describe.skipIf(!RUN)("index scaling (PX_PERF_SCALING=1)", () => {
         })
       );
 
-      for (const r of rows) console.log(`  ${r.label.padEnd(52)} ${String(r.ms).padStart(7)} ms  → ${r.produced} items`);
+      for (const r of rows)
+        console.log(`  ${r.label.padEnd(52)} ${String(r.ms).padStart(7)} ms  → ${r.produced} items`);
 
       // A completion request calls entries() SEVEN times (completion.ts).
       const oneWalk = rows[1].ms;

--- a/packages/server/test/perf/profileRequests.ts
+++ b/packages/server/test/perf/profileRequests.ts
@@ -125,9 +125,11 @@ const completionPos = { line: 6, character: 3 }; // inside immediate = { }
 
 async function timed(label: string, method: string, params: unknown): Promise<number> {
   const t0 = performance.now();
-  const res: any = await conn.sendRequest(method, params);
+  const res: unknown = await conn.sendRequest(method, params);
   const ms = performance.now() - t0;
-  const count = Array.isArray(res) ? res.length : (res?.items?.length ?? -1);
+  const count = Array.isArray(res)
+    ? res.length
+    : ((res as { items?: unknown[] } | null)?.items?.length ?? -1);
   console.log(`  ${label.padEnd(34)} ${String(Math.round(ms)).padStart(8)} ms   items=${count}`);
   return ms;
 }

--- a/packages/server/test/perf/profileRequests.ts
+++ b/packages/server/test/perf/profileRequests.ts
@@ -1,0 +1,220 @@
+/**
+ * CPU-profile the REQUEST path on a real large workspace (perf round 2).
+ *
+ * The §A3 bench proves the workspace is slow; it does not say which function
+ * is. This driver boots the packaged server under --cpu-prof against real
+ * roots, lets the scan finish UNINTERRUPTED (so the scan's own cost is not
+ * confounded by starved requests), then measures, in order:
+ *
+ *   cold      the first completion after an index change  (cache miss)
+ *   warm      the same request again                      (cache hit)
+ *   afterSave a completion right after a save             (cache invalidated)
+ *
+ * and writes a .cpuprofile for the whole session.
+ *
+ * Usage (from the repo root, after `pnpm run compile`):
+ *   node --experimental-strip-types packages/server/test/perf/profileRequests.ts <outDir> [--agot-x2]
+ */
+import { fork, type ChildProcess } from "child_process";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { createMessageConnection, IPCMessageReader, IPCMessageWriter } from "vscode-jsonrpc/node";
+
+const HERE = path.dirname(new URL(import.meta.url).pathname.replace(/^\/([A-Za-z]:)/, "$1"));
+const SERVER = path.join(HERE, "..", "..", "dist", "server.js");
+const WIKIDOCS = path.join(HERE, "..", "..", "data", "ck3", "wikidocs");
+const devPaths = JSON.parse(
+  fs.readFileSync(path.join(HERE, "..", "..", "..", "..", "dev-paths.json"), "utf8")
+);
+
+const outDir = process.argv[2] ?? path.join(os.tmpdir(), "px-profile");
+const twice = process.argv.includes("--agot-x2");
+fs.mkdirSync(outDir, { recursive: true });
+
+const GAME: string = devPaths.gamePath;
+const CORPUS: string = devPaths.corpusPath;
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+const toUri = (p: string) => "file:///" + p.replace(/\\/g, "/").replace(/^\//, "");
+
+function write(file: string, content: string): string {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, content, "utf8");
+  return file;
+}
+
+// A small synthetic mod holds the edited file: the corpus is never written to.
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "px-prof-"));
+const scratchRoot = path.join(tmp, "scratch-mod");
+write(path.join(scratchRoot, "descriptor.mod"), 'version="1.0"\nname="prof"\nsupported_version="1.16.*"\n');
+const scratchFile = write(
+  path.join(scratchRoot, "events", "prof_events.txt"),
+  [
+    "namespace = prof",
+    "",
+    "prof.1 = {",
+    "\ttype = character_event",
+    "\ttitle = prof.1.t",
+    "\timmediate = {",
+    "\t\tadd_gold = 5",
+    "\t}",
+    "}",
+    "",
+  ].join("\n")
+);
+
+const links: string[] = [];
+const workspaceMods = [CORPUS];
+if (twice) {
+  const copy = path.join(tmp, "agot-copy");
+  fs.symlinkSync(CORPUS, copy, "junction");
+  links.push(copy);
+  workspaceMods.push(copy);
+}
+
+const settings = {
+  gamePath: GAME,
+  logsPath: null,
+  modPath: scratchRoot,
+  parentPaths: [...workspaceMods],
+  workspaceMods,
+  locLanguage: "english",
+  scopeInlayHints: false,
+  diagnosticsIgnore: [],
+  diagnosticsIgnorePatterns: [],
+  diagnosticsVanilla: false,
+  tracePerf: true,
+};
+
+const storageDir = fs.mkdtempSync(path.join(os.tmpdir(), "px-prof-storage-"));
+const child: ChildProcess = fork(SERVER, ["--node-ipc"], {
+  stdio: ["ignore", "pipe", "pipe", "ipc"],
+  silent: true,
+  execArgv: [
+    "--expose-gc",
+    "--max-old-space-size=4096",
+    "--cpu-prof",
+    "--cpu-prof-dir",
+    outDir,
+    "--cpu-prof-name",
+    "server.cpuprofile",
+  ],
+});
+
+const logs: string[] = [];
+child.stderr?.on("data", (b: Buffer) => logs.push(b.toString().trimEnd()));
+
+const conn = createMessageConnection(new IPCMessageReader(child), new IPCMessageWriter(child));
+let indexed = false;
+const perfLines: string[] = [];
+conn.onNotification("window/logMessage", (p: { message: string }) => {
+  logs.push(p.message);
+  if (p.message.startsWith("perf ") || p.message.includes("indexed ")) perfLines.push(p.message);
+});
+conn.onNotification("paradox/status", (p: { indexing: boolean; definitions: number }) => {
+  if (!p.indexing && p.definitions > 0) indexed = true;
+});
+conn.onNotification(() => undefined);
+conn.onRequest(() => null);
+conn.listen();
+
+const uri = toUri(scratchFile);
+const baseText = fs.readFileSync(scratchFile, "utf8");
+const completionPos = { line: 6, character: 3 }; // inside immediate = { }
+
+async function timed(label: string, method: string, params: unknown): Promise<number> {
+  const t0 = performance.now();
+  const res: any = await conn.sendRequest(method, params);
+  const ms = performance.now() - t0;
+  const count = Array.isArray(res) ? res.length : (res?.items?.length ?? -1);
+  console.log(`  ${label.padEnd(34)} ${String(Math.round(ms)).padStart(8)} ms   items=${count}`);
+  return ms;
+}
+
+const results: Record<string, number> = {};
+
+await conn.sendRequest("initialize", {
+  processId: process.pid,
+  rootUri: toUri(scratchRoot),
+  workspaceFolders: [{ uri: toUri(scratchRoot), name: "prof" }],
+  capabilities: {},
+  initializationOptions: {
+    storageDir,
+    wikidocsDir: WIKIDOCS,
+    client: { hoverHtml: true, commands: [], ownFileWatcher: true },
+    settings,
+  },
+});
+const tScan = performance.now();
+await conn.sendNotification("initialized", {});
+void conn.sendNotification("textDocument/didOpen", {
+  textDocument: { uri, languageId: "paradox", version: 1, text: baseText },
+});
+
+console.log(`waiting for the index (roots: game + ${workspaceMods.length} corpus mount(s))…`);
+while (!indexed) await sleep(250); // NO probing: the scan runs uninterrupted
+results.timeToIndexedCleanMs = Math.round(performance.now() - tScan);
+console.log(`index built, uninterrupted: ${results.timeToIndexedCleanMs} ms\n`);
+
+console.log("request timings:");
+results.completionCold = await timed("completion (cold cache)", "textDocument/completion", {
+  textDocument: { uri },
+  position: completionPos,
+});
+results.completionWarm = await timed("completion (warm cache)", "textDocument/completion", {
+  textDocument: { uri },
+  position: completionPos,
+});
+results.semanticTokens = await timed("semanticTokens/full", "textDocument/semanticTokens/full", {
+  textDocument: { uri },
+});
+results.hover = await timed("hover", "textDocument/hover", {
+  textDocument: { uri },
+  position: { line: 6, character: 5 },
+});
+results.documentSymbol = await timed("documentSymbol", "textDocument/documentSymbol", {
+  textDocument: { uri },
+});
+
+// A save invalidates the index revision — the cache-miss path a user hits on
+// EVERY Ctrl+S, which is what "it goes white again after I type" describes.
+const text = `${baseText}\n# profile touch\n`;
+fs.writeFileSync(scratchFile, text, "utf8");
+void conn.sendNotification("textDocument/didChange", {
+  textDocument: { uri, version: 2 },
+  contentChanges: [{ text }],
+});
+void conn.sendNotification("textDocument/didSave", { textDocument: { uri }, text });
+void conn.sendNotification("paradox/modFileChanged", { fsPath: scratchFile });
+await sleep(1200);
+results.completionAfterSave = await timed("completion (after save)", "textDocument/completion", {
+  textDocument: { uri },
+  position: completionPos,
+});
+results.tokensAfterSave = await timed("semanticTokens (after save)", "textDocument/semanticTokens/full", {
+  textDocument: { uri },
+});
+
+fs.writeFileSync(path.join(outDir, "results.json"), JSON.stringify(results, null, 2));
+fs.writeFileSync(path.join(outDir, "server.log"), logs.join("\n"));
+console.log(`\nwrote ${outDir}/results.json and server.log`);
+
+try {
+  await conn.sendRequest("shutdown");
+  void conn.sendNotification("exit");
+} catch {
+  /* already gone */
+}
+await sleep(2500); // let --cpu-prof flush
+if (!child.killed) child.kill();
+for (const l of links) {
+  try {
+    fs.unlinkSync(l);
+  } catch {
+    /* gone */
+  }
+}
+fs.rmSync(tmp, { recursive: true, force: true });
+fs.rmSync(storageDir, { recursive: true, force: true });
+process.exit(0);

--- a/packages/server/test/references.test.ts
+++ b/packages/server/test/references.test.ts
@@ -102,6 +102,45 @@ describe("extractReferences", () => {
   });
 });
 
+describe("ReferenceIndex.chainedCalls (perf round 2)", () => {
+  const callFile = "C:\\mod\\common\\scripted_effects\\calls.txt";
+  const withCalls = () =>
+    extractReferences(
+      "my_event.1 = {\n\timmediate = {\n\t\tmy_effect = yes\n\t\ttrigger_event = ns.1\n\t}\n}\n",
+      callFile,
+      "mod",
+      schema
+    ).references;
+
+  it("yields the chained call sites and nothing else", () => {
+    const idx = new ReferenceIndex();
+    const all = withCalls();
+    idx.addAll(all);
+    const chained = [...idx.chainedCalls()];
+    expect(chained.length).toBeGreaterThan(0);
+    // Exactly the refs the old full-index walk would have kept.
+    expect(chained).toEqual(all.filter((r) => r.call && r.chain !== undefined));
+    expect(chained.every((r) => r.call === true && r.chain !== undefined)).toBe(true);
+    // trigger_event is a value reference, never a call site.
+    expect(chained.find((r) => r.name === "ns.1")).toBeUndefined();
+  });
+
+  it("removeFile drops them, so a deleted call site cannot keep typing scopes", () => {
+    const idx = new ReferenceIndex();
+    idx.addAll(withCalls());
+    expect([...idx.chainedCalls()].length).toBeGreaterThan(0);
+    idx.removeFile(callFile);
+    expect([...idx.chainedCalls()]).toHaveLength(0);
+  });
+
+  it("clear() drops them too", () => {
+    const idx = new ReferenceIndex();
+    idx.addAll(withCalls());
+    idx.clear();
+    expect([...idx.chainedCalls()]).toHaveLength(0);
+  });
+});
+
 describe("ReferenceIndex", () => {
   it("removeFile drops that file's references only", () => {
     const idx = new ReferenceIndex();

--- a/packages/server/test/varScopes.test.ts
+++ b/packages/server/test/varScopes.test.ts
@@ -416,6 +416,100 @@ describe("call-site scope aggregation (scripted effects without @scope)", () => 
     };
     expect(scopesAt("my_effect = {\n\t|\n}", null, ctx)).toEqual(["artifact"]);
   });
+
+  /**
+   * Equivalence guard for the perf-round-2 rewrite of buildCallSiteScopes.
+   *
+   * That rewrite makes three assumptions, any of which would silently change
+   * scope inference (and so completion ranking and hover) rather than fail:
+   * that only chained call sites matter, that a (root scopes, chain) pair
+   * resolves the same wherever it occurs, and that a SHARED root-scope Set is
+   * as good as a fresh one per call. This reimplements the pre-optimization
+   * version — walk everything, resolve every site, fresh Set every time — and
+   * demands an identical map.
+   */
+  it("matches a naive full walk, including shared vs fresh root-scope Sets", () => {
+    // Per-file root scopes, so several distinct Set identities are in play.
+    const rootsOf = (file: string): Set<string> | null => {
+      if (file.startsWith("events/")) return new Set(["character"]);
+      if (file.startsWith("common/province/")) return new Set(["province"]);
+      if (file.startsWith("common/untyped/")) return null; // unknown root
+      return new Set(["character", "landed_title"]);
+    };
+    // The optimized path is handed ONE shared Set per file, as server.ts's
+    // memoized rootScopesForFile now does.
+    const shared = new Map<string, Set<string> | null>();
+    const sharedRoots = (file: string) => {
+      if (!shared.has(file)) shared.set(file, rootsOf(file));
+      return shared.get(file)!;
+    };
+    // The naive path gets a fresh Set every single call, as the old code did.
+    const freshRoots = (file: string) => {
+      const r = rootsOf(file);
+      return r ? new Set(r) : null;
+    };
+
+    const files = [
+      "events/a.txt",
+      "events/b.txt",
+      "common/province/p.txt",
+      "common/untyped/u.txt",
+      "common/other/o.txt",
+    ];
+    const chains = [
+      "immediate",
+      "immediate.every_held_title",
+      "immediate.scope:mystery", // unresolvable: must contribute nothing
+      "immediate.liege.culture",
+      "", // top-level chain
+      "immediate.random_list",
+    ];
+    // Repeat the same (file, chain) pairs so the memo is actually exercised,
+    // and interleave files so the per-file hoist sees the value change back.
+    const refs = [];
+    for (let round = 0; round < 3; round++) {
+      for (const file of files) {
+        for (let c = 0; c < chains.length; c++) {
+          refs.push(callRef(`eff_${c % 4}`, chains[c], file));
+        }
+      }
+    }
+    // TWO names sharing ONE chain, in this order, inside one file. This is the
+    // only shape that catches a memoized Set being handed out instead of
+    // copied: `poll_a` takes the cached resolution of "immediate", its second
+    // call site unions "landed_title" INTO that same object, and `poll_b` then
+    // reads the corrupted entry. With each chain used by a single name the
+    // corruption is self-consistent and invisible, which is how the first
+    // version of this test passed against that bug.
+    refs.push(callRef("poll_a", "immediate", "events/a.txt"));
+    refs.push(callRef("poll_a", "immediate.every_held_title", "events/a.txt"));
+    refs.push(callRef("poll_b", "immediate", "events/a.txt"));
+    // Non-call and chain-less references: the optimized path never sees these
+    // (ReferenceIndex filters them out), the naive one must skip them itself.
+    const noise = refs.slice(0, 5).map((r) => ({ ...r, call: false as const }));
+    const chainless = refs.slice(5, 9).map((r) => {
+      const { chain: _drop, ...rest } = r;
+      return rest as typeof r;
+    });
+
+    const naive = new Map<string, Set<string>>();
+    for (const ref of [...refs, ...noise, ...chainless]) {
+      if (!ref.call || ref.chain === undefined) continue;
+      const resolved = resolveKeyChainScopes(ref.chain.split("."), model, freshRoots(ref.file));
+      if (!resolved || resolved.size === 0) continue;
+      const prev = naive.get(ref.name);
+      if (prev) for (const s of resolved) prev.add(s);
+      else naive.set(ref.name, new Set(resolved));
+    }
+
+    const optimized = buildCallSiteScopes(refs, model, sharedRoots);
+
+    expect(optimized.size).toBe(naive.size);
+    expect(optimized.size).toBeGreaterThan(0); // the fixture must actually resolve
+    for (const [name, scopes] of naive) {
+      expect([...(optimized.get(name) ?? [])].sort(), `scopes of ${name}`).toEqual([...scopes].sort());
+    }
+  });
 });
 
 describe("collectSavedScopeTypes: save_temporary_value_as", () => {

--- a/packages/vscode/CHANGELOG.md
+++ b/packages/vscode/CHANGELOG.md
@@ -6,15 +6,20 @@
 
 - **`Paradox: Reduce VS Code Indexing Load`** for large workspaces (field
   report: game install + 40 mods). The toolkit's own index already skips
-  binary files, but VS Code's built-in file watcher and search crawl every
-  workspace folder whole — a game install is ~100k files of mostly
-  `.dds`/mesh/audio. The command writes workspace-scoped
-  `files.watcherExclude` and `search.exclude` patterns for the asset trees
-  (`gfx/`, `map_data/`, `music/`, `sound/`, `soundtrack/`, `dlc/`,
-  `binaries/`, plus loose `.dds`/`.tga`/`.mesh`/`.anim` for the watcher).
-  Additive and undoable: existing patterns survive, a pattern set to `false`
-  stays `false`, and the confirmation offers one-click Undo. Also a button on
-  the big-workspace warning.
+  binary files, but VS Code's built-in search and file watcher crawl every
+  workspace folder whole, and most of a game install is `.dds`/mesh/audio.
+  The command writes workspace-scoped `search.exclude` and
+  `files.watcherExclude` patterns for the asset trees (`gfx/`, `map_data/`,
+  `music/`, `sound/`, `soundtrack/`, `dlc/`, `binaries/`, plus loose
+  `.dds`/`.tga`/`.mesh`/`.anim` for the watcher). Measured on game + AGOT
+  (69,912 files, 74% removed by the patterns): Find in Files drops from
+  ~110 s to ~30 s. The watcher half matters on Linux (inotify watch per
+  directory) and against Steam-update churn; on Windows the watcher costs
+  the same either way (one recursive OS handle per root — measured 123 vs
+  124 MB). Additive and undoable: existing patterns survive, a pattern set
+  to `false` stays `false`, and the confirmation offers one-click Undo.
+  Also a button on the big-workspace warning. Numbers in
+  `docs/PERFORMANCE.md`.
 - **The exclude picker offers "Keep as Read-Only Context".** Excluding a mod
   removes it entirely; the new follow-up moves newly excluded mods into
   `px.parentMods` instead, indexing them like dependency parents: completion,

--- a/packages/vscode/CHANGELOG.md
+++ b/packages/vscode/CHANGELOG.md
@@ -19,19 +19,19 @@
 - **`Paradox: Reduce VS Code Indexing Load`** for large workspaces (field
   report: game install + 40 mods). The toolkit's own index already skips
   binary files, but VS Code's built-in search and file watcher crawl every
-  workspace folder whole, and most of a game install is `.dds`/mesh/audio.
-  The command writes workspace-scoped `search.exclude` and
-  `files.watcherExclude` patterns for the asset trees (`gfx/`, `map_data/`,
-  `music/`, `sound/`, `soundtrack/`, `dlc/`, `binaries/`, plus loose
-  `.dds`/`.tga`/`.mesh`/`.anim` for the watcher). Measured on game + AGOT
-  (69,912 files, 74% removed by the patterns): Find in Files drops from
-  ~110 s to ~30 s. The watcher half matters on Linux (inotify watch per
-  directory) and against Steam-update churn; on Windows the watcher costs
-  the same either way (one recursive OS handle per root — measured 123 vs
-  124 MB). Additive and undoable: existing patterns survive, a pattern set
-  to `false` stays `false`, and the confirmation offers one-click Undo.
-  Also a button on the big-workspace warning. Numbers in
-  `docs/PERFORMANCE.md`.
+  workspace folder whole, and 62% of a game install is textures, meshes and
+  audio. The command writes workspace-scoped `search.exclude` and
+  `files.watcherExclude` patterns for binary EXTENSIONS (`.dds`, `.tga`,
+  `.mesh`, `.anim`, `.png`, `.bk2`, `.bank`, `.wav`, `.ttf`, `.otf`).
+  Measured on game + AGOT (69,912 files, 43,067 skipped): whole-workspace
+  Find in Files goes from 1.7 s warm (up to 106 s when the binaries are not
+  in the OS cache) to a stable 0.65 s. Patterns match extensions only, never
+  directories, so script under `gfx/`, `music/` or `dlc/` stays searchable
+  and still re-indexes on save; a test enforces that. Additive and undoable:
+  existing patterns survive, a pattern set to `false` stays `false`, and the
+  confirmation offers one-click Undo. Also a button on the big-workspace
+  warning. Numbers in `docs/PERFORMANCE.md`.
+
 - **The exclude picker offers "Keep as Read-Only Context".** Excluding a mod
   removes it entirely; the new follow-up moves newly excluded mods into
   `px.parentMods` instead, indexing them like dependency parents: completion,

--- a/packages/vscode/CHANGELOG.md
+++ b/packages/vscode/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+### Fixed
+
+- **Values no longer render colourless while the server catches up.** Bare
+  identifiers in value position (`has_trait = brave`, entries of
+  `traits = { … }`) had no TextMate scope, so they showed the theme's
+  default foreground until the language server's semantic tokens arrived —
+  on a big workspace or during the initial index build, that is the "text
+  stays white for a while before it gets colour coded" report. A catch-all
+  grammar rule now gives them a base string colour immediately, in all
+  games and .gui files; semantic tokens refine it as before once the index
+  answers.
+
 ### Added
 
 - **`Paradox: Reduce VS Code Indexing Load`** for large workspaces (field

--- a/packages/vscode/CHANGELOG.md
+++ b/packages/vscode/CHANGELOG.md
@@ -4,6 +4,20 @@
 
 ### Fixed
 
+- **Typing and saving no longer stall on a large workspace.** Profiling the
+  server on the game plus AGOT found that the first completion after any
+  index change cost 4.3 s, and that a save invalidates exactly the caches
+  involved — so every Ctrl+S made the next completion pay full price. Three
+  causes, all fixed: the scope aggregation resolved "which schema folder is
+  this file in" once per reference (4.1M times for 3,944 distinct answers,
+  each rebuilding the parent-mod list), it scanned the entire reference
+  index to find the 4% that are call sites, and the file scan read one file
+  at a time. Measured on game + AGOT: completion after a save 4180 ms →
+  606 ms, first completion after an index change 4314 ms → 800 ms, time to
+  indexed 32 s → 25 s warm and 82 s → 70 s cold. Semantic highlighting was
+  always 1 ms; it was queued behind the completion, which is why text sat
+  colourless. Numbers and method in `docs/PERFORMANCE.md`.
+
 - **Values no longer render colourless while the server catches up.** Bare
   identifiers in value position (`has_trait = brave`, entries of
   `traits = { … }`) had no TextMate scope, so they showed the theme's

--- a/packages/vscode/CHANGELOG.md
+++ b/packages/vscode/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- **`Paradox: Reduce VS Code Indexing Load`** for large workspaces (field
+  report: game install + 40 mods). The toolkit's own index already skips
+  binary files, but VS Code's built-in file watcher and search crawl every
+  workspace folder whole — a game install is ~100k files of mostly
+  `.dds`/mesh/audio. The command writes workspace-scoped
+  `files.watcherExclude` and `search.exclude` patterns for the asset trees
+  (`gfx/`, `map_data/`, `music/`, `sound/`, `soundtrack/`, `dlc/`,
+  `binaries/`, plus loose `.dds`/`.tga`/`.mesh`/`.anim` for the watcher).
+  Additive and undoable: existing patterns survive, a pattern set to `false`
+  stays `false`, and the confirmation offers one-click Undo. Also a button on
+  the big-workspace warning.
+- **The exclude picker offers "Keep as Read-Only Context".** Excluding a mod
+  removes it entirely; the new follow-up moves newly excluded mods into
+  `px.parentMods` instead, indexing them like dependency parents: completion,
+  hover and go-to-definition still see their content, without the reference
+  index (the expensive half). The right tier for vanilla-copy packs (an
+  unofficial patch) and framework mods you load but never edit. Un-excluding
+  a mod pulls it back out of `px.parentMods`. `docs/PERFORMANCE.md` explains
+  the tiers.
+
 ## 0.3.3 (beta) - tiger download fix
 
 ### Fixed

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -270,6 +270,12 @@
         "icon": "$(eye-closed)"
       },
       {
+        "command": "px.reduceEditorLoad",
+        "category": "Paradox",
+        "title": "Reduce VS Code Indexing Load (exclude game assets)",
+        "icon": "$(dashboard)"
+      },
+      {
         "command": "px.addDependencyMod",
         "category": "Paradox",
         "title": "Add Dependency Mod (parent mod)",
@@ -803,6 +809,10 @@
         },
         {
           "command": "px.excludeMods",
+          "when": "px.isCk3Workspace"
+        },
+        {
+          "command": "px.reduceEditorLoad",
           "when": "px.isCk3Workspace"
         },
         {

--- a/packages/vscode/src/editorExcludes.ts
+++ b/packages/vscode/src/editorExcludes.ts
@@ -1,36 +1,52 @@
 /**
- * Exclude patterns that keep VS CODE ITSELF from crawling game assets.
+ * Exclude patterns that keep VS CODE ITSELF from crawling game binaries.
  *
  * The toolkit's own index never reads binaries — the definition scan walks
  * schema folders with an extension filter, and the client watchers glob only
- * the txt/yml/gui/mod extensions — but the editor's built-in file watcher and
- * search walk every workspace folder whole. A game install is ~100k files of
- * mostly .dds/.mesh/audio, and the field-report workspace (game + 40 mods)
- * multiplies that. `files.watcherExclude` and `search.exclude` are the two
- * knobs VS Code offers, both workspace-writable, both object-valued and
- * merged across scopes, so adding keys at workspace scope never erases the
- * defaults (.git, node_modules).
+ * the txt/yml/gui/mod extensions — but the editor's built-in search and file
+ * watcher walk every workspace folder whole. In a game install plus AGOT that
+ * is 43,067 of 69,912 files (62%) spent on textures, meshes and audio, and a
+ * whole-workspace Find in Files pays for reading them: measured 0.65 s with
+ * these patterns against 1.7 s warm and 106 s once the binaries have fallen
+ * out of the OS cache (2026-08-27, NVMe, warm-cache best case for both).
+ *
+ * BY EXTENSION, NEVER BY DIRECTORY. The obvious version of this excluded
+ * whole trees: gfx, music, dlc and friends. That is wrong, because those
+ * trees hold real script. CK3 indexes seven SCHEMA folders under gfx/
+ * alone (portrait_modifiers, court_scene, scripted_illustrations, …), and
+ * game + AGOT hold 584 script files under gfx/, 47 under music/ and 3,537
+ * under dlc/. A directory exclude hides them from search AND suppresses the
+ * watcher events that re-index them on save. An extension exclude cannot:
+ * every listed extension is a format the schema never maps and the parser
+ * never reads. `editorExcludesSafety.test.ts` enforces that.
+ *
+ * `files.watcherExclude` and `search.exclude` are the two knobs VS Code
+ * offers, both workspace-writable, both object-valued and merged across
+ * scopes, so adding keys at workspace scope never erases the defaults
+ * (.git, node_modules).
  *
  * No `vscode` imports: merge planning is unit-tested in plain Node.
  */
 
-/** Asset directories every Jomini game ships, in the install and in mods. */
-const ASSET_DIRS = ["gfx", "map_data", "music", "sound", "soundtrack", "dlc", "binaries"];
+/**
+ * Binary formats no Paradox game stores script in. Extensions only — see the
+ * directory warning above. `.asset` and `.particle2` are deliberately absent:
+ * they are text, and modders search them for entity and particle names.
+ */
+export const BINARY_EXTS = ["dds", "tga", "mesh", "anim", "png", "bk2", "bank", "wav", "ttf", "otf"] as const;
 
-/** Binary formats that also appear outside those directories. */
-const ASSET_EXTS = ["dds", "tga", "mesh", "anim"];
+const patterns = BINARY_EXTS.map((e) => `**/*.${e}`);
 
-/** For the file watcher: directories plus stray binaries. Watching them buys
- * nothing (the toolkit never indexes them; editors reload on focus anyway). */
-export const WATCHER_EXCLUDES: string[] = [
-  ...ASSET_DIRS.map((d) => `**/${d}/**`),
-  ...ASSET_EXTS.map((e) => `**/*.${e}`),
-];
+/**
+ * For the file watcher. On Windows this does not shrink the watcher (one
+ * recursive handle per root either way, measured 123 vs 124 MB), but it keeps
+ * a Steam update that rewrites 27k textures from turning into 27k events the
+ * editor has to fan out.
+ */
+export const WATCHER_EXCLUDES: string[] = patterns;
 
-/** For search: directories only. `search.exclude` also filters Quick Open,
- * and dropping whole asset trees is the win; hiding every *.dds by extension
- * would additionally hide loose textures users still open by name. */
-export const SEARCH_EXCLUDES: string[] = ASSET_DIRS.map((d) => `**/${d}/**`);
+/** For search: the same list. This is where the measured win is. */
+export const SEARCH_EXCLUDES: string[] = patterns;
 
 export interface ExcludePlan {
   /** New workspace-scope value, or null when there is nothing to add. */

--- a/packages/vscode/src/editorExcludes.ts
+++ b/packages/vscode/src/editorExcludes.ts
@@ -1,0 +1,59 @@
+/**
+ * Exclude patterns that keep VS CODE ITSELF from crawling game assets.
+ *
+ * The toolkit's own index never reads binaries — the definition scan walks
+ * schema folders with an extension filter, and the client watchers glob only
+ * the txt/yml/gui/mod extensions — but the editor's built-in file watcher and
+ * search walk every workspace folder whole. A game install is ~100k files of
+ * mostly .dds/.mesh/audio, and the field-report workspace (game + 40 mods)
+ * multiplies that. `files.watcherExclude` and `search.exclude` are the two
+ * knobs VS Code offers, both workspace-writable, both object-valued and
+ * merged across scopes, so adding keys at workspace scope never erases the
+ * defaults (.git, node_modules).
+ *
+ * No `vscode` imports: merge planning is unit-tested in plain Node.
+ */
+
+/** Asset directories every Jomini game ships, in the install and in mods. */
+const ASSET_DIRS = ["gfx", "map_data", "music", "sound", "soundtrack", "dlc", "binaries"];
+
+/** Binary formats that also appear outside those directories. */
+const ASSET_EXTS = ["dds", "tga", "mesh", "anim"];
+
+/** For the file watcher: directories plus stray binaries. Watching them buys
+ * nothing (the toolkit never indexes them; editors reload on focus anyway). */
+export const WATCHER_EXCLUDES: string[] = [
+  ...ASSET_DIRS.map((d) => `**/${d}/**`),
+  ...ASSET_EXTS.map((e) => `**/*.${e}`),
+];
+
+/** For search: directories only. `search.exclude` also filters Quick Open,
+ * and dropping whole asset trees is the win; hiding every *.dds by extension
+ * would additionally hide loose textures users still open by name. */
+export const SEARCH_EXCLUDES: string[] = ASSET_DIRS.map((d) => `**/${d}/**`);
+
+export interface ExcludePlan {
+  /** New workspace-scope value, or null when there is nothing to add. */
+  value: Record<string, unknown> | null;
+  /** The patterns the plan adds. */
+  added: string[];
+}
+
+/**
+ * Additions for one exclude setting. `effective` is the merged view across
+ * scopes: a pattern already present anywhere — true from defaults or user
+ * settings, or false by the user's explicit choice — is left alone. The new
+ * value keeps every existing workspace entry verbatim (search.exclude values
+ * may be `{ "when": … }` objects, not just booleans).
+ */
+export function planExcludes(
+  effective: Record<string, unknown> | undefined,
+  workspaceValue: Record<string, unknown> | undefined,
+  patterns: string[]
+): ExcludePlan {
+  const added = patterns.filter((p) => !(effective && p in effective));
+  if (added.length === 0) return { value: null, added };
+  const value: Record<string, unknown> = { ...(workspaceValue ?? {}) };
+  for (const p of added) value[p] = true;
+  return { value, added };
+}

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -57,6 +57,7 @@ import { ErrorLogWatcher, launchGameDebugCommand } from "./errorLog";
 import { serverHeapMb } from "./serverHeap";
 import { planWatchRoots } from "./watchRoots";
 import { bigWorkspaceWarning, measureWorkspace } from "./bigWorkspace";
+import { reduceEditorLoadCommand } from "./reduceEditorLoad";
 import { translateNextCommand } from "./translationLoop";
 import { newContentCommand } from "./scaffold/command";
 import { registerDescriptorMod } from "./descriptorMod";
@@ -198,9 +199,16 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       if (!context.workspaceState.get<boolean>("px.bigWorkspaceNotice")) {
         void context.workspaceState.update("px.bigWorkspaceNotice", true);
         void vscode.window
-          .showWarningMessage(`Paradox Modding Toolkit: ${bigWorkspace}`, "Exclude Mods...", "Settings")
+          .showWarningMessage(
+            `Paradox Modding Toolkit: ${bigWorkspace}`,
+            "Exclude Mods...",
+            "Reduce VS Code Load",
+            "Settings"
+          )
           .then((choice) => {
             if (choice === "Exclude Mods...") void vscode.commands.executeCommand("px.excludeMods");
+            else if (choice === "Reduce VS Code Load")
+              void vscode.commands.executeCommand("px.reduceEditorLoad");
             else if (choice === "Settings")
               void vscode.commands.executeCommand("workbench.action.openSettings", "px.excludedMods");
           });
@@ -703,6 +711,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     vscode.commands.registerCommand("px.addDependencyMod", () =>
       addDependencyModCommand(cfg, views.focusRoot())
     ),
+    vscode.commands.registerCommand("px.reduceEditorLoad", () => reduceEditorLoadCommand()),
     vscode.commands.registerCommand("px.showDependencies", async () => {
       const editor = vscode.window.activeTextEditor;
       if (!editor || !isScriptLang(editor.document.languageId)) {

--- a/packages/vscode/src/reduceEditorLoad.ts
+++ b/packages/vscode/src/reduceEditorLoad.ts
@@ -20,7 +20,7 @@ export async function reduceEditorLoadCommand(): Promise<void> {
 
   if (watcherPlan.value === null && searchPlan.value === null) {
     void vscode.window.showInformationMessage(
-      "Paradox Modding Toolkit: game assets are already excluded from VS Code's file watcher and search " +
+      "Paradox Modding Toolkit: game binaries are already excluded from VS Code's search and file watcher " +
         "in this workspace. Nothing to change."
     );
     return;
@@ -33,9 +33,9 @@ export async function reduceEditorLoadCommand(): Promise<void> {
   const n = watcherPlan.added.length + searchPlan.added.length;
   const choice = await vscode.window.showInformationMessage(
     `Paradox Modding Toolkit: added ${n} exclude pattern(s) to this workspace's settings. VS Code's ` +
-      "file watcher and search now skip game asset folders (gfx, map_data, music, sound, dlc, binaries) " +
-      "and loose binary files. The toolkit's own index was already skipping them. Search and Quick Open " +
-      "no longer list files in those folders.",
+      "search and file watcher now skip binary files (.dds, .mesh, .anim, audio, fonts), which are 62% " +
+      "of a game install. Find in Files gets several times faster. Script is never excluded: the " +
+      "patterns match binary extensions only, so files under gfx/, music/ or dlc/ stay searchable.",
     "Undo",
     "Open Settings"
   );

--- a/packages/vscode/src/reduceEditorLoad.ts
+++ b/packages/vscode/src/reduceEditorLoad.ts
@@ -1,0 +1,48 @@
+/**
+ * `Paradox: Reduce VS Code Indexing Load`: writes `files.watcherExclude` and
+ * `search.exclude` patterns for game asset trees into the WORKSPACE settings.
+ * See editorExcludes.ts for why this exists and what the patterns are. The
+ * write is additive (object settings merge across scopes, and the plan keeps
+ * every existing workspace entry), announced, and undoable in one click.
+ */
+import * as vscode from "vscode";
+import { planExcludes, SEARCH_EXCLUDES, WATCHER_EXCLUDES } from "./editorExcludes";
+
+type Obj = Record<string, unknown> | undefined;
+
+export async function reduceEditorLoadCommand(): Promise<void> {
+  const files = vscode.workspace.getConfiguration("files");
+  const search = vscode.workspace.getConfiguration("search");
+  const beforeWatcher = files.inspect<Record<string, unknown>>("watcherExclude")?.workspaceValue;
+  const beforeSearch = search.inspect<Record<string, unknown>>("exclude")?.workspaceValue;
+  const watcherPlan = planExcludes(files.get<Obj>("watcherExclude"), beforeWatcher, WATCHER_EXCLUDES);
+  const searchPlan = planExcludes(search.get<Obj>("exclude"), beforeSearch, SEARCH_EXCLUDES);
+
+  if (watcherPlan.value === null && searchPlan.value === null) {
+    void vscode.window.showInformationMessage(
+      "Paradox Modding Toolkit: game assets are already excluded from VS Code's file watcher and search " +
+        "in this workspace. Nothing to change."
+    );
+    return;
+  }
+
+  const target = vscode.ConfigurationTarget.Workspace;
+  if (watcherPlan.value !== null) await files.update("watcherExclude", watcherPlan.value, target);
+  if (searchPlan.value !== null) await search.update("exclude", searchPlan.value, target);
+
+  const n = watcherPlan.added.length + searchPlan.added.length;
+  const choice = await vscode.window.showInformationMessage(
+    `Paradox Modding Toolkit: added ${n} exclude pattern(s) to this workspace's settings. VS Code's ` +
+      "file watcher and search now skip game asset folders (gfx, map_data, music, sound, dlc, binaries) " +
+      "and loose binary files. The toolkit's own index was already skipping them. Search and Quick Open " +
+      "no longer list files in those folders.",
+    "Undo",
+    "Open Settings"
+  );
+  if (choice === "Undo") {
+    if (watcherPlan.value !== null) await files.update("watcherExclude", beforeWatcher, target);
+    if (searchPlan.value !== null) await search.update("exclude", beforeSearch, target);
+  } else if (choice === "Open Settings") {
+    void vscode.commands.executeCommand("workbench.action.openSettings", "files.watcherExclude");
+  }
+}

--- a/packages/vscode/src/views.ts
+++ b/packages/vscode/src/views.ts
@@ -22,6 +22,7 @@ import {
   type OverrideInfo,
 } from "@px-lsp/protocol/protocol";
 import { readModName } from "@px-lsp/protocol/modName";
+import { sanitizeStringList } from "@px-lsp/protocol/suppression";
 import { allWorkspaceModCandidates, modRootFor, type PxConfig } from "./config";
 
 /**
@@ -555,11 +556,48 @@ export function registerPxViews(
         placeHolder: "Checked mods are skipped entirely: no completion, navigation, diagnostics or views",
       });
       if (!picked) return;
-      await vscode.workspace.getConfiguration("px").update(
-        "excludedMods",
-        picked.map((i) => i.root),
-        vscode.ConfigurationTarget.Workspace
+      const chosen = picked.map((i) => i.root);
+      const pxCfg = vscode.workspace.getConfiguration("px");
+      await pxCfg.update("excludedMods", chosen, vscode.ConfigurationTarget.Workspace);
+
+      // Excluding is all-or-nothing; the cheaper middle ground is indexing a
+      // mod like a dependency parent (definitions for completion/hover/
+      // navigation, no reference index — the expensive half; vanilla-copy
+      // packs like the Unofficial Patch are exactly this case). That is just
+      // px.parentMods, so offer to move newly excluded mods there, and pull
+      // un-excluded mods back out (a parentMods entry for a fully indexed
+      // workspace mod is dead weight).
+      const before = new Set(cfg.excludedMods.map((p) => p.toLowerCase()));
+      const chosenKeys = new Set(chosen.map((p) => p.toLowerCase()));
+      const parents = sanitizeStringList(pxCfg.get("parentMods"));
+      const unexcluded = parents.filter(
+        (p) => before.has(p.toLowerCase()) && !chosenKeys.has(p.toLowerCase())
       );
+      if (unexcluded.length > 0) {
+        await pxCfg.update(
+          "parentMods",
+          parents.filter((p) => !unexcluded.includes(p)),
+          vscode.ConfigurationTarget.Workspace
+        );
+      }
+      const newly = chosen.filter((r) => !before.has(r.toLowerCase()));
+      if (newly.length > 0) {
+        const parentKeys = new Set(parents.map((p) => p.toLowerCase()));
+        const movable = newly.filter((r) => !parentKeys.has(r.toLowerCase()));
+        if (movable.length > 0) {
+          const keep = await vscode.window.showInformationMessage(
+            `Paradox Modding Toolkit: excluded ${newly.length} mod(s) from indexing. Keep them as ` +
+              "read-only context instead? They are then indexed like dependency mods: completion, " +
+              "hover and go-to-definition still see their content, at a fraction of the memory " +
+              "(no reference index, diagnostics or views).",
+            "Keep as Read-Only Context"
+          );
+          if (keep === "Keep as Read-Only Context") {
+            const latest = sanitizeStringList(pxCfg.get("parentMods"));
+            await pxCfg.update("parentMods", [...latest, ...movable], vscode.ConfigurationTarget.Workspace);
+          }
+        }
+      }
     })
   );
 

--- a/packages/vscode/syntaxes/paradox.tmLanguage.json
+++ b/packages/vscode/syntaxes/paradox.tmLanguage.json
@@ -20,6 +20,7 @@
     { "include": "#control" },
     { "include": "#block-key" },
     { "include": "#loc-property" },
+    { "include": "#value-ref" },
     { "include": "#operator" },
     { "include": "#braces" }
   ],
@@ -122,6 +123,11 @@
       "comment": "Any other key on the left of = reads as a property; keeps key/value texture visible",
       "name": "variable.other.property.paradox",
       "match": "\\b[A-Za-z_][A-Za-z0-9_.\\-]*\\s*(?=\\??=)"
+    },
+    "value-ref": {
+      "comment": "Catch-all for bare identifiers in value position (trait = brave, list entries). Without a base scope they render default-foreground until the server's semantic tokens land — the 'text stays white for a while' reports. Same string colour family as asset-ref; semantic tokens refine it once the index answers.",
+      "name": "string.unquoted.value.paradox",
+      "match": "\\b[A-Za-z_][A-Za-z0-9_.\\-]*\\b"
     },
     "operator": {
       "name": "keyword.operator.comparison.paradox",

--- a/packages/vscode/test/editorExcludes.test.ts
+++ b/packages/vscode/test/editorExcludes.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Merge planning for `px.reduceEditorLoad`: adds only patterns no scope has
+ * decided yet, and never drops or rewrites existing workspace entries.
+ */
+import { describe, expect, it } from "vitest";
+import { planExcludes, SEARCH_EXCLUDES, WATCHER_EXCLUDES } from "../src/editorExcludes";
+
+describe("planExcludes", () => {
+  it("adds every pattern to an empty workspace value", () => {
+    const plan = planExcludes({}, undefined, WATCHER_EXCLUDES);
+    expect(plan.added).toEqual(WATCHER_EXCLUDES);
+    for (const p of WATCHER_EXCLUDES) expect(plan.value?.[p]).toBe(true);
+  });
+
+  it("skips patterns already decided in ANY scope, true or false", () => {
+    // "**/gfx/**": false is the user's explicit choice; it must survive as-is.
+    const effective = { "**/gfx/**": false, "**/*.dds": true, "**/.git": true };
+    const workspace = { "**/gfx/**": false };
+    const plan = planExcludes(effective, workspace, WATCHER_EXCLUDES);
+    expect(plan.added).not.toContain("**/gfx/**");
+    expect(plan.added).not.toContain("**/*.dds");
+    expect(plan.value?.["**/gfx/**"]).toBe(false);
+  });
+
+  it("keeps non-boolean workspace entries verbatim (search.exclude when-clauses)", () => {
+    const when = { when: "$(basename).ts" };
+    const plan = planExcludes({ "**/*.js": when }, { "**/*.js": when }, SEARCH_EXCLUDES);
+    expect(plan.value?.["**/*.js"]).toBe(when);
+  });
+
+  it("returns a null value when everything is already excluded", () => {
+    const effective = Object.fromEntries(SEARCH_EXCLUDES.map((p) => [p, true]));
+    const plan = planExcludes(effective, effective, SEARCH_EXCLUDES);
+    expect(plan.value).toBeNull();
+    expect(plan.added).toEqual([]);
+  });
+});

--- a/packages/vscode/test/editorExcludesSafety.test.ts
+++ b/packages/vscode/test/editorExcludesSafety.test.ts
@@ -1,0 +1,64 @@
+/**
+ * The guard for the mistake this feature shipped with first: exclude patterns
+ * written as DIRECTORIES (a glob over the whole gfx tree) hide real script from search and, worse,
+ * suppress the watcher events that re-index a file on save. CK3 maps seven
+ * schema folders under gfx/, and a real workspace holds hundreds of script
+ * files under gfx/, music/ and dlc/.
+ *
+ * So: every pattern must be extension-scoped, and no pattern may match a file
+ * in any schema folder of any supported game, or a .txt/.yml/.gui/.mod at all.
+ */
+import { describe, expect, it } from "vitest";
+import { SEARCH_EXCLUDES, WATCHER_EXCLUDES, BINARY_EXTS } from "../src/editorExcludes";
+import { CK3_SCHEMA } from "@px-lsp/server/games/ck3/schema";
+import { VIC3_SCHEMA } from "@px-lsp/server/games/vic3/schema";
+
+const ALL = [...new Set([...WATCHER_EXCLUDES, ...SEARCH_EXCLUDES])];
+
+/** Our patterns are all extension globs; this reads the extension back. */
+const extOf = (pattern: string): string | null => {
+  const m = /^\*\*\/\*\.([A-Za-z0-9]+)$/.exec(pattern);
+  return m ? m[1].toLowerCase() : null;
+};
+
+describe("editor exclude patterns are safe", () => {
+  it("are all extension patterns, never directory patterns", () => {
+    for (const p of ALL) {
+      expect(extOf(p), `${p} is not an extension pattern`).not.toBeNull();
+    }
+  });
+
+  it("never exclude an extension the toolkit indexes", () => {
+    const indexed = new Set(["txt", "yml", "gui", "mod", "info", "csv", "json", "asset"]);
+    for (const p of ALL) {
+      expect(indexed.has(extOf(p)!), `${p} would hide indexed content`).toBe(false);
+    }
+  });
+
+  it("never exclude an extension any schema entry maps", () => {
+    const schemaExts = new Set(
+      [...CK3_SCHEMA, ...VIC3_SCHEMA].map((e) => (e.ext ?? ".txt").replace(/^\./, "").toLowerCase())
+    );
+    for (const ext of BINARY_EXTS) {
+      expect(schemaExts.has(ext), `.${ext} is a schema-mapped extension`).toBe(false);
+    }
+  });
+
+  it("cannot match a script file living under an asset directory (the shipped bug)", () => {
+    // Paths that a directory-shaped exclude WOULD have swallowed. Under an
+    // extension-only scheme every one of them stays visible.
+    const scriptUnderAssets = [
+      "gfx/portraits/portrait_modifiers/00_portrait_modifiers.txt",
+      "gfx/court_scene/character_roles/00_roles.txt",
+      "gfx/interface/illustrations/scripted_illustrations/00_illustrations.txt",
+      "music/00_music.txt",
+      "dlc/dlc001/common/traits/00_traits.txt",
+      "map_data/geographical_region.txt",
+    ];
+    for (const file of scriptUnderAssets) {
+      for (const p of ALL) {
+        expect(file.endsWith(`.${extOf(p)}`), `${p} would hide ${file}`).toBe(false);
+      }
+    }
+  });
+});


### PR DESCRIPTION
Stacked on the [#24](https://github.com/JDeffner/paradox-modding-toolkit/pull/24) branch. This one stops guessing and profiles.

## Method

Two new drivers live in `packages/server/test/perf/`:

- `profileRequests.ts` boots the packaged server under `--cpu-prof` against real roots (game + AGOT), lets the scan finish **uninterrupted**, then times cold/warm/after-save requests. Run: `node --experimental-strip-types packages/server/test/perf/profileRequests.ts <outDir>`
- `indexScaling.test.ts` builds a 1.4M-definition index in-process to time index primitives in seconds instead of the 9-minute recipe.

## What the profile said (and what it ruled out)

My first two hypotheses were wrong and the measurements killed them:

- **`index.entries()` walking every name** — measured 77–90 ms on a 1.4M index. Not it.
- **GUI editor / webviews** — every panel is constructed inside a `registerCommand` callback. They cost nothing until opened. Not it.

The actual findings:

1. **`rootScopesForFile` ran per REFERENCE.** The scope aggregation asked "which schema folder is this file in?" **4,124,139 times for 3,944 distinct answers**, and each miss rebuilt the content-root list (parent mods + playset probes) and walked every schema entry. → memoized per file; `contentRoots()` memoized alongside; both cleared on reindex.
2. **`buildCallSiteScopes` scanned the whole reference index** to find the 4% that are chained call sites, then re-resolved each chain from scratch. → `ReferenceIndex` tracks chained calls separately (same shape as the existing `trackedNames`), resolution memoized per (root scopes, chain), and the per-file lookup hoisted.
3. **The scan read one file at a time.** Cold reads cost **~10 ms/file regardless of size** (measured 9.7/10.3/10.9/10.9 across four untouched mods) because the cost is the round trip; a cold profile put **157 s of a 185 s startup — 80% of the process — inside `readFileUtf8`**. → batches read with reads in flight.

**The kicker:** all these caches key on the index revision, and **every save changes it**. So every Ctrl+S made the next completion pay full price. Semantic tokens were always ~1 ms — they were queued *behind* that completion on the server's single thread. That is the "text stays white for a while" report.

## Measured (game + AGOT, Ryzen 7 5800X, NVMe)

| operation | before | after |
|---|---|---|
| completion, first after an index change | 4314 ms | 800 ms |
| completion, first after a **save** | 4180 ms | **606 ms** |
| completion, cache warm | 20 ms | 18 ms |
| time to indexed, warm cache | 32 s | 25 s |
| time to indexed, cold cache | 82 s | 70 s |

**On the cold row, being precise:** the first cold run measured 185 s, but that was a truly-untouched boot state I cannot reproduce on demand. The 82 → 70 s figure is an A/B under identical partial cache eviction (30 GB read to flush), so it is the honest number. The per-file measurements suggest the gap widens the colder the cache is.

## Verification

- 1602 tests pass (3 new: `chainedCalls()` returns exactly what the old full walk kept, and `removeFile`/`clear` drop them — a stale call site would otherwise keep typing scopes after its file is gone).
- typecheck + lint clean.
- Test vsix built and installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Improve large-workspace responsiveness by optimizing server indexing and scope aggregation while reducing unnecessary VS Code asset indexing.

New Features:
- Add a command to reduce VS Code search and file-watcher load by excluding known binary asset extensions while preserving existing settings and allowing undo.
- Offer excluded workspace mods as read-only context so their definitions remain available without the full reference index.

Bug Fixes:
- Reduce large-workspace completion and post-save latency by caching scope resolution, indexing chained call sites directly, and resolving repeated call-site chains efficiently.
- Accelerate large-workspace indexing by reading files concurrently in bounded batches.
- Provide immediate base syntax coloring for bare value identifiers while semantic tokens are delayed.

Enhancements:
- Add profiling and index-scaling tools to measure request and indexing performance on realistic large workspaces.
- Document the profiled bottlenecks, performance improvements, workspace indexing tiers, and safe VS Code asset exclusions.

Documentation:
- Expand performance guidance with measured before-and-after completion and indexing timings and explanations of VS Code indexing behavior.

Tests:
- Add coverage for chained-call reference tracking cleanup, optimized call-site scope equivalence, exclude-setting merge behavior, and safety of extension-only exclusions.