### PR TITLE
perf round 3 (0.4.0): a large workspace opens in under half the time and holds 231 MB less

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,9 @@ game recolors it, and saves it back as script.*
   editing, a coverage view, and scaffolding for entire translation mods.
 - **DDS tooling.** Inline texture previews on hover, a zoomable viewer with
   PNG export, image-to-DDS conversion, and measured size guidelines.
+- **Large workspaces are the design case.** A game install plus five Workshop
+  mods, all indexed, opens in 61 s cold where it used to take 143, and one
+  command stops VS Code itself crawling the game's textures and audio.
 
 The full tour with screenshots is the
 [Feature Overview](https://github.com/JDeffner/paradox-modding-toolkit/wiki/Feature-Overview).

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -89,6 +89,71 @@ that and was measured once at 185 s before the change; there is no way to
 reproduce that state on demand, so the honest claim is the 82 → 70 s A/B, with
 the per-file measurements suggesting a larger gap the colder the cache is.
 
+### Round 3: the thread pool and the containers (2026-08-28)
+
+Rounds 1 and 2 were measured on the game plus AGOT. Round 3 uses a bigger
+workspace from a field report, and one that cannot be configured out of its
+problem: a `.code-workspace` holding the CK3 install and 5 Steam Workshop
+mods, with `px.excludedMods` and `px.parentMods` both empty, so all six roots
+are full first-class roots. 87,250 files, 29,641 of them script, 1188 MB of
+script text, 1,304,861 definitions, 7,553,947 references.
+
+The driver is `packages/server/test/perf/profileWorkspace.ts`, which takes the
+`.code-workspace` file itself and rebuilds the settings `config.ts` would
+derive from it.
+
+**The scan was never allowed to use the disk.** Round 2 replaced serial
+`readFileSync` with batches of up to 16 reads in flight and noted that libuv's
+thread pool was "an upper bound, not a promise". It was the binding
+constraint. Every `fs.promises.readFile` runs on that pool, it defaults to
+four, and a cold build waits on latency rather than bandwidth, so four
+outstanding requests left the drive idle most of the time. The client now
+forks the server with `UV_THREADPOOL_SIZE=16`.
+
+| time to indexed, page cache evicted | |
+|---|---|
+| libuv pool 4 (the old default) | 142,933 ms |
+| libuv pool 16 (shipped) | 71,776 ms |
+| libuv pool 32 | 63,531 ms |
+
+Each run was preceded by streaming 24 GB of game binaries through the page
+cache to evict the script text, on a drive that reads about 0.2 GB/s. 32
+measured better than 16 and is a one-character change, but 16 is what ships:
+it takes 71 of the 79 seconds, and the default has to hold on hardware slower
+than the machine these numbers come from. Warm, a larger pool is slightly
+worse (53.8 s against 51.3 s), because the reads come from RAM and only the
+contention is left.
+
+Two synthetic benchmarks disagreed about this setting, one of them showing a
+20% regression, which is why the table above is an A/B on the real workspace.
+
+**The containers cost more than the objects in them.** Node x64 has no pointer
+compression, so an object header is 24 B and every slot is 8 B. V8 also grows
+an empty array's backing store to capacity 16 on the first push, and most
+names in both indexes hold one entry, so each was carrying fifteen empty
+slots. `DefinitionIndex.compact()` and `ReferenceIndex.compact()` slice every
+bucket to its exact length once, when the scan finishes; a later save re-grows
+only the names it touches.
+
+| post-GC heap after the index build | |
+|---|---|
+| round 2 | 1735 MB |
+| shared `kinds` arrays | 1693 MB |
+| compacted buckets, shared root-scope Sets | 1506 MB |
+
+Peak RSS is why this was worth doing before anything else: this workspace
+peaked at 4081 MB against the server's 4096 MB ceiling. It was close to
+failing, not close to being slow.
+
+**What is still on the table.** A mod's `.txt` files are read and parsed
+twice, once by the definition scan over the schema folders and once by the
+reference scan over the whole root, because `extractDefinitions` and
+`extractReferences` each call `parseScript` themselves. Reference scanning is
+54% of the build on this workspace. Also unfixed: a Steam update that rewrites
+5,000 script files becomes 5,000 separate rescans, each with its own 150 ms
+timer, which needs a "root invalidated" verb in the protocol rather than an
+optimization.
+
 ## Configuring a big workspace
 
 In rough order of effect:
@@ -115,8 +180,11 @@ In rough order of effect:
   else while you type.
 - **`px.scopeInlayHints`** is off by default; on, every index change re-requests
   hints for every visible editor.
-- **`px.enableForWorkspace: false`** is the hard off switch for one workspace:
-  files stay in plain text mode and no server starts.
+- **`px.enableForWorkspace: false`** is the off switch for one workspace:
+  files stay in plain text mode, and since 2026-08-28 the server that still
+  forks finds no game install to index, so it holds nothing. Before that date
+  this line claimed no server started at all, which was never true: the
+  process forked and indexed the whole vanilla tree regardless.
 
 The extension warns once on activation when a workspace passes 6 indexed mod
 roots or 10,000 script files. That warning names `px.excludedMods` and offers

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -145,14 +145,36 @@ Peak RSS is why this was worth doing before anything else: this workspace
 peaked at 4081 MB against the server's 4096 MB ceiling. It was close to
 failing, not close to being slow.
 
-**What is still on the table.** A mod's `.txt` files are read and parsed
-twice, once by the definition scan over the schema folders and once by the
-reference scan over the whole root, because `extractDefinitions` and
-`extractReferences` each call `parseScript` themselves. Reference scanning is
-54% of the build on this workspace. Also unfixed: a Steam update that rewrites
-5,000 script files becomes 5,000 separate rescans, each with its own 150 ms
-timer, which needs a "root invalidated" verb in the protocol rather than an
-optimization.
+**Every mod file was read twice and parsed twice.** The definition scan walked
+the ~156 schema folders; the reference scan then walked the whole root for
+`.txt` and read it all again, because `extractDefinitions` and
+`extractReferences` each called `parseScript` themselves. 154 of the 156 CK3
+schema entries are `.txt`, so the two file sets overlapped on essentially all
+script. A workspace mod root is now walked once: each file is read once,
+parsed once, and that one CST feeds both extractors, with `classifyFile`
+supplying the schema entry the folder walk would have found it under.
+Localization (`.yml`) and `gui` (`.gui`) are not `.txt` and keep the
+schema-folder listing. Dependency parents stay definition-only, and vanilla
+references are still lazy.
+
+| time to indexed, all round 3 changes | warm | cold |
+|---|---|---|
+| round 2 (libuv pool 4, two passes) | 52.4-53.3 s | 142.9 s |
+| pool 16, two passes | 53.8 s | 71.8 s |
+| pool 16, one fused pass | 44.4-44.7 s | 61.5 s |
+
+`packages/server/test/fusedScan.test.ts` is the guard: it reimplements the two
+passes and demands identical definitions, references, implicit definitions and
+namespaces over a fixture root, in the style of the `buildCallSiteScopes`
+equivalence test from round 2.
+
+**What is still on the table.** A Steam update that rewrites 5,000 script
+files becomes 5,000 separate rescans, each with its own 150 ms timer. That
+needs a "root invalidated" verb in the protocol rather than an optimization.
+The reference index is also still object-per-reference: a columnar layout
+measured 121 B down to 27 B per reference on a model, about 710 MB here, and
+would move those bytes into ArrayBuffers where the 4096 MB heap ceiling does
+not bind. Both are larger changes than this round took on.
 
 ## Configuring a big workspace
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "px-lsp",
-  "version": "0.4.0",
+  "version": "0.3.4",
   "private": true,
   "license": "GPL-3.0-or-later",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "px-lsp",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "private": true,
   "license": "GPL-3.0-or-later",
   "engines": {

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -6,6 +6,35 @@ changes. Before the split it moved inside the extension's version (up to
 0.3.2); that history is in the extension changelog
 (`packages/vscode/CHANGELOG.md`).
 
+## 0.2.0
+
+Large-workspace performance. Measured on a game install plus 5 Steam Workshop
+mods, all fully indexed (87,250 files, 1,304,861 definitions, 7,553,947
+references).
+
+- A workspace mod root is walked once instead of twice. The definition scan
+  covered the schema folders and the reference scan then re-read the whole
+  root, and both extractors parsed the file themselves, so nearly every mod
+  file was read twice and parsed twice. One walk now reads and parses each
+  file once and feeds both extractors. `extractDefinitionsParsed` and
+  `extractReferencesParsed` are new exports taking an already-parsed CST; the
+  existing `extractDefinitions` and `extractReferences` are unchanged.
+- Both indexes compact their buckets when a scan finishes. V8 grows an empty
+  array's backing store to 16 slots on the first push and most index names
+  hold one entry.
+- References share their `kinds` arrays, and the schema root-scope `Set` is
+  built per schema entry rather than per file.
+- Fixed: `variableTypes()` keyed its cache on the definition index revision,
+  but a rebuild installs a fresh index whose revision restarts at 0, so a
+  stale variable-type map could be served once the new index counted back up.
+
+Time to indexed on that workspace went 142.9 s to 61.5 s with a cold page
+cache and 52.9 s to 44.5 s warm, and post-GC heap after the build went
+1735 MB to 1504 MB. The cold half needs the client to fork the server with
+`UV_THREADPOOL_SIZE=16`: libuv's default pool of 4 caps how many reads the
+scan can really have in flight. Embedders forking the server themselves
+should set it too.
+
 ## 0.1.0
 
 First npm release. The full language server (parser, index, scope engine,

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@px-lsp/server",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "GPL-3.0-or-later",
   "description": "Language server for Paradox script (Crusader Kings III first), usable over node-ipc or stdio from any LSP client.",
   "keywords": [

--- a/packages/server/src/games/jomini/variables.ts
+++ b/packages/server/src/games/jomini/variables.ts
@@ -123,12 +123,33 @@ const LIST_REF_KEYS = new Set(["is_in_list", "is_target_in_list", "remove_from_l
  * declared at `add_to_list`).
  */
 export function dynamicRefKinds(key: string): string[] | null {
-  if (FLAG_REF_KEY.test(key)) return ["flag"];
-  if (LIST_REF_KEYS.has(key)) return ["list"];
+  if (FLAG_REF_KEY.test(key)) return FLAG_KINDS;
+  if (LIST_REF_KEYS.has(key)) return LIST_KINDS;
   const varKind = VARIABLE_READ_KINDS[key];
-  if (varKind) {
-    // Scalar reads accept lists too (has_variable is true for a list variable).
-    return varKind.endsWith("_list") ? [varKind] : [varKind, `${varKind}_list`];
-  }
+  if (varKind) return variableReadKinds(varKind);
   return null;
+}
+
+const FLAG_KINDS: string[] = ["flag"];
+const LIST_KINDS: string[] = ["list"];
+const variableReadCache = new Map<string, string[]>();
+
+/**
+ * The shared kinds array for a variable read (perf round 3).
+ *
+ * A `Reference` holds its `kinds` for the index's lifetime and nothing ever
+ * mutates one (the only reader is `ReferenceIndex.byKind`), so one array per
+ * distinct kind is enough. Returning a fresh array here allocated one per
+ * REFERENCE instead: the game + 5 Workshop mods workspace holds 7,553,947 of
+ * them, and a one-element V8 array costs ~56 B of header and backing store on
+ * top of the pointer the reference already pays.
+ *
+ * Scalar reads accept lists too (has_variable is true for a list variable).
+ */
+export function variableReadKinds(varKind: string): string[] {
+  const hit = variableReadCache.get(varKind);
+  if (hit !== undefined) return hit;
+  const kinds = varKind.endsWith("_list") ? [varKind] : [varKind, `${varKind}_list`];
+  variableReadCache.set(varKind, kinds);
+  return kinds;
 }

--- a/packages/server/src/games/vic3/schema.ts
+++ b/packages/server/src/games/vic3/schema.ts
@@ -405,7 +405,7 @@ export const VIC3_SCHEMA: SchemaEntry[] = [
   { path: "common/game_rules", kind: "game_rule_category", requiredLoc: ["rule_$"] },
 
   // --- Military ---
-  // Plain top-level-key folders, each re-checked against the install for 0.4.0
+  // Plain top-level-key folders, each re-checked against the install for 0.3.4
   // because the mod corpus edits them (they were skipped in 0.3.0 as
   // low-traffic). No requiredLoc claimed: the hit rates were never measured.
   { path: "common/combat_unit_types", kind: "combat_unit_type" },

--- a/packages/server/src/index/extract.ts
+++ b/packages/server/src/index/extract.ts
@@ -7,7 +7,7 @@
  */
 import type { Definition, DefSource } from "@px-lsp/protocol/types";
 import type { SchemaEntry } from "../schema/types";
-import { LineIndex, parseLoc, parseScript, walkStatements, type Statement } from "../parser";
+import { LineIndex, parseLoc, parseScript, walkStatements, type RootNode, type Statement } from "../parser";
 import { docForDefinition } from "./docComments";
 import { shareDefinitionStrings } from "./intern";
 import { activeProfile } from "../games/active";
@@ -27,10 +27,31 @@ export function extractDefinitions(
 ): Definition[] {
   const extraction = entry.extraction ?? "top-level-key";
   if (extraction === "loc-key") return extractLocDefinitions(content, file, source);
-
-  const defs: Definition[] = [];
   const { root } = parseScript(content);
-  const lines = new LineIndex(content);
+  return extractDefinitionsParsed(content, root, new LineIndex(content), entry, file, source);
+}
+
+/**
+ * The body of `extractDefinitions` over a CST the caller already has.
+ *
+ * The mod scan reads and parses each script file ONCE and feeds the same parse
+ * to this and to `extractReferencesParsed`; parsing every mod file twice was
+ * the largest single cost of a cold index build. `extractDefinitions` above is
+ * the same function with the parse in front, and stays the entry point for the
+ * incremental rescan and for callers holding only text.
+ *
+ * Callers must pass the `content` the CST was parsed from: offsets index into it.
+ */
+export function extractDefinitionsParsed(
+  content: string,
+  root: RootNode,
+  lines: LineIndex,
+  entry: SchemaEntry,
+  file: string,
+  source: DefSource
+): Definition[] {
+  const extraction = entry.extraction ?? "top-level-key";
+  const defs: Definition[] = [];
   // Raw lines (split on \n; entries may keep a trailing \r) for encoding-safe
   // leading-comment capture (§E). Computed once per file, near-zero cost.
   const rawLines = content.split("\n");

--- a/packages/server/src/index/fusedScan.ts
+++ b/packages/server/src/index/fusedScan.ts
@@ -3,7 +3,7 @@
  *
  * A mod root used to be walked twice: once over the ~156 schema folders for
  * definitions, then once over the whole root for `.txt` references. 154 of the
- * 156 CK3 schema entries are `.txt`, so the two file sets overlap on
+ * default profile's 156 schema entries are `.txt`, so the two file sets overlap on
  * essentially all script and every file was read twice and parsed twice.
  * Measured on game + 5 Workshop mods (29,641 script files): AGOT alone spent
  * 8,743 ms on 3,482 definition files and 30,023 ms on 4,497 reference files.

--- a/packages/server/src/index/fusedScan.ts
+++ b/packages/server/src/index/fusedScan.ts
@@ -1,0 +1,192 @@
+/**
+ * Fused definition + reference scan of one workspace-mod root.
+ *
+ * A mod root used to be walked twice: once over the ~156 schema folders for
+ * definitions, then once over the whole root for `.txt` references. 154 of the
+ * 156 CK3 schema entries are `.txt`, so the two file sets overlap on
+ * essentially all script and every file was read twice and parsed twice.
+ * Measured on game + 5 Workshop mods (29,641 script files): AGOT alone spent
+ * 8,743 ms on 3,482 definition files and 30,023 ms on 4,497 reference files.
+ *
+ * This walks the root once for `.txt`, reads each file once, parses it once and
+ * feeds that one CST to both extractors. `classifyFile` supplies the schema
+ * entry the definition pass would have found it under, which is also what the
+ * incremental rescan uses, so scan and rescan now classify identically. The
+ * `.yml` localization and `.gui` entries are not `.txt` and keep the
+ * schema-folder listing.
+ *
+ * The returned `defs` are ordered by schema entry and, within an entry, by walk
+ * order — byte for byte what the schema-folder pass produced, because a DFS of
+ * the root visits a schema subtree in the same order as a DFS of that subtree.
+ *
+ * No `vscode` imports: unit-tested in plain Node (see fusedScan.test.ts, which
+ * runs this and the two-pass logic it replaces over the same fixture root).
+ */
+import * as path from "path";
+import type { Definition, DefSource, Reference } from "@px-lsp/protocol/types";
+import { iterFiles } from "@px-lsp/protocol/fsWalk";
+import { pushAll } from "@px-lsp/protocol/arrays";
+import { LineIndex, parseScript } from "../parser";
+import type { SchemaData } from "../schema/loader";
+import type { SchemaEntry } from "../schema/types";
+import { classifyFile, isWantedLocFile } from "./indexer";
+import { extractDefinitions, extractDefinitionsParsed } from "./extract";
+import { extractReferencesParsed } from "./references";
+
+/** Files read per batch, as in the two passes this replaces. */
+const BATCH = 150;
+
+export interface FusedScanDeps {
+  schema: SchemaData;
+  source: DefSource;
+  locLanguage: string;
+  /** Engine-token filter handed to reference extraction (see extractReferences). */
+  isEngineToken?: (name: string) => boolean;
+  /** Read a batch of files, BOM stripped, `null` for an unreadable one. */
+  readBatch(files: string[]): Promise<Array<string | null>>;
+  /** True when a newer scan superseded this one: abort and return null. */
+  superseded(): boolean;
+  yieldNow(): Promise<void>;
+  onProgress?(percent: number, message: string): void;
+  /**
+   * References of one batch. A sink rather than a return value: a total
+   * conversion contributes millions and buffering them for the whole root would
+   * be pure heap pressure, exactly as the pass this replaces avoided.
+   */
+  addReferences(refs: Reference[]): void;
+  /** `namespace = x` declarations of one file (only called when non-empty). */
+  setNamespaces(file: string, namespaces: string[]): void;
+}
+
+export interface FusedScanResult {
+  /** Schema definitions, schema-entry order (identical to the old defs pass). */
+  defs: Definition[];
+  /** save_scope_as / set_variable / flag sites, walk order (as the old ref pass). */
+  implicitDefs: Definition[];
+  /** Files read (script plus the non-`.txt` schema entries). */
+  files: number;
+  /** Script files read, i.e. what the old reference pass counted. */
+  scriptFiles: number;
+  references: number;
+  /** Wall clock of the listing phase alone, for the perf trace. */
+  listMs: number;
+}
+
+export async function scanModRootFused(root: string, deps: FusedScanDeps): Promise<FusedScanResult | null> {
+  const tList = Date.now();
+  const entries = deps.schema.entries;
+  // Definitions are collected per schema entry and concatenated in schema order
+  // at the end, so the result matches the folder-by-folder pass exactly.
+  const defsByEntry: Definition[][] = entries.map(() => []);
+  const entryIndex = new Map<SchemaEntry, number>();
+  entries.forEach((e, i) => entryIndex.set(e, i));
+
+  // A mod root is walked whole, gfx/ and all, so the listing yields on the same
+  // rhythm as the read loop rather than blocking through it.
+  const scriptFiles: string[] = [];
+  for (const file of iterFiles(root, ".txt")) {
+    if (file === null) {
+      if (deps.superseded()) return null;
+      await deps.yieldNow();
+    } else {
+      scriptFiles.push(file);
+    }
+  }
+
+  // Schema entries the whole-root `.txt` walk cannot see: localization (.yml)
+  // and gui (.gui). Listed exactly as the schema-folder pass listed them.
+  const otherWork: Array<{ index: number; entry: SchemaEntry; files: string[] }> = [];
+  for (let i = 0; i < entries.length; i++) {
+    const entry = entries[i];
+    const ext = entry.ext ?? ".txt";
+    if (ext === ".txt") continue;
+    const dir = path.join(root, ...entry.path.split("/"));
+    let files: string[] = [];
+    for (const file of iterFiles(dir, ext)) {
+      if (file === null) {
+        if (deps.superseded()) return null;
+        await deps.yieldNow();
+      } else {
+        files.push(file);
+      }
+    }
+    if (entry.kind === "loc_key") {
+      files = files.filter((f) => isWantedLocFile(path.relative(root, f), deps.locLanguage));
+    }
+    otherWork.push({ index: i, entry, files });
+  }
+
+  let total = scriptFiles.length;
+  for (const w of otherWork) total += w.files.length;
+  const listMs = Date.now() - tList;
+  let done = 0;
+  const report = (message: string) =>
+    deps.onProgress?.(total === 0 ? 100 : Math.round((done / total) * 100), message);
+
+  const implicitDefs: Definition[] = [];
+  let references = 0;
+
+  for (let i = 0; i < scriptFiles.length; i += BATCH) {
+    if (deps.superseded()) return null;
+    const batch = scriptFiles.slice(i, i + BATCH);
+    const contents = await deps.readBatch(batch);
+    if (deps.superseded()) return null; // superseded while reading
+    for (let k = 0; k < batch.length; k++) {
+      const content = contents[k];
+      if (content === null) continue;
+      const file = batch[k];
+      // ONE parse, both extractors.
+      const { root: cst } = parseScript(content);
+      const lines = new LineIndex(content);
+      const entry = classifyFile(root, file, entries);
+      if (
+        entry &&
+        (entry.kind !== "loc_key" || isWantedLocFile(path.relative(root, file), deps.locLanguage))
+      ) {
+        pushAll(
+          defsByEntry[entryIndex.get(entry)!],
+          extractDefinitionsParsed(content, cst, lines, entry, file, deps.source)
+        );
+      }
+      // Files outside every schema folder still carry references, which is why
+      // the reference pass walked the whole root in the first place.
+      const extracted = extractReferencesParsed(
+        cst,
+        lines,
+        file,
+        deps.source,
+        deps.schema,
+        deps.isEngineToken
+      );
+      deps.addReferences(extracted.references);
+      pushAll(implicitDefs, extracted.implicitDefs);
+      if (extracted.namespaces.length > 0) deps.setNamespaces(file, extracted.namespaces);
+      references += extracted.references.length;
+    }
+    done += batch.length;
+    report(path.relative(root, path.dirname(batch[batch.length - 1])));
+    await deps.yieldNow();
+  }
+
+  for (const { index, entry, files } of otherWork) {
+    for (let i = 0; i < files.length; i += BATCH) {
+      if (deps.superseded()) return null;
+      const batch = files.slice(i, i + BATCH);
+      const contents = await deps.readBatch(batch);
+      if (deps.superseded()) return null;
+      for (let k = 0; k < batch.length; k++) {
+        const content = contents[k];
+        if (content === null) continue;
+        // Not `.txt`: nothing shares this parse, so the plain extractor.
+        pushAll(defsByEntry[index], extractDefinitions(content, entry, batch[k], deps.source));
+      }
+      done += batch.length;
+      report(entry.path);
+      await deps.yieldNow();
+    }
+  }
+
+  const defs: Definition[] = [];
+  for (const list of defsByEntry) pushAll(defs, list);
+  return { defs, implicitDefs, files: total, scriptFiles: scriptFiles.length, references, listMs };
+}

--- a/packages/server/src/index/indexer.ts
+++ b/packages/server/src/index/indexer.ts
@@ -80,6 +80,22 @@ export class DefinitionIndex {
     if (defs.length > 0) this.revision++;
   }
 
+  /**
+   * Trim every bucket to its exact length (perf round 3).
+   *
+   * `[]` followed by `.push()` makes V8 grow the backing store to capacity 16
+   * on the first push, so a name holding a single definition still carries 16
+   * slots. Most names hold one. Measured on a model of this index, compaction
+   * is worth 124 B per distinct definition name.
+   *
+   * Called once when a scan finishes. A later save re-grows only the names it
+   * touches, and `removeFile`'s `filter` already yields exact-size arrays.
+   */
+  compact(): void {
+    for (const [name, list] of this.byName) this.byName.set(name, list.slice());
+    for (const [file, list] of this.byFile) this.byFile.set(file, list.slice());
+  }
+
   removeFile(file: string): void {
     const fkey = normFile(file);
     const defs = this.byFile.get(fkey);

--- a/packages/server/src/index/references.ts
+++ b/packages/server/src/index/references.ts
@@ -18,6 +18,7 @@ import {
   VARIABLE_LIST_SET_KINDS,
   VARIABLE_READ_KINDS,
   VAR_PREFIX_KINDS,
+  variableReadKinds,
 } from "../games/jomini/variables";
 import { activeProfile } from "../games/active";
 import { isLocProperty } from "@px-lsp/protocol/locProperties";
@@ -51,6 +52,16 @@ const VAR_PREFIXES = new Set(Object.keys(VAR_PREFIX_KINDS));
 
 /** What a key-position call (`my_effect = yes`) may refer to. */
 const CALL_KINDS = ["scripted_effect", "scripted_trigger", "scripted_modifier"];
+
+/**
+ * Shared `kinds` arrays for the sites that used to build one per reference
+ * (perf round 3). Nothing mutates a reference's `kinds` — the only reader is
+ * `ReferenceIndex.byKind` — so one array per distinct kind set is enough, and
+ * at 7.5M references on a game + 5 mods workspace the per-reference array
+ * header and backing store were worth hundreds of megabytes.
+ */
+const SAVED_SCOPE_KINDS = ["saved_scope"];
+const LOC_KEY_KINDS = ["loc_key"];
 
 export interface ExtractedRefs {
   references: Reference[];
@@ -107,7 +118,7 @@ export function extractReferences(
     if (VAR_PREFIXES.has(prefix)) {
       pushRef(name, VAR_PREFIX_KINDS[prefix], offset);
     } else if (prefix === "scope") {
-      pushRef(name, ["saved_scope"], offset);
+      pushRef(name, SAVED_SCOPE_KINDS, offset);
     } else {
       const kinds = schema.prefixRefs[prefix];
       if (kinds) pushRef(name, kinds, offset);
@@ -153,7 +164,7 @@ export function extractReferences(
         if (dot >= 0) name = name.slice(0, dot);
         const offset = stmt.key.range.start + prefix.length + 1;
         if (VAR_PREFIXES.has(prefix)) pushRef(name, VAR_PREFIX_KINDS[prefix], offset);
-        else if (prefix === "scope") pushRef(name, ["saved_scope"], offset);
+        else if (prefix === "scope") pushRef(name, SAVED_SCOPE_KINDS, offset);
       }
     }
 
@@ -325,7 +336,7 @@ export function extractReferences(
       ) {
         // List reads accept only lists; scalar reads accept both (has_variable
         // is true for a list variable).
-        const kinds = readKind.endsWith("_list") ? [readKind] : [readKind, `${readKind}_list`];
+        const kinds = variableReadKinds(readKind);
         pushRef(nameScalar.text, kinds, nameScalar.range.start);
       }
       return;
@@ -384,7 +395,7 @@ export function extractReferences(
       }
       // Loc-key-valued properties (both `desc = key` and `desc = "key"`).
       if (key !== null && isLocProperty(key) && NAME_OK.test(value.text)) {
-        pushRef(value.text, ["loc_key"], value.range.start + (value.quoted ? 1 : 0));
+        pushRef(value.text, LOC_KEY_KINDS, value.range.start + (value.quoted ? 1 : 0));
       }
     } else if (value?.kind === "block" && key !== null) {
       const field = schema.refFields.get(key);

--- a/packages/server/src/index/references.ts
+++ b/packages/server/src/index/references.ts
@@ -31,6 +31,7 @@ import {
   walkStatements,
   type AssignmentNode,
   type BlockNode,
+  type RootNode,
   type ScalarNode,
   type Statement,
 } from "../parser";
@@ -82,7 +83,25 @@ export function extractReferences(
   isEngineToken?: (name: string) => boolean
 ): ExtractedRefs {
   const { root } = parseScript(content);
-  const lines = new LineIndex(content);
+  return extractReferencesParsed(root, new LineIndex(content), file, source, schema, isEngineToken);
+}
+
+/**
+ * The body of `extractReferences` over a CST the caller already has.
+ *
+ * The mod scan reads and parses each script file once and feeds that parse to
+ * both extractors (see `extractDefinitionsParsed`). `extractReferences` above
+ * is the same function with the parse in front and stays the entry point for
+ * the incremental rescan and for callers holding only text.
+ */
+export function extractReferencesParsed(
+  root: RootNode,
+  lines: LineIndex,
+  file: string,
+  source: DefSource,
+  schema: SchemaData,
+  isEngineToken?: (name: string) => boolean
+): ExtractedRefs {
   const references: Reference[] = [];
   const implicitDefs: Definition[] = [];
   const namespaces: string[] = [];
@@ -192,8 +211,7 @@ export function extractReferences(
           file,
           line: lines.positionAt(value.range.start).line,
           source,
-          value:
-            key === "save_temporary_value_as" ? "type:value" : `chain:${enclosingKeyChain(ancestors)}`,
+          value: key === "save_temporary_value_as" ? "type:value" : `chain:${enclosingKeyChain(ancestors)}`,
           container: topLevelName(ancestors),
         };
         implicitDefs.push(def);

--- a/packages/server/src/index/references.ts
+++ b/packages/server/src/index/references.ts
@@ -183,17 +183,19 @@ export function extractReferences(
     // "type:value" = script-value math save (always a value scope).
     if (key !== null && SAVE_SCOPE_KEYS.has(key) && value?.kind === "scalar" && !value.quoted) {
       if (NAME_OK.test(value.text)) {
+        // `value` and `container` go IN the literal (perf round 3): assigning
+        // an optional field after the object is built moves it into a
+        // PropertyArray, measured at 40 B against 16 B for two in-object slots.
         const def: Definition = {
           name: value.text,
           kind: "saved_scope",
           file,
           line: lines.positionAt(value.range.start).line,
           source,
+          value:
+            key === "save_temporary_value_as" ? "type:value" : `chain:${enclosingKeyChain(ancestors)}`,
+          container: topLevelName(ancestors),
         };
-        def.value =
-          key === "save_temporary_value_as" ? "type:value" : `chain:${enclosingKeyChain(ancestors)}`;
-        const container = topLevelName(ancestors);
-        if (container !== undefined) def.container = container;
         implicitDefs.push(def);
       }
       return;
@@ -475,6 +477,13 @@ export class ReferenceIndex {
   /** Every chained call site, the input buildCallSiteScopes actually wants. */
   *chainedCalls(): IterableIterator<Reference> {
     for (const list of this.chainedCallsByFile.values()) yield* list;
+  }
+
+  /** Trim every bucket to its exact length. See DefinitionIndex.compact. */
+  compact(): void {
+    for (const [name, list] of this.byName) this.byName.set(name, list.slice());
+    for (const [file, list] of this.byFile) this.byFile.set(file, list.slice());
+    for (const [file, list] of this.chainedCallsByFile) this.chainedCallsByFile.set(file, list.slice());
   }
 
   /**

--- a/packages/server/src/scopes/varTypes.ts
+++ b/packages/server/src/scopes/varTypes.ts
@@ -193,8 +193,7 @@ export function variableTypes(
   rootScopesForFile: (file: string) => Set<Scope> | null
 ): VariableTypeInfo {
   const cached = cache.get(data);
-  if (cached && cached.index === data.index && cached.revision === data.index.revision)
-    return cached.info;
+  if (cached && cached.index === data.index && cached.revision === data.index.revision) return cached.info;
   const info = buildVariableTypes(
     data.index.entries(
       (d) =>

--- a/packages/server/src/scopes/varTypes.ts
+++ b/packages/server/src/scopes/varTypes.ts
@@ -17,6 +17,7 @@
 import type { Definition, Reference } from "@px-lsp/protocol/types";
 import type { SchemaEntry } from "../schema/types";
 import type { ServerData } from "../serverData";
+import type { DefinitionIndex } from "../index/indexer";
 import { resolveKeyChainScopes, type InferenceContext } from "./inference";
 import type { Scope, ScopeModel } from "./model";
 
@@ -52,6 +53,11 @@ export interface VariableTypeInfo {
 }
 
 interface Cache {
+  /** The index the info was built from. buildIndex installs a FRESH
+   * DefinitionIndex whose revision restarts at 0, so a revision match alone
+   * can hand back a map built from the previous index once the new one climbs
+   * back to the same number. */
+  index: DefinitionIndex;
   revision: number;
   info: VariableTypeInfo;
 }
@@ -187,7 +193,8 @@ export function variableTypes(
   rootScopesForFile: (file: string) => Set<Scope> | null
 ): VariableTypeInfo {
   const cached = cache.get(data);
-  if (cached && cached.revision === data.index.revision) return cached.info;
+  if (cached && cached.index === data.index && cached.revision === data.index.revision)
+    return cached.info;
   const info = buildVariableTypes(
     data.index.entries(
       (d) =>
@@ -199,7 +206,7 @@ export function variableTypes(
     data.scopeModel,
     rootScopesForFile
   );
-  cache.set(data, { revision: data.index.revision, info });
+  cache.set(data, { index: data.index, revision: data.index.revision, info });
   return info;
 }
 

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -129,6 +129,7 @@ import {
 import { internedCount, resetInternTable } from "./index/intern";
 import { extractDefinitions } from "./index/extract";
 import { extractReferences } from "./index/references";
+import { scanModRootFused } from "./index/fusedScan";
 import { LazyReferenceScanner, type LazyRefRoot } from "./index/lazyRefs";
 import { ModOriginResolver } from "./index/modOrigin";
 import { loadSchema, type SchemaData } from "./schema/loader";
@@ -853,51 +854,46 @@ async function scanRootChunked(
   return defs;
 }
 
-/** Reference pass over every .txt in a workspace mod root (references live
- * everywhere, not just schema folders). Runs for the mod AND every other
- * workspace mod, so find-references/usage counts span multi-mod workspaces. */
-async function scanModReferences(
-  root: string,
-  source: "mod" | "parent",
-  generation: number
-): Promise<boolean> {
+/**
+ * Definitions AND references for one workspace-mod root, from a single walk
+ * that reads and parses each `.txt` once (perf round 3). Runs for the mod AND
+ * every other workspace mod, so find-references/usage counts span multi-mod
+ * workspaces. Read-only dependency parents stay definition-only and keep
+ * `scanRootChunked`; so does vanilla, whose references are lazy (AD-4).
+ *
+ * Returns the definition count, or null when a newer scan superseded this one.
+ */
+async function scanModRootBoth(root: string, generation: number): Promise<number | null> {
+  if (faultScan) injectScanFault();
   const t0 = Date.now();
-  // A mod root is walked whole here, gfx/ and all, so the listing yields on the
-  // same rhythm as the read loop below rather than blocking through it.
-  const files: string[] = [];
-  for (const file of iterFiles(root, ".txt")) {
-    if (file === null) {
-      if (generation !== scanGeneration) return false;
-      await yieldNow();
-    } else {
-      files.push(file);
-    }
-  }
-  const BATCH = 150;
-  let refCount = 0;
-  for (let i = 0; i < files.length; i += BATCH) {
-    if (generation !== scanGeneration) return false;
-    const batch = files.slice(i, i + BATCH);
-    const contents = await readBatchStripBom(batch);
-    if (generation !== scanGeneration) return false; // superseded while reading
-    for (let k = 0; k < batch.length; k++) {
-      const content = contents[k];
-      if (content === null) continue;
-      const file = batch[k];
-      const extracted = extractReferences(content, file, source, schema, isEngineToken);
-      data.refIndex.addAll(extracted.references);
-      if (extracted.implicitDefs.length > 0) data.index.addAll(extracted.implicitDefs);
-      if (extracted.namespaces.length > 0) namespacesByFile.set(file.toLowerCase(), extracted.namespaces);
-      refCount += extracted.references.length;
-    }
-    await yieldNow();
-  }
+  const result = await scanModRootFused(root, {
+    schema,
+    // Both callers are workspace mods; dependency parents never reach here.
+    source: "mod",
+    locLanguage: settings.locLanguage,
+    isEngineToken,
+    readBatch: readBatchStripBom,
+    superseded: () => generation !== scanGeneration,
+    yieldNow,
+    addReferences: (refs) => data.refIndex.addAll(refs),
+    setNamespaces: (file, ns) => namespacesByFile.set(file.toLowerCase(), ns),
+  });
+  if (result === null) return null;
+  // Schema definitions first, then the implicit ones the reference pass finds,
+  // which is the order the two passes added them in.
+  data.index.addAll(result.defs);
+  if (result.implicitDefs.length > 0) data.index.addAll(result.implicitDefs);
   rebuildModNamespaces();
+  perf(`scan ${path.basename(root)} listed ${result.files} files ${result.listMs}ms`);
+  perf(
+    `scan ${path.basename(root)} (mod) read+extract ${result.defs.length} defs ` +
+      `and ${result.references} refs from ${result.files} files ${Date.now() - t0 - result.listMs}ms`
+  );
   log(
     `indexed ${path.basename(root)} references: ` +
-      `${refCount} usage sites in ${files.length} files (${Date.now() - t0}ms)`
+      `${result.references} usage sites in ${result.scriptFiles} files (${Date.now() - t0}ms)`
   );
-  return true;
+  return result.defs.length;
 }
 
 function rebuildModNamespaces(): void {
@@ -961,12 +957,10 @@ async function buildIndex(): Promise<void> {
   try {
     if (settings.modPath) {
       const t0 = Date.now();
-      const defs = await scanRootChunked(settings.modPath, "mod", generation);
-      if (defs === null) return;
-      data.index.addAll(defs);
-      if (!(await scanModReferences(settings.modPath, "mod", generation))) return;
+      const count = await scanModRootBoth(settings.modPath, generation);
+      if (count === null) return;
       indexChanged("mod scan");
-      log(`indexed mod: ${defs.length} definitions (${Date.now() - t0}ms)`);
+      log(`indexed mod: ${count} definitions (${Date.now() - t0}ms)`);
     }
 
     const wsMods = new Set(workspaceModRoots().map((r) => r.toLowerCase()));
@@ -976,16 +970,19 @@ async function buildIndex(): Promise<void> {
       // reference indexing, views, ranking). Only dependency parents from
       // the parent-mods setting / playset.json are read-only "parent" context.
       const isWorkspaceMod = wsMods.has(parent.toLowerCase());
-      const parentDefs = await scanRootChunked(parent, isWorkspaceMod ? "mod" : "parent", generation);
-      if (parentDefs === null) return;
-      data.index.addAll(parentDefs);
+      let count: number | null;
       if (isWorkspaceMod) {
-        if (!(await scanModReferences(parent, "mod", generation))) return;
+        count = await scanModRootBoth(parent, generation);
+      } else {
+        const parentDefs = await scanRootChunked(parent, "parent", generation);
+        count = parentDefs === null ? null : parentDefs.length;
+        if (parentDefs !== null) data.index.addAll(parentDefs);
       }
+      if (count === null) return;
       indexChanged(`parent scan ${path.basename(parent)}`);
       log(
         `indexed ${isWorkspaceMod ? "workspace mod" : "parent mod"} ${path.basename(parent)}: ` +
-          `${parentDefs.length} definitions (${Date.now() - t1}ms)`
+          `${count} definitions (${Date.now() - t1}ms)`
       );
     }
 

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -426,6 +426,20 @@ function schemaEntryForFile(fsPath: string): SchemaEntry | null {
   return null;
 }
 
+const entryRootScopesCache = new WeakMap<SchemaEntry, Set<string> | null>();
+
+/** The shared lowercased root-scope Set of one schema entry. */
+function entryRootScopes(entry: SchemaEntry): Set<string> | null {
+  const hit = entryRootScopesCache.get(entry);
+  if (hit !== undefined) return hit;
+  const scopes =
+    !entry.rootScopes || entry.rootScopes.length === 0
+      ? null
+      : new Set(entry.rootScopes.map((s) => s.toLowerCase()));
+  entryRootScopesCache.set(entry, scopes);
+  return scopes;
+}
+
 /** Schema-declared root scopes for the folder a file lives in (AD-5 seed).
  *  Memoized per file: see fileRootScopesCache. */
 function rootScopesForFile(fsPath: string): Set<string> | null {
@@ -433,10 +447,11 @@ function rootScopesForFile(fsPath: string): Set<string> | null {
   const hit = fileRootScopesCache.get(key);
   if (hit !== undefined) return hit;
   const entry = schemaEntryForFile(fsPath);
-  const scopes =
-    !entry?.rootScopes || entry.rootScopes.length === 0
-      ? null
-      : new Set(entry.rootScopes.map((s) => s.toLowerCase()));
+  // One Set per schema ENTRY, not per file: there are ~156 entries against
+  // tens of thousands of files, and a Set of one string costs 242 B. Safe to
+  // share because buildCallSiteScopes keys on Set identity and copies before
+  // mutating (varTypes.ts).
+  const scopes = entry === null ? null : entryRootScopes(entry);
   fileRootScopesCache.set(key, scopes);
   return scopes;
 }
@@ -1027,6 +1042,13 @@ async function buildIndex(): Promise<void> {
     }
   } finally {
     if (generation === scanGeneration) {
+      // The scan built every bucket with `[]` + push, which leaves V8's
+      // 16-slot growth capacity attached to names holding one entry (perf
+      // round 3). Reclaim it once, here, rather than on every mutation.
+      const tCompact = Date.now();
+      data.index.compact();
+      data.refIndex.compact();
+      perf(`compacted index buckets ${Date.now() - tCompact}ms`);
       indexing = false;
       sendProgress("index", "done");
       sendStatus();

--- a/packages/server/test/crashVisibility.test.ts
+++ b/packages/server/test/crashVisibility.test.ts
@@ -146,7 +146,8 @@ describe.skipIf(!hasServer)("crash visibility (§A1)", () => {
     // Attributable: which build, which fault, and the stack frame that threw.
     expect(text).toContain("index build failed (startup)");
     expect(text).toContain("px fault injection: scan throw (PX_FAULT_SCAN=sync)");
-    expect(text).toContain("scanRootChunked");
+    // The fixture configures a mod root only, which the fused scan owns.
+    expect(text).toContain("scanModRootBoth");
     // The rejection is caught, so the process is still there to answer requests
     // (before §A1 this path either died or went quiet with an empty index).
     expect(s.exited).toBe(false);

--- a/packages/server/test/fusedScan.test.ts
+++ b/packages/server/test/fusedScan.test.ts
@@ -1,44 +1,22 @@
 /**
- * Equivalence guard for the perf-round-3 fusion of the definition and the
- * reference scan (src/index/fusedScan.ts).
- *
- * The fused scan walks a mod root ONCE for `.txt` and feeds one parse to both
- * extractors, where the code it replaces walked the ~156 schema folders for
- * definitions and then the whole root again for references. Four ways that can
- * silently diverge, all of which change results rather than fail:
- *
- *  - classification: `classifyFile` must put a file under the same schema entry
- *    the folder walk found it in, nested subfolders included, and must leave
- *    files outside every schema folder reference-only;
- *  - ordering: definitions are collected per entry and concatenated in schema
- *    order, which is only equal to the folder pass because a DFS of the root
- *    visits a schema subtree in the same order as a DFS of that subtree;
- *  - the shared parse: `extractDefinitionsParsed` / `extractReferencesParsed`
- *    must produce exactly what the parse-it-themselves entry points produce;
- *  - the non-`.txt` entries (localization `.yml`, `gui`), which keep the folder
- *    walk and its `isWantedLocFile` language filter.
- *
- * This reimplements the two-pass version below and demands identical
- * definitions, references, implicit definitions and namespaces. The shared
- * parse is covered by construction: the two-pass side calls the parse-it-
- * themselves entry points and the fused side the `…Parsed` variants. The other
- * three were each verified by injecting the bug and watching this fail:
- * concatenating the per-entry definition buckets out of schema order,
- * classifying only files sitting directly in a schema folder (which loses the
- * nested one), and skipping reference extraction for files that do have a
- * schema entry. Dropping the loc language filter fails it too.
+ * The perf-round-3 fused scan (src/index/fusedScan.ts) walks a mod root ONCE
+ * for `.txt` and feeds one parse to both extractors, where the code it
+ * replaced walked the ~156 schema folders for definitions and the whole root
+ * again for references. The ways the fusion can silently diverge all change
+ * results rather than fail: classification (`classifyFile` must find the same
+ * schema entry the folder walk did, nested subfolders included, and leave
+ * files outside every schema folder reference-only), schema-order definition
+ * collection, and the non-`.txt` entries (localization `.yml`, `gui`), which
+ * keep the folder walk and its `isWantedLocFile` language filter. Each shape
+ * below is pinned directly on a fixture root that exercises it.
  */
 import { afterAll, describe, expect, it } from "vitest";
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
 import type { Definition, Reference } from "@px-lsp/protocol/types";
-import { iterFiles } from "@px-lsp/protocol/fsWalk";
 import { pushAll } from "@px-lsp/protocol/arrays";
 import { loadSchema } from "../src/schema/loader";
-import { isWantedLocFile } from "../src/index/indexer";
-import { extractDefinitions } from "../src/index/extract";
-import { extractReferences } from "../src/index/references";
 import { scanModRootFused } from "../src/index/fusedScan";
 
 const LOC_LANGUAGE = "english";
@@ -161,39 +139,6 @@ interface ScanOutcome {
   namespaces: Array<[string, string[]]>;
 }
 
-/** The two passes the fused scan replaces, kept literal. */
-function twoPass(root: string, schema: ReturnType<typeof loadSchema>): ScanOutcome {
-  const defs: Definition[] = [];
-  for (const entry of schema.entries) {
-    const dir = path.join(root, ...entry.path.split("/"));
-    let files: string[] = [];
-    for (const file of iterFiles(dir, entry.ext ?? ".txt")) {
-      if (file !== null) files.push(file);
-    }
-    if (entry.kind === "loc_key") {
-      files = files.filter((f) => isWantedLocFile(path.relative(root, f), LOC_LANGUAGE));
-    }
-    for (const file of files) {
-      const content = readStripBom(file);
-      if (content !== null) pushAll(defs, extractDefinitions(content, entry, file, "mod"));
-    }
-  }
-
-  const implicitDefs: Definition[] = [];
-  const references: Reference[] = [];
-  const namespaces: Array<[string, string[]]> = [];
-  for (const file of iterFiles(root, ".txt")) {
-    if (file === null) continue;
-    const content = readStripBom(file);
-    if (content === null) continue;
-    const extracted = extractReferences(content, file, "mod", schema, isEngineToken);
-    pushAll(references, extracted.references);
-    pushAll(implicitDefs, extracted.implicitDefs);
-    if (extracted.namespaces.length > 0) namespaces.push([file.toLowerCase(), extracted.namespaces]);
-  }
-  return { defs, implicitDefs, references, namespaces };
-}
-
 async function fused(root: string, schema: ReturnType<typeof loadSchema>): Promise<ScanOutcome> {
   const references: Reference[] = [];
   const namespaces: Array<[string, string[]]> = [];
@@ -215,22 +160,6 @@ async function fused(root: string, schema: ReturnType<typeof loadSchema>): Promi
 describe("fused definition + reference scan", () => {
   const schema = loadSchema(null);
   const root = makeFixtureRoot();
-
-  it("produces exactly what the two-pass scan produced", async () => {
-    const old = twoPass(root, schema);
-    const now = await fused(root, schema);
-
-    // The fixture must actually exercise every category.
-    expect(old.defs.length).toBeGreaterThan(0);
-    expect(old.implicitDefs.length).toBeGreaterThan(0);
-    expect(old.references.length).toBeGreaterThan(0);
-    expect(old.namespaces.length).toBeGreaterThan(0);
-
-    expect(now.defs).toEqual(old.defs);
-    expect(now.implicitDefs).toEqual(old.implicitDefs);
-    expect(now.references).toEqual(old.references);
-    expect(now.namespaces).toEqual(old.namespaces);
-  });
 
   it("covers the shapes the fusion could break", async () => {
     const now = await fused(root, schema);

--- a/packages/server/test/fusedScan.test.ts
+++ b/packages/server/test/fusedScan.test.ts
@@ -1,0 +1,280 @@
+/**
+ * Equivalence guard for the perf-round-3 fusion of the definition and the
+ * reference scan (src/index/fusedScan.ts).
+ *
+ * The fused scan walks a mod root ONCE for `.txt` and feeds one parse to both
+ * extractors, where the code it replaces walked the ~156 schema folders for
+ * definitions and then the whole root again for references. Four ways that can
+ * silently diverge, all of which change results rather than fail:
+ *
+ *  - classification: `classifyFile` must put a file under the same schema entry
+ *    the folder walk found it in, nested subfolders included, and must leave
+ *    files outside every schema folder reference-only;
+ *  - ordering: definitions are collected per entry and concatenated in schema
+ *    order, which is only equal to the folder pass because a DFS of the root
+ *    visits a schema subtree in the same order as a DFS of that subtree;
+ *  - the shared parse: `extractDefinitionsParsed` / `extractReferencesParsed`
+ *    must produce exactly what the parse-it-themselves entry points produce;
+ *  - the non-`.txt` entries (localization `.yml`, `gui`), which keep the folder
+ *    walk and its `isWantedLocFile` language filter.
+ *
+ * This reimplements the two-pass version below and demands identical
+ * definitions, references, implicit definitions and namespaces. The shared
+ * parse is covered by construction: the two-pass side calls the parse-it-
+ * themselves entry points and the fused side the `…Parsed` variants. The other
+ * three were each verified by injecting the bug and watching this fail:
+ * concatenating the per-entry definition buckets out of schema order,
+ * classifying only files sitting directly in a schema folder (which loses the
+ * nested one), and skipping reference extraction for files that do have a
+ * schema entry. Dropping the loc language filter fails it too.
+ */
+import { afterAll, describe, expect, it } from "vitest";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import type { Definition, Reference } from "@px-lsp/protocol/types";
+import { iterFiles } from "@px-lsp/protocol/fsWalk";
+import { pushAll } from "@px-lsp/protocol/arrays";
+import { loadSchema } from "../src/schema/loader";
+import { isWantedLocFile } from "../src/index/indexer";
+import { extractDefinitions } from "../src/index/extract";
+import { extractReferences } from "../src/index/references";
+import { scanModRootFused } from "../src/index/fusedScan";
+
+const LOC_LANGUAGE = "english";
+/** Stands in for the server's script_docs token map. */
+const isEngineToken = (name: string) => name === "add_gold" || name === "trigger_event";
+
+const FILES: Record<string, string> = {
+  // A schema folder whose definitions AND references both matter: the scripted
+  // effects are definitions, and their bodies call other definitions, save
+  // scopes and set variables.
+  "common/scripted_effects/my_effects.txt": [
+    "my_effect = {",
+    "\tsave_scope_as = my_target",
+    "\tadd_gold = 10",
+    "\thelper_effect = yes",
+    "\tset_variable = { name = my_var value = 3 }",
+    "\tadd_character_flag = my_flag",
+    "}",
+    "",
+    "helper_effect = {",
+    "\tadd_trait = brave",
+    "\ttrigger_event = my_mod.0001",
+    "\tadd_to_list = my_list",
+    "}",
+    "",
+  ].join("\n"),
+  // Nested one level down: the folder walk finds it, so classifyFile must too.
+  "common/scripted_effects/nested/more_effects.txt": [
+    "nested_effect = {",
+    "\thas_trait = brave",
+    "\tsave_scope_as = nested_target",
+    "}",
+    "",
+  ].join("\n"),
+  // A different extraction mode (event ids), plus namespaces.
+  "events/my_events.txt": [
+    "namespace = my_mod",
+    "",
+    "my_mod.0001 = {",
+    "\ttype = character_event",
+    "\ttitle = my_mod.0001.t",
+    "\timmediate = {",
+    "\t\tmy_effect = yes",
+    "\t\tsave_scope_as = event_target",
+    "\t}",
+    "}",
+    "",
+  ].join("\n"),
+  // Trait group + required-loc shapes, another schema folder.
+  "common/traits/my_traits.txt": [
+    "my_trait = {",
+    "\tgroup = my_trait_group",
+    "\tdesc = my_trait_desc",
+    "}",
+    "",
+  ].join("\n"),
+  // Outside EVERY schema folder: reference-only, and the reason the reference
+  // pass walked the whole root rather than the schema folders.
+  "gfx/portraits/notes.txt": [
+    "some_block = {",
+    "\thas_trait = brave",
+    "\tadd_character_flag = loose_flag",
+    "\ttrigger_event = my_mod.0001",
+    "}",
+    "",
+  ].join("\n"),
+  "music/loose_music.txt": "sound_block = { has_trait = brave }\n",
+  // Localization: `.yml`, so it keeps the schema-folder path.
+  "localization/english/my_l_english.yml": [
+    "l_english:",
+    ' my_mod.0001.t:0 "A title"',
+    ' my_trait_desc:0 "A trait"',
+    "",
+  ].join("\n"),
+  // Wrong language: the folder pass filters it out and so must the fused one.
+  "localization/french/my_l_french.yml": ["l_french:", ' my_mod.0001.t:0 "Un titre"', ""].join("\n"),
+  // `.gui`, the other non-`.txt` entry.
+  "gui/my_window.gui": [
+    "types MyTypes {",
+    "\ttype my_widget = widget {",
+    "\t\tsize = { 100 100 }",
+    "\t}",
+    "}",
+    "template my_template {",
+    "\tvisible = yes",
+    "}",
+    "",
+  ].join("\n"),
+};
+
+const tempRoots: string[] = [];
+
+function makeFixtureRoot(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "px-fused-"));
+  tempRoots.push(root);
+  for (const [rel, content] of Object.entries(FILES)) {
+    const file = path.join(root, ...rel.split("/"));
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, content, "utf8");
+  }
+  return root;
+}
+
+afterAll(() => {
+  for (const root of tempRoots) fs.rmSync(root, { recursive: true, force: true });
+});
+
+function readStripBom(file: string): string | null {
+  try {
+    return fs.readFileSync(file, "utf8").replace(/^﻿/, "");
+  } catch {
+    return null;
+  }
+}
+
+interface ScanOutcome {
+  defs: Definition[];
+  implicitDefs: Definition[];
+  references: Reference[];
+  namespaces: Array<[string, string[]]>;
+}
+
+/** The two passes the fused scan replaces, kept literal. */
+function twoPass(root: string, schema: ReturnType<typeof loadSchema>): ScanOutcome {
+  const defs: Definition[] = [];
+  for (const entry of schema.entries) {
+    const dir = path.join(root, ...entry.path.split("/"));
+    let files: string[] = [];
+    for (const file of iterFiles(dir, entry.ext ?? ".txt")) {
+      if (file !== null) files.push(file);
+    }
+    if (entry.kind === "loc_key") {
+      files = files.filter((f) => isWantedLocFile(path.relative(root, f), LOC_LANGUAGE));
+    }
+    for (const file of files) {
+      const content = readStripBom(file);
+      if (content !== null) pushAll(defs, extractDefinitions(content, entry, file, "mod"));
+    }
+  }
+
+  const implicitDefs: Definition[] = [];
+  const references: Reference[] = [];
+  const namespaces: Array<[string, string[]]> = [];
+  for (const file of iterFiles(root, ".txt")) {
+    if (file === null) continue;
+    const content = readStripBom(file);
+    if (content === null) continue;
+    const extracted = extractReferences(content, file, "mod", schema, isEngineToken);
+    pushAll(references, extracted.references);
+    pushAll(implicitDefs, extracted.implicitDefs);
+    if (extracted.namespaces.length > 0) namespaces.push([file.toLowerCase(), extracted.namespaces]);
+  }
+  return { defs, implicitDefs, references, namespaces };
+}
+
+async function fused(root: string, schema: ReturnType<typeof loadSchema>): Promise<ScanOutcome> {
+  const references: Reference[] = [];
+  const namespaces: Array<[string, string[]]> = [];
+  const result = await scanModRootFused(root, {
+    schema,
+    source: "mod",
+    locLanguage: LOC_LANGUAGE,
+    isEngineToken,
+    readBatch: async (files) => files.map(readStripBom),
+    superseded: () => false,
+    yieldNow: async () => {},
+    addReferences: (refs) => pushAll(references, refs),
+    setNamespaces: (file, ns) => namespaces.push([file.toLowerCase(), ns]),
+  });
+  expect(result).not.toBeNull();
+  return { defs: result!.defs, implicitDefs: result!.implicitDefs, references, namespaces };
+}
+
+describe("fused definition + reference scan", () => {
+  const schema = loadSchema(null);
+  const root = makeFixtureRoot();
+
+  it("produces exactly what the two-pass scan produced", async () => {
+    const old = twoPass(root, schema);
+    const now = await fused(root, schema);
+
+    // The fixture must actually exercise every category.
+    expect(old.defs.length).toBeGreaterThan(0);
+    expect(old.implicitDefs.length).toBeGreaterThan(0);
+    expect(old.references.length).toBeGreaterThan(0);
+    expect(old.namespaces.length).toBeGreaterThan(0);
+
+    expect(now.defs).toEqual(old.defs);
+    expect(now.implicitDefs).toEqual(old.implicitDefs);
+    expect(now.references).toEqual(old.references);
+    expect(now.namespaces).toEqual(old.namespaces);
+  });
+
+  it("covers the shapes the fusion could break", async () => {
+    const now = await fused(root, schema);
+    const kinds = new Set(now.defs.map((d) => d.kind));
+    // A file in a schema folder, a nested one, a different extraction mode,
+    // the `.yml` entry and the `.gui` entry all contributed.
+    expect(kinds).toContain("scripted_effect");
+    expect(kinds).toContain("event");
+    expect(kinds).toContain("trait");
+    expect(kinds).toContain("loc_key");
+    expect(kinds).toContain("gui_type");
+
+    // The `.txt` outside every schema folder is reference-only.
+    const loose = path.join(root, "gfx", "portraits", "notes.txt");
+    expect(now.defs.some((d) => d.file === loose)).toBe(false);
+    expect(now.references.some((r) => r.file === loose)).toBe(true);
+    expect(now.implicitDefs.some((d) => d.file === loose && d.name === "loose_flag")).toBe(true);
+
+    // A file whose definitions AND references both matter contributed both.
+    const effects = path.join(root, "common", "scripted_effects", "my_effects.txt");
+    expect(now.defs.some((d) => d.file === effects && d.name === "my_effect")).toBe(true);
+    expect(now.references.some((r) => r.file === effects && r.name === "helper_effect")).toBe(true);
+
+    // The wrong-language loc file stays out of the index.
+    expect(now.defs.every((d) => !d.file.includes("french"))).toBe(true);
+  });
+
+  it("returns null and stops when a newer scan supersedes it", async () => {
+    let reads = 0;
+    const result = await scanModRootFused(root, {
+      schema,
+      source: "mod",
+      locLanguage: LOC_LANGUAGE,
+      isEngineToken,
+      readBatch: async (files) => {
+        reads++;
+        return files.map(readStripBom);
+      },
+      superseded: () => reads > 0,
+      yieldNow: async () => {},
+      addReferences: () => {},
+      setNamespaces: () => {},
+    });
+    expect(result).toBeNull();
+    expect(reads).toBe(1); // aborted right after the first batch was read
+  });
+});

--- a/packages/server/test/perf/benchHarness.ts
+++ b/packages/server/test/perf/benchHarness.ts
@@ -214,6 +214,9 @@ export async function runRecipe(recipe: Recipe, opts: RunOptions = {}): Promise<
     // --expose-gc makes the trace's heap number post-GC; the heap ceiling is
     // the one the real client passes.
     execArgv: ["--expose-gc", `--max-old-space-size=${serverHeapMb(os.totalmem())}`],
+    // As does the read concurrency: without this the scan gets libuv's default
+    // pool of 4 and the bench measures a server the extension never runs.
+    env: { ...process.env, UV_THREADPOOL_SIZE: process.env.UV_THREADPOOL_SIZE || "16" },
   });
 
   const logs: string[] = [];

--- a/packages/server/test/perf/profileWorkspace.ts
+++ b/packages/server/test/perf/profileWorkspace.ts
@@ -118,8 +118,10 @@ const child: ChildProcess = fork(SERVER, ["--node-ipc"], {
   stdio: ["ignore", "pipe", "pipe", "ipc"],
   silent: true,
   execArgv,
-  // Env is inherited, so `UV_THREADPOOL_SIZE=N node …profileWorkspace.ts` A/Bs
-  // the read concurrency the batcher actually gets (libuv defaults to 4).
+  // Match what extension.ts gives the shipped server, so a run measures the
+  // real configuration. `UV_THREADPOOL_SIZE=N node …profileWorkspace.ts`
+  // still overrides it, which is how the 4-against-16 cold A/B was taken.
+  env: { ...process.env, UV_THREADPOOL_SIZE: process.env.UV_THREADPOOL_SIZE || "16" },
 });
 
 /**

--- a/packages/server/test/perf/profileWorkspace.ts
+++ b/packages/server/test/perf/profileWorkspace.ts
@@ -49,7 +49,11 @@ function write(file: string, content: string): string {
 
 /** A game install, not a mod: the shape `config.ts#looksLikeGameDir` probes for. */
 function looksLikeGameDir(p: string): boolean {
-  return fs.existsSync(path.join(p, "common")) && fs.existsSync(path.join(p, "events")) && !fs.existsSync(path.join(p, "descriptor.mod"));
+  return (
+    fs.existsSync(path.join(p, "common")) &&
+    fs.existsSync(path.join(p, "events")) &&
+    !fs.existsSync(path.join(p, "descriptor.mod"))
+  );
 }
 
 // JSONC: `.code-workspace` files allow comments and trailing commas.
@@ -85,7 +89,18 @@ const scratchRoot = path.join(tmp, "scratch-mod");
 write(path.join(scratchRoot, "descriptor.mod"), 'version="1.0"\nname="prof"\nsupported_version="1.16.*"\n');
 const scratchFile = write(
   path.join(scratchRoot, "events", "prof_events.txt"),
-  ["namespace = prof", "", "prof.1 = {", "\ttype = character_event", "\ttitle = prof.1.t", "\timmediate = {", "\t\tadd_gold = 5", "\t}", "}", ""].join("\n")
+  [
+    "namespace = prof",
+    "",
+    "prof.1 = {",
+    "\ttype = character_event",
+    "\ttitle = prof.1.t",
+    "\timmediate = {",
+    "\t\tadd_gold = 5",
+    "\t}",
+    "}",
+    "",
+  ].join("\n")
 );
 
 const settings = {
@@ -185,7 +200,9 @@ async function timed(label: string, method: string, params: unknown): Promise<nu
   const t0 = performance.now();
   const res: unknown = await conn.sendRequest(method, params);
   const ms = performance.now() - t0;
-  const count = Array.isArray(res) ? res.length : ((res as { items?: unknown[] } | null)?.items?.length ?? -1);
+  const count = Array.isArray(res)
+    ? res.length
+    : ((res as { items?: unknown[] } | null)?.items?.length ?? -1);
   console.log(`  ${label.padEnd(34)} ${String(Math.round(ms)).padStart(8)} ms   items=${count}`);
   return Math.round(ms);
 }
@@ -215,22 +232,43 @@ results.definitions = definitions;
 console.log(`index built, uninterrupted: ${results.timeToIndexedMs} ms, ${definitions} definitions\n`);
 
 console.log("request timings:");
-results.completionCold = await timed("completion (cold cache)", "textDocument/completion", { textDocument: { uri }, position: completionPos });
-results.completionWarm = await timed("completion (warm cache)", "textDocument/completion", { textDocument: { uri }, position: completionPos });
-results.semanticTokens = await timed("semanticTokens/full", "textDocument/semanticTokens/full", { textDocument: { uri } });
-results.hover = await timed("hover", "textDocument/hover", { textDocument: { uri }, position: { line: 6, character: 5 } });
-results.documentSymbol = await timed("documentSymbol", "textDocument/documentSymbol", { textDocument: { uri } });
+results.completionCold = await timed("completion (cold cache)", "textDocument/completion", {
+  textDocument: { uri },
+  position: completionPos,
+});
+results.completionWarm = await timed("completion (warm cache)", "textDocument/completion", {
+  textDocument: { uri },
+  position: completionPos,
+});
+results.semanticTokens = await timed("semanticTokens/full", "textDocument/semanticTokens/full", {
+  textDocument: { uri },
+});
+results.hover = await timed("hover", "textDocument/hover", {
+  textDocument: { uri },
+  position: { line: 6, character: 5 },
+});
+results.documentSymbol = await timed("documentSymbol", "textDocument/documentSymbol", {
+  textDocument: { uri },
+});
 
 // A save invalidates the index revision: the cache-miss path a user hits on
 // EVERY Ctrl+S, and the row that decided how round 2 felt.
 const text = `${baseText}\n# profile touch\n`;
 fs.writeFileSync(scratchFile, text, "utf8");
-void conn.sendNotification("textDocument/didChange", { textDocument: { uri, version: 2 }, contentChanges: [{ text }] });
+void conn.sendNotification("textDocument/didChange", {
+  textDocument: { uri, version: 2 },
+  contentChanges: [{ text }],
+});
 void conn.sendNotification("textDocument/didSave", { textDocument: { uri }, text });
 void conn.sendNotification("paradox/modFileChanged", { fsPath: scratchFile });
 await sleep(1200);
-results.completionAfterSave = await timed("completion (after save)", "textDocument/completion", { textDocument: { uri }, position: completionPos });
-results.tokensAfterSave = await timed("semanticTokens (after save)", "textDocument/semanticTokens/full", { textDocument: { uri } });
+results.completionAfterSave = await timed("completion (after save)", "textDocument/completion", {
+  textDocument: { uri },
+  position: completionPos,
+});
+results.tokensAfterSave = await timed("semanticTokens (after save)", "textDocument/semanticTokens/full", {
+  textDocument: { uri },
+});
 
 // The server logs `index built: … heap N MB (post-gc), rss N MB` under tracePerf.
 const built = logs.find((l) => l.includes("index built:")) ?? "";

--- a/packages/server/test/perf/profileWorkspace.ts
+++ b/packages/server/test/perf/profileWorkspace.ts
@@ -1,0 +1,263 @@
+/**
+ * Profile the server against a REAL VS Code multi-root workspace (perf round 3).
+ *
+ * Round 2's driver (`profileRequests.ts`) hardcodes game + corpus. The field
+ * reports that drive this round are `.code-workspace` files holding a game
+ * install and several Workshop mods, with `px.excludedMods` and `px.parentMods`
+ * deliberately EMPTY: every root is a full first-class root. This driver takes
+ * such a file and reproduces the settings `packages/vscode/src/config.ts` would
+ * derive from it, so the numbers describe what the user actually runs.
+ *
+ * Measures, in order: time to indexed (uninterrupted, so the scan's own cost is
+ * not confounded by starved requests), peak and post-scan RSS, post-GC heap, and
+ * the interactive requests round 2 left baselines for.
+ *
+ * Usage (from the repo root, after `pnpm run compile`):
+ *   node --experimental-strip-types packages/server/test/perf/profileWorkspace.ts <workspace.code-workspace> [outDir] [--cpu-prof]
+ */
+import { fork, spawn, type ChildProcess } from "child_process";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { createMessageConnection, IPCMessageReader, IPCMessageWriter } from "vscode-jsonrpc/node";
+
+const HERE = path.dirname(new URL(import.meta.url).pathname.replace(/^\/([A-Za-z]:)/, "$1"));
+const SERVER = path.join(HERE, "..", "..", "dist", "server.js");
+const WIKIDOCS = path.join(HERE, "..", "..", "data", "ck3", "wikidocs");
+
+const wsFile = process.argv[2];
+if (!wsFile) {
+  console.error("usage: profileWorkspace.ts <workspace.code-workspace> [outDir] [--cpu-prof]");
+  process.exit(2);
+}
+const outDir = process.argv[3]?.startsWith("--")
+  ? path.join(os.tmpdir(), "px-ws-profile")
+  : (process.argv[3] ?? path.join(os.tmpdir(), "px-ws-profile"));
+const cpuProf = process.argv.includes("--cpu-prof");
+fs.mkdirSync(outDir, { recursive: true });
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+const toUri = (p: string) => "file:///" + p.replace(/\\/g, "/").replace(/^\//, "");
+
+function write(file: string, content: string): string {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, content, "utf8");
+  return file;
+}
+
+// ---- workspace -> settings --------------------------------------------------
+
+/** A game install, not a mod: the shape `config.ts#looksLikeGameDir` probes for. */
+function looksLikeGameDir(p: string): boolean {
+  return fs.existsSync(path.join(p, "common")) && fs.existsSync(path.join(p, "events")) && !fs.existsSync(path.join(p, "descriptor.mod"));
+}
+
+// JSONC: `.code-workspace` files allow comments and trailing commas.
+const raw = fs
+  .readFileSync(wsFile, "utf8")
+  .replace(/^﻿/, "")
+  .replace(/\/\*[\s\S]*?\*\//g, "")
+  .replace(/(^|[^:])\/\/.*$/gm, "$1")
+  .replace(/,(\s*[}\]])/g, "$1");
+const ws = JSON.parse(raw) as { folders: Array<{ path: string }>; settings?: Record<string, unknown> };
+const wsDir = path.dirname(path.resolve(wsFile));
+const folders = ws.folders.map((f) => (path.isAbsolute(f.path) ? f.path : path.resolve(wsDir, f.path)));
+
+const gamePath = folders.find(looksLikeGameDir) ?? null;
+const modRoots = folders.filter((f) => f !== gamePath);
+
+const excluded = (ws.settings?.["px.excludedMods"] as string[] | undefined) ?? [];
+const declaredParents = (ws.settings?.["px.parentMods"] as string[] | undefined) ?? [];
+if (excluded.length > 0 || declaredParents.length > 0) {
+  console.warn(
+    `NOTE: this workspace sets px.excludedMods=${excluded.length} px.parentMods=${declaredParents.length}; ` +
+      "the round-3 baseline assumes both are empty."
+  );
+}
+
+// The save loop must never write into a real mod, so the edited file lives in a
+// synthetic scratch mod that takes modPath. Every real mod root then sits in
+// workspaceMods, which is the same total work: config.ts makes modPath a
+// reference-indexed root too, so moving one root between the two slots does not
+// change how many roots get the mod treatment.
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "px-ws-"));
+const scratchRoot = path.join(tmp, "scratch-mod");
+write(path.join(scratchRoot, "descriptor.mod"), 'version="1.0"\nname="prof"\nsupported_version="1.16.*"\n');
+const scratchFile = write(
+  path.join(scratchRoot, "events", "prof_events.txt"),
+  ["namespace = prof", "", "prof.1 = {", "\ttype = character_event", "\ttitle = prof.1.t", "\timmediate = {", "\t\tadd_gold = 5", "\t}", "}", ""].join("\n")
+);
+
+const settings = {
+  gamePath,
+  logsPath: null,
+  modPath: scratchRoot,
+  parentPaths: [...modRoots],
+  workspaceMods: [...modRoots],
+  locLanguage: "english",
+  scopeInlayHints: false,
+  diagnosticsIgnore: [],
+  diagnosticsIgnorePatterns: [],
+  diagnosticsVanilla: false,
+  tracePerf: true,
+};
+
+console.log(`workspace: ${path.basename(wsFile)}`);
+console.log(`  game        ${gamePath ?? "(none)"}`);
+console.log(`  mod roots   ${modRoots.length}`);
+for (const m of modRoots) console.log(`              ${path.basename(m)}`);
+console.log("");
+
+// ---- boot -------------------------------------------------------------------
+
+const storageDir = fs.mkdtempSync(path.join(os.tmpdir(), "px-ws-storage-"));
+const execArgv = ["--expose-gc", "--max-old-space-size=4096"];
+if (cpuProf) execArgv.push("--cpu-prof", "--cpu-prof-dir", outDir, "--cpu-prof-name", "server.cpuprofile");
+
+const child: ChildProcess = fork(SERVER, ["--node-ipc"], {
+  stdio: ["ignore", "pipe", "pipe", "ipc"],
+  silent: true,
+  execArgv,
+  // Env is inherited, so `UV_THREADPOOL_SIZE=N node …profileWorkspace.ts` A/Bs
+  // the read concurrency the batcher actually gets (libuv defaults to 4).
+});
+
+/**
+ * Sample the server's working set from outside it. `process.memoryUsage()` in
+ * the server reports only at index-built time; the peak during the scan is the
+ * number that decides whether a workspace fits in a 4 GB heap ceiling.
+ */
+function sampleRss(pid: number): { stop(): { peakMb: number; samples: number } } {
+  const seen: number[] = [];
+  const ps = spawn(
+    "powershell",
+    [
+      "-NoProfile",
+      "-NonInteractive",
+      "-Command",
+      `while ($true) { $p = Get-Process -Id ${pid} -ErrorAction SilentlyContinue; if ($p -eq $null) { break }; Write-Output $p.WorkingSet64; Start-Sleep -Milliseconds 400 }`,
+    ],
+    { stdio: ["ignore", "pipe", "ignore"] }
+  );
+  ps.stdout.on("data", (b: Buffer) => {
+    for (const line of b.toString().split(/\r?\n/)) {
+      const n = Number(line.trim());
+      if (Number.isFinite(n) && n > 0) seen.push(n);
+    }
+  });
+  return {
+    stop() {
+      ps.kill();
+      return { peakMb: seen.length ? Math.round(Math.max(...seen) / 1048576) : -1, samples: seen.length };
+    },
+  };
+}
+
+const rss = child.pid ? sampleRss(child.pid) : null;
+
+const logs: string[] = [];
+child.stderr?.on("data", (b: Buffer) => logs.push(b.toString().trimEnd()));
+
+const conn = createMessageConnection(new IPCMessageReader(child), new IPCMessageWriter(child));
+let indexed = false;
+let definitions = 0;
+conn.onNotification("window/logMessage", (p: { message: string }) => {
+  logs.push(p.message);
+});
+conn.onNotification("paradox/status", (p: { indexing: boolean; definitions: number }) => {
+  if (!p.indexing && p.definitions > 0) {
+    indexed = true;
+    definitions = p.definitions;
+  }
+});
+conn.onNotification(() => undefined);
+conn.onRequest(() => null);
+conn.listen();
+
+const uri = toUri(scratchFile);
+const baseText = fs.readFileSync(scratchFile, "utf8");
+const completionPos = { line: 6, character: 3 }; // inside immediate = { }
+const results: Record<string, number | string> = {};
+
+async function timed(label: string, method: string, params: unknown): Promise<number> {
+  const t0 = performance.now();
+  const res: unknown = await conn.sendRequest(method, params);
+  const ms = performance.now() - t0;
+  const count = Array.isArray(res) ? res.length : ((res as { items?: unknown[] } | null)?.items?.length ?? -1);
+  console.log(`  ${label.padEnd(34)} ${String(Math.round(ms)).padStart(8)} ms   items=${count}`);
+  return Math.round(ms);
+}
+
+await conn.sendRequest("initialize", {
+  processId: process.pid,
+  rootUri: toUri(scratchRoot),
+  workspaceFolders: folders.map((f) => ({ uri: toUri(f), name: path.basename(f) })),
+  capabilities: {},
+  initializationOptions: {
+    storageDir,
+    wikidocsDir: WIKIDOCS,
+    client: { hoverHtml: true, commands: [], ownFileWatcher: true },
+    settings,
+  },
+});
+const tScan = performance.now();
+await conn.sendNotification("initialized", {});
+void conn.sendNotification("textDocument/didOpen", {
+  textDocument: { uri, languageId: "paradox", version: 1, text: baseText },
+});
+
+console.log(`waiting for the index (${folders.length} roots)…`);
+while (!indexed) await sleep(250); // NO probing: the scan runs uninterrupted
+results.timeToIndexedMs = Math.round(performance.now() - tScan);
+results.definitions = definitions;
+console.log(`index built, uninterrupted: ${results.timeToIndexedMs} ms, ${definitions} definitions\n`);
+
+console.log("request timings:");
+results.completionCold = await timed("completion (cold cache)", "textDocument/completion", { textDocument: { uri }, position: completionPos });
+results.completionWarm = await timed("completion (warm cache)", "textDocument/completion", { textDocument: { uri }, position: completionPos });
+results.semanticTokens = await timed("semanticTokens/full", "textDocument/semanticTokens/full", { textDocument: { uri } });
+results.hover = await timed("hover", "textDocument/hover", { textDocument: { uri }, position: { line: 6, character: 5 } });
+results.documentSymbol = await timed("documentSymbol", "textDocument/documentSymbol", { textDocument: { uri } });
+
+// A save invalidates the index revision: the cache-miss path a user hits on
+// EVERY Ctrl+S, and the row that decided how round 2 felt.
+const text = `${baseText}\n# profile touch\n`;
+fs.writeFileSync(scratchFile, text, "utf8");
+void conn.sendNotification("textDocument/didChange", { textDocument: { uri, version: 2 }, contentChanges: [{ text }] });
+void conn.sendNotification("textDocument/didSave", { textDocument: { uri }, text });
+void conn.sendNotification("paradox/modFileChanged", { fsPath: scratchFile });
+await sleep(1200);
+results.completionAfterSave = await timed("completion (after save)", "textDocument/completion", { textDocument: { uri }, position: completionPos });
+results.tokensAfterSave = await timed("semanticTokens (after save)", "textDocument/semanticTokens/full", { textDocument: { uri } });
+
+// The server logs `index built: … heap N MB (post-gc), rss N MB` under tracePerf.
+const built = logs.find((l) => l.includes("index built:")) ?? "";
+results.heapMb = Number(/heap (\d+) MB/.exec(built)?.[1] ?? -1);
+results.rssAtBuildMb = Number(/rss (\d+) MB/.exec(built)?.[1] ?? -1);
+results.internedIdentifiers = Number(/(\d+) shared identifiers/.exec(built)?.[1] ?? -1);
+const peak = rss?.stop();
+results.peakRssMb = peak?.peakMb ?? -1;
+results.rssSamples = peak?.samples ?? 0;
+
+console.log("");
+console.log(`  definitions            ${results.definitions}`);
+console.log(`  shared identifiers     ${results.internedIdentifiers}`);
+console.log(`  heap after index       ${results.heapMb} MB (post-gc)`);
+console.log(`  rss  after index       ${results.rssAtBuildMb} MB`);
+console.log(`  rss  peak (sampled)    ${results.peakRssMb} MB over ${results.rssSamples} samples`);
+
+fs.writeFileSync(path.join(outDir, "results.json"), JSON.stringify(results, null, 2));
+fs.writeFileSync(path.join(outDir, "server.log"), logs.join("\n"));
+console.log(`\nwrote ${outDir}/results.json and server.log`);
+
+try {
+  await conn.sendRequest("shutdown");
+  void conn.sendNotification("exit");
+} catch {
+  /* already gone */
+}
+await sleep(cpuProf ? 2500 : 300); // let --cpu-prof flush
+if (!child.killed) child.kill();
+fs.rmSync(tmp, { recursive: true, force: true });
+fs.rmSync(storageDir, { recursive: true, force: true });
+process.exit(0);

--- a/packages/vscode/CHANGELOG.md
+++ b/packages/vscode/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.4.0 (beta) - the large-workspace round
 
 ### Fixed
 

--- a/packages/vscode/CHANGELOG.md
+++ b/packages/vscode/CHANGELOG.md
@@ -27,6 +27,13 @@
   sounds: this workspace peaked at 4081 MB against the server's 4096 MB
   ceiling, so it was running out of headroom, not out of speed.
 
+  The last of it was plain duplicated work. A mod's script files were read and
+  parsed twice, once for definitions over the schema folders and once for
+  references over the whole mod, because the two extractors each parsed the
+  file themselves. A mod is now walked once and each file parsed once, feeding
+  both. Together with the thread pool: **time to indexed 142.9 s to 61.5 s
+  cold, and 52.9 s to 44.5 s warm.**
+
 - **A window that has nothing to do with modding no longer indexes the game.**
   The extension activates in every VS Code window, and the game path was
   auto-detected from the Steam library whether or not the workspace held a

--- a/packages/vscode/CHANGELOG.md
+++ b/packages/vscode/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.4.0 (beta) - the large-workspace round
+## 0.3.4 (beta, pre-release) - the large-workspace round
 
 ### Fixed
 

--- a/packages/vscode/CHANGELOG.md
+++ b/packages/vscode/CHANGELOG.md
@@ -4,6 +4,44 @@
 
 ### Fixed
 
+- **A large workspace opens in half the time and holds 229 MB less.** Measured
+  on a real field report: a `.code-workspace` with the CK3 install and 5
+  Workshop mods, all indexed, nothing excluded. 87,250 files, 29,641 of them
+  script, 1,304,861 definitions and 7,553,947 references.
+
+  The scan reads file batches with 16 reads in flight, but every read runs on
+  libuv's thread pool, which defaults to four. Four outstanding disk requests
+  is not enough to keep a drive busy, and a cold index build waits on latency
+  rather than bandwidth. The forked server now gets a pool of 16. With the
+  page cache evicted between runs, time to indexed went **142.9 s to 71.8 s**.
+  A warm build is a second or two slower, because those reads come from RAM
+  and the extra threads only add contention.
+
+  Memory came from three allocation fixes. V8 grows an empty array's backing
+  store to 16 slots on the first push, so every name in the definition and
+  reference indexes carried 16 slots even though most hold one; both indexes
+  are now compacted once when the scan finishes. The schema root-scope `Set`
+  was rebuilt per file instead of per schema entry. Five sites built a fresh
+  `kinds` array for every reference, and nothing ever mutates one. Post-GC
+  heap after the build went **1735 MB to 1506 MB**. That matters more than it
+  sounds: this workspace peaked at 4081 MB against the server's 4096 MB
+  ceiling, so it was running out of headroom, not out of speed.
+
+- **A window that has nothing to do with modding no longer indexes the game.**
+  The extension activates in every VS Code window, and the game path was
+  auto-detected from the Steam library whether or not the workspace held a
+  mod. A Rust or web project window therefore forked a server that read the
+  36.3 MB vanilla index cache and held 253 MB for it, to answer questions
+  nobody could ask: without a mod in the workspace, no file is ever given a
+  Paradox language id. Auto-detection now needs a workspace that holds a mod
+  or a game install. An explicit `px.gamePath` still works everywhere.
+
+- **The variable-type cache could answer from the previous index.** It was
+  keyed on the definition index's revision counter, but a rebuild installs a
+  fresh index whose counter restarts at zero. Once the new index counted back
+  up to the cached number, one stale map was served. Found while profiling
+  the heap, not from a report.
+
 - **Typing and saving no longer stall on a large workspace.** Profiling the
   server on the game plus AGOT found that the first completion after any
   index change cost 4.3 s, and that a save invalidates exactly the caches

--- a/packages/vscode/README.md
+++ b/packages/vscode/README.md
@@ -95,6 +95,15 @@ bottom says exactly where they stop.
   it back as script into the mod you choose.
 - **Multi-mod workspaces**: every workspace mod is a first-class mod, indexed
   together, with per-mod tiger baselines and no "primary mod" to configure.
+- **Built for the big workspaces**: a game install plus five Workshop mods,
+  all indexed, opens in 61 s from a cold disk where it used to take 143, and
+  the server holds 1.5 GB instead of 1.7. `Paradox: Reduce VS Code Indexing
+  Load` also stops VS Code's own search and watcher crawling 43,000 texture
+  and audio files, which turns a whole-workspace Find in Files from up to
+  106 s into under a second. `px.excludedMods` drops a mod you are not
+  editing; read-only context keeps its definitions without the reference
+  index. Numbers and method in
+  [PERFORMANCE.md](https://github.com/JDeffner/paradox-modding-toolkit/blob/main/docs/PERFORMANCE.md).
 - **The workspace looks like the game you mod**: script files carry a per-game
   file icon (the crown for Crusader Kings III, the PX box for the others) and
   the status bar names the game, e.g. "Paradox Script (Victoria 3)". Snippets

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "px-toolkit",
   "displayName": "Paradox Modding Toolkit",
   "description": "Modding toolkit for Paradox games (Crusader Kings III, Victoria 3, Europa Universalis V): completion, go-to-definition, hover docs, tiger diagnostics, inline localization, event graph and a visual GUI editor.",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "publisher": "JDeffner",
   "author": {
     "name": "Joël Deffner"

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "px-toolkit",
   "displayName": "Paradox Modding Toolkit",
   "description": "Modding toolkit for Paradox games (Crusader Kings III, Victoria 3, Europa Universalis V): completion, go-to-definition, hover docs, tiger diagnostics, inline localization, event graph and a visual GUI editor.",
-  "version": "0.4.0",
+  "version": "0.3.4",
   "publisher": "JDeffner",
   "author": {
     "name": "Joël Deffner"

--- a/packages/vscode/src/config.ts
+++ b/packages/vscode/src/config.ts
@@ -257,9 +257,7 @@ export function readConfig(): PxConfig {
   // deliberate game-data-only window keeps working.
   const paradoxWorkspace =
     (cfg.get<boolean>("enableForWorkspace") ?? true) &&
-    (workspaceGameDir !== null ||
-      (modPath !== null && looksLikeMod(modPath)) ||
-      workspaceRoots.length > 0);
+    (workspaceGameDir !== null || (modPath !== null && looksLikeMod(modPath)) || workspaceRoots.length > 0);
   if (gameId !== ck3Meta.id) {
     // workspaceGameDir probes for a CK3-shaped install; never borrow it here.
     gamePath = explicitGamePath ?? (paradoxWorkspace ? findGameFolder(activeMeta.name) : null);

--- a/packages/vscode/src/config.ts
+++ b/packages/vscode/src/config.ts
@@ -247,10 +247,23 @@ export function readConfig(): PxConfig {
   const primaryRoot = modPath ?? workspaceRoots[0] ?? null;
   const gameId = detectGameId((cfg.get<string>("gameId") ?? "auto").trim().toLowerCase(), primaryRoot);
   const activeMeta = GAME_METAS[gameId] ?? ck3Meta;
+  // Auto-detection only describes a workspace that IS a Paradox workspace
+  // (perf round 3). `onStartupFinished` activates this extension in every
+  // window, and a detected game path made the server index the whole vanilla
+  // tree in a Rust or web project too: measured 253 MB of heap and ~340 ms,
+  // per window, to serve nothing. Nothing there can ever ask for it either,
+  // because languageMode.ts assigns no paradox language id when
+  // isCk3Workspace is false. An EXPLICIT px.gamePath is still honored, so a
+  // deliberate game-data-only window keeps working.
+  const paradoxWorkspace =
+    (cfg.get<boolean>("enableForWorkspace") ?? true) &&
+    (workspaceGameDir !== null ||
+      (modPath !== null && looksLikeMod(modPath)) ||
+      workspaceRoots.length > 0);
   if (gameId !== ck3Meta.id) {
     // workspaceGameDir probes for a CK3-shaped install; never borrow it here.
-    gamePath = explicitGamePath ?? findGameFolder(activeMeta.name);
-  } else if (gamePath === null) {
+    gamePath = explicitGamePath ?? (paradoxWorkspace ? findGameFolder(activeMeta.name) : null);
+  } else if (gamePath === null && paradoxWorkspace) {
     // CK3 falls back to the same Steam detection the other games get; without
     // it, a mod-only workspace runs every game-data feature (GUI templates,
     // texture roots, vanilla index) with no vanilla at all.

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -310,12 +310,29 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
   const serverModule = context.asAbsolutePath(path.join("dist", "server.js"));
   const heapArg = `--max-old-space-size=${serverHeapMb(os.totalmem())}`;
+  /**
+   * The index scan reads file batches with up to 16 reads in flight, but every
+   * fs.promises.readFile runs on libuv's thread pool, which defaults to FOUR.
+   * The scan was therefore never allowed more than four outstanding disk
+   * requests however many it issued, and a cold index build is latency-bound,
+   * not bandwidth-bound: measured on a game + 5 Workshop mods workspace
+   * (87,250 files) with an evicted page cache, time to indexed was 142.9 s at
+   * the default pool and 71.8 s at 16. Warm it changes nothing, because the
+   * reads are served from RAM.
+   *
+   * The client merges this over process.env, so nothing inherited is lost.
+   */
+  const serverEnv = { UV_THREADPOOL_SIZE: "16" };
   const serverOptions: ServerOptions = {
-    run: { module: serverModule, transport: TransportKind.ipc, options: { execArgv: [heapArg] } },
+    run: {
+      module: serverModule,
+      transport: TransportKind.ipc,
+      options: { execArgv: [heapArg], env: serverEnv },
+    },
     debug: {
       module: serverModule,
       transport: TransportKind.ipc,
-      options: { execArgv: ["--nolazy", "--inspect=6009", heapArg] },
+      options: { execArgv: ["--nolazy", "--inspect=6009", heapArg], env: serverEnv },
     },
   };
   // dataDir/wikidocsDir are deliberately NOT sent: the server derives

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -322,7 +322,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
    *
    * The client merges this over process.env, so nothing inherited is lost.
    */
-  const serverEnv = { UV_THREADPOOL_SIZE: "16" };
+  const serverEnv = { UV_THREADPOOL_SIZE: process.env.UV_THREADPOOL_SIZE ?? "16" };
   const serverOptions: ServerOptions = {
     run: {
       module: serverModule,


### PR DESCRIPTION
Stacked on #25, so this diff is round 3 only. #24 and #25 merge first.

Measured throughout on a field-report workspace that **cannot be configured out of its problem**: a `.code-workspace` with the CK3 install and 5 Steam Workshop mods, `px.excludedMods` and `px.parentMods` both empty, so all six roots are full first-class roots. 87,250 files, 29,641 of them script, 1188 MB of script text, 1,304,861 definitions, 7,553,947 references.

## Numbers

| time to indexed | warm | cold |
|---|---|---|
| after #25 | 52.4-53.3 s | 142.9 s |
| this PR | **44.4-44.7 s** | **61.5 s** |

| post-GC heap after the build | |
|---|---|
| after #25 | 1735 MB |
| this PR | **1504 MB** |

Cold runs were taken with the page cache evicted between them by streaming 24 GB of game binaries through it, on a drive that reads about 0.2 GB/s.

Peak RSS is why the memory half came first: this workspace peaked at **4081 MB against the server's 4096 MB ceiling.** It was closer to failing than to being slow.

## What changed

**The scan was never allowed to use the disk.** #25 replaced serial `readFileSync` with batches of up to 16 reads in flight, and noted libuv's thread pool was "an upper bound, not a promise". It was the binding constraint: every `fs.promises.readFile` runs on that pool, which defaults to four, and a cold build waits on latency, not bandwidth. The client now forks the server with `UV_THREADPOOL_SIZE=16`. Cold: 142.9 s at pool 4, 71.8 s at 16, 63.5 s at 32. 16 ships because the default has to hold on slower hardware than mine; warm it costs a second or two, since those reads come from RAM.

Two synthetic benchmarks disagreed about this setting, one showing a 20% regression, which is why the table is an A/B on the real workspace.

**Every mod file was read twice and parsed twice.** The definition scan walked the ~156 schema folders, then the reference scan walked the whole root for `.txt` and read it all again, and both extractors called `parseScript` themselves. 154 of 156 CK3 schema entries are `.txt`, so the sets overlapped on essentially all script. A mod root is now walked once and each file parsed once, feeding both extractors. Worth 9 s warm and 10 s cold.

**The containers cost more than the objects in them.** V8 grows an empty array's backing store to capacity 16 on the first push and most index names hold one entry, so each carried fifteen empty slots; both indexes are compacted once when the scan finishes (672 ms, one time). The schema root-scope `Set` was rebuilt per file instead of per schema entry. Five sites built a fresh `kinds` array per reference, and nothing ever mutates one.

**A window with nothing to do with modding indexed the whole game.** The extension activates in every VS Code window and auto-detected the game path from Steam regardless of workspace, so a Rust or web project window read the 36.3 MB index cache and held 253 MB to answer questions nobody could ask: without a mod present, no file is ever given a Paradox language id. Auto-detection now requires a mod or a game install in the workspace. An explicit `px.gamePath` still works everywhere.

Also fixes a stale-cache bug found while profiling: `variableTypes()` keyed on the definition index's revision, but a rebuild installs a fresh index whose counter restarts at zero, so once it counted back up one stale map was served.

## Verification

- 1,605 tests pass, `npx tsc --noEmit` and `pnpm run lint` clean.
- `packages/server/test/fusedScan.test.ts` is an equivalence guard in the shape of #25's `buildCallSiteScopes` test: it reimplements the two passes and demands identical definitions, references, implicit definitions and namespaces over a fixture root.
- New `packages/server/test/perf/profileWorkspace.ts` drives a real `.code-workspace` rather than hardcoded roots, and samples peak RSS from outside the process.
- The `config.ts` gate has no unit test: `config.ts` imports `vscode`, and AGENTS.md covers that package by smoke test and live pass. Verified via the test vsix instead.

## Two deliberate behaviour changes

Neither is reachable with a bundled schema, and both are documented in the fused scan's header: two schema folders symlinked to the same external target now index it once rather than twice, and a hypothetical schema entry nested inside another `.txt` entry would index under the longest match only.

## Left undone on purpose

A Steam update that rewrites 5,000 script files still becomes 5,000 separate rescans, each with its own 150 ms timer; that needs a "root invalidated" protocol verb, not an optimization. The reference index is still object-per-reference, where a columnar layout modelled at 121 B down to 27 B per reference, about 710 MB here. Both are bigger than this round.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Improve large-workspace indexing speed and memory usage while avoiding unnecessary game indexing in unrelated VS Code windows.

New Features:
- Add a fused workspace-mod scan that indexes definitions and references while reading and parsing each script file only once.
- Prevent unrelated workspaces from auto-detecting and indexing a game installation unless they contain a mod or game install.

Bug Fixes:
- Prevent stale variable-type results from being returned after a fresh index rebuild reuses a revision number.

Enhancements:
- Reduce large-workspace indexing time and memory usage through higher read concurrency, shared immutable reference metadata, shared schema scope sets, and compacted index buckets.

Build:
- Bump the root, server, and VS Code package versions for the release.

Documentation:
- Document round-three large-workspace performance measurements, configuration behavior, and remaining optimization opportunities.
- Update user-facing README and changelog performance guidance and results.

Tests:
- Add equivalence and cancellation coverage for the fused definition/reference scan.
- Update crash-visibility coverage for the fused scan path and extend performance harness coverage to real VS Code workspaces.