### PR TITLE
Hover redesign: one icon map for hovers, completion and trees

### DIFF
--- a/docs/EMBEDDING.md
+++ b/docs/EMBEDDING.md
@@ -211,6 +211,7 @@ interface ParadoxClientCapabilities {
   hoverHtml?: boolean;      // renders the sanitized <span style="color:var(--vscode-*)"> hover markup
   commands?: string[];      // the px.* command ids this client actually registers
   ownFileWatcher?: boolean; // client watches the mod tree and pushes paradox/modFileChanged
+  hoverIcons?: boolean;     // client sets supportThemeIcons, so hover badges may use $(codicon) glyphs
 }
 ```
 

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -69,6 +69,7 @@ interface ParadoxClientCapabilities {
   hoverHtml?: boolean;      // client renders the sanitized <span style="color:var(--vscode-*)"> hover markup
   commands?: string[];      // the px.* command ids this client registers (see "Client command ids")
   ownFileWatcher?: boolean; // client watches the mod tree itself and pushes paradox/modFileChanged
+  hoverIcons?: boolean;     // client sets supportThemeIcons, so hover badges may use $(codicon) glyphs
 }
 
 interface ParadoxSettings {
@@ -80,6 +81,7 @@ interface ParadoxSettings {
   workspaceMods?: string[];    // mods being EDITED (reference indexing + diagnostics)
   locLanguage: string;         // "english", ...
   scopeInlayHints: boolean;
+  hoverDetail?: "compact" | "standard" | "full"; // how much a hover shows; default "standard"
   diagnosticsIgnore: string[];         // diagnostic codes to suppress
   diagnosticsIgnorePatterns: string[]; // workspace-relative globs to suppress
   diagnosticsVanilla: boolean;         // false (default) = never diagnose game files
@@ -483,6 +485,11 @@ tokens and structural diagnostics all work over plain LSP.
 The `client` capabilities switch the remaining surface automatically, one
 capability at a time. A client declaring nothing (every field off) gets:
 
+- **`hoverIcons` off** — hover kind badges use a `■` square instead of a
+  `$(codicon)` glyph. The default matters: a client that does not render theme
+  icons prints the literal text `$(symbol-method)`, which is worse than the
+  square. The `<details>` disclosure that caps long examples is also omitted,
+  since it needs `hoverHtml`;
 - **`hoverHtml` off** — hover markdown is plain: no sanitized HTML spans. The
   span *content* is always self-sufficient plain text ("■ trigger", a scope
   name), so the cards read the same either way;

--- a/packages/protocol/CHANGELOG.md
+++ b/packages/protocol/CHANGELOG.md
@@ -11,9 +11,12 @@ version (up to 0.3.2); that history is in the extension changelog
 ### Added
 
 - `kinds.ts`: one map from a concept (`trigger`, `saved_scope`, `data_type`, a
-  GUI widget type) to its codicon, its `CompletionItemKind` name and its colour
-  family. Shared by the server's hover and completion and by the VS Code
-  client's tree views, so the three surfaces cannot drift apart. Carries the two
+  GUI widget type) to its codicon and its `CompletionItemKind` name. Shared by
+  the server's hover and completion and by the VS Code client's tree views, so
+  the three surfaces cannot drift apart. The badge colour is derived, not
+  chosen: it is the `symbolIcon.*Foreground` token of the completion kind, the
+  token VS Code paints the completion row with, so the two surfaces agree by
+  construction. Carries the two
   facts that make the table easy to re-break: codicon aliases collapse to one
   picture, and only `CompletionItemKind` reaches the suggest widget.
 - `ParadoxClientCapabilities.hoverIcons`: the client renders `$(codicon)` in

--- a/packages/protocol/CHANGELOG.md
+++ b/packages/protocol/CHANGELOG.md
@@ -6,6 +6,20 @@ the shared helpers change. Before the split it moved inside the extension's
 version (up to 0.3.2); that history is in the extension changelog
 (`packages/vscode/CHANGELOG.md`).
 
+## Unreleased
+
+### Added
+
+- `kinds.ts`: one map from a concept (`trigger`, `saved_scope`, `data_type`, a
+  GUI widget type) to its codicon, its `CompletionItemKind` name and its colour
+  family. Shared by the server's hover and completion and by the VS Code
+  client's tree views, so the three surfaces cannot drift apart. Carries the two
+  facts that make the table easy to re-break: codicon aliases collapse to one
+  picture, and only `CompletionItemKind` reaches the suggest widget.
+- `ParadoxClientCapabilities.hoverIcons`: the client renders `$(codicon)` in
+  hover markdown. Default false.
+- `ParadoxSettings.hoverDetail`: `compact` | `standard` | `full`.
+
 ## 0.1.0
 
 First npm release. The wire contract (custom `paradox/*` requests and

--- a/packages/protocol/src/kinds.ts
+++ b/packages/protocol/src/kinds.ts
@@ -2,110 +2,138 @@
  * One kind map, three surfaces.
  *
  * Every place the product names a concept - the hover badge, the completion
- * list icon, the tree leaf - reads its glyph and colour from here, so a trigger
- * looks like a trigger everywhere. Before this map the three disagreed: the
- * hover drew coloured `■` squares from one table, completion picked
- * `CompletionItemKind` values from another, and `views.ts` painted every leaf
- * `symbol-field` regardless of kind.
+ * list icon, the tree leaf - reads its glyph from here, so a trigger looks like
+ * a trigger everywhere.
+ *
+ * The colour is not a second decision. VS Code paints a completion row from the
+ * `symbolIcon.*Foreground` token of the `CompletionItemKind` we send, and we
+ * cannot override it, so the kind IS the colour. The hover badge reuses that
+ * same token, which is why there is no colour column to keep in sync. Four
+ * groups come out of that, and choosing the kind is choosing the group:
+ *
+ *   purple   asks a question        Method
+ *   orange   makes it happen        Class, Event, Enum, Value
+ *   blue     you stored it          Variable, Field, Interface, EnumMember
+ *   grey     syntax, everything else  all the rest
  *
  * Two facts shape the table and are easy to re-break:
  *
  *  1. **Codicon aliases collapse.** `symbol-method`, `symbol-function` and
  *     `symbol-constructor` are one codepoint, so they are one picture. Same for
- *     `symbol-enum`/`symbol-value` and `symbol-key`/`symbol-text`. Check a
- *     proposed mapping against codepoints, not against the enum names. The old
- *     `trigger -> Function` / `effect -> Method` split drew a condition and an
- *     action identically, which is the single worst case in Paradox script.
- *  2. **Only `CompletionItemKind` reaches the suggest widget.** 26 values, ~22
- *     distinct pictures after the collapse. A concept that appears in a
- *     completion list cannot use a glyph from outside that set without the two
- *     surfaces disagreeing, which is the thing this map exists to end.
+ *     `symbol-enum`/`symbol-value`, `symbol-key`/`symbol-text`,
+ *     `symbol-struct`/`symbol-structure`, `symbol-unit`/`symbol-ruler` and
+ *     `symbol-type-parameter`/`symbol-parameter`. Check a proposed mapping
+ *     against codepoints, not against the names. Prefer the canonical name of a
+ *     pair: only it carries the `symbolIcon.*Foreground` rule, so a themed tree
+ *     leaf tints and an alias does not.
+ *  2. **Only `CompletionItemKind` reaches the suggest widget.** 25 values,
+ *     22 distinct pictures after the collapse. A concept that appears in a
+ *     completion list cannot use a glyph from outside that set in the list,
+ *     even though the hover and the tree can draw all 461 codicons.
  *
- * Uniqueness is promised *within a completion list*, not globally: script and
- * datafunction completions never appear together, so they may share glyphs.
+ * `codicon` and `completionKind` are separate fields for exactly that reason.
+ * They name the same picture everywhere except `texture`, whose `file-media`
+ * glyph no completion kind can produce.
+ *
+ * Uniqueness is promised *within a completion list*, not globally: script, gui
+ * and datafunction completions never appear together, so they may share glyphs.
  *
  * No imports: this is shared by the server and the VS Code client.
  */
-
-/** Colour family. VS Code's own symbol palette is three colours plus default. */
-export type KindFamily = "condition" | "action" | "data" | "default";
 
 export interface KindStyle {
   /** Codicon id, drawn in the hover badge and the tree. */
   codicon: string;
   /** `CompletionItemKind` member name; the server maps it to the enum. */
   completionKind: string;
-  family: KindFamily;
+  /** Hover badge colour as a `--vscode-symbolIcon-*` var, or null for none. */
+  color: string | null;
 }
 
-/** `--vscode-*` colour per family. "default" emits no span at all. */
-export const FAMILY_COLOR: Record<Exclude<KindFamily, "default">, string> = {
-  condition: "var(--vscode-symbolIcon-functionForeground)",
-  action: "var(--vscode-symbolIcon-classForeground)",
-  data: "var(--vscode-symbolIcon-variableForeground)",
+/**
+ * The only completion kinds VS Code tints; the other 15 render in the plain
+ * editor foreground, so their badge emits no span at all.
+ */
+const TINT: Record<string, string> = {
+  Method: "method",
+  Function: "function",
+  Constructor: "constructor",
+  Class: "class",
+  Enum: "enumerator",
+  Value: "enumerator",
+  Event: "event",
+  Variable: "variable",
+  Field: "field",
+  Interface: "interface",
+  EnumMember: "enumeratorMember",
 };
 
-const c = (codicon: string, completionKind: string, family: KindFamily): KindStyle => ({
+/**
+ * `colorFrom` defaults to the completion kind, which is what keeps the badge
+ * and the row the same colour. `on_action` is the one entry that overrides it:
+ * it wants the interface glyph with the orange of the group it belongs to, and
+ * a completion row cannot have both.
+ */
+const c = (codicon: string, completionKind: string, colorFrom = completionKind): KindStyle => ({
   codicon,
   completionKind,
-  family,
+  color: TINT[colorFrom] ? `var(--vscode-symbolIcon-${TINT[colorFrom]}Foreground)` : null,
 });
 
-/**
- * Script layer. Engine and mod versions of one concept share a glyph on
- * purpose; the head tail (`· mod`, `· engine`) carries the difference.
- */
 const SCRIPT: Record<string, KindStyle> = {
-  trigger: c("symbol-method", "Function", "condition"),
-  scripted_trigger: c("symbol-method", "Method", "condition"),
-  effect: c("symbol-event", "Event", "action"),
-  scripted_effect: c("symbol-event", "Event", "action"),
-  event: c("symbol-class", "Class", "action"),
-  on_action: c("symbol-operator", "Operator", "action"),
-  decision: c("symbol-structure", "Struct", "action"),
-  trait: c("symbol-enum-member", "EnumMember", "default"),
-  modifier: c("symbol-property", "Property", "default"),
-  scripted_modifier: c("symbol-ruler", "Unit", "default"),
-  script_value: c("symbol-enum", "Value", "default"),
-  define: c("symbol-constant", "Constant", "default"),
-  namespace: c("symbol-namespace", "Module", "default"),
-  // One family, one glyph: a name that resolves to a scope or a stored value.
-  saved_scope: c("symbol-variable", "Variable", "data"),
-  variable: c("symbol-variable", "Variable", "data"),
-  local_variable: c("symbol-variable", "Variable", "data"),
-  global_variable: c("symbol-variable", "Variable", "data"),
-  variable_list: c("symbol-variable", "Variable", "data"),
-  local_variable_list: c("symbol-variable", "Variable", "data"),
-  global_variable_list: c("symbol-variable", "Variable", "data"),
-  list: c("symbol-variable", "Variable", "data"),
-  event_target: c("symbol-variable", "Variable", "data"),
-  scope_word: c("symbol-variable", "Variable", "data"),
-  macro_param: c("symbol-parameter", "TypeParameter", "default"),
-  structure_key: c("symbol-field", "Field", "default"),
-  keyword: c("symbol-keyword", "Keyword", "default"),
-  loc_key: c("symbol-key", "Text", "default"),
-  text_format: c("symbol-color", "Color", "default"),
-  texture: c("symbol-file", "File", "default"),
-  // GUI layer. `gui_type` and `gui_property` used to fall through to the
-  // "definition kinds read green" default, which nobody chose.
-  gui_type: c("symbol-class", "Class", "action"),
-  gui_template: c("symbol-snippet", "Snippet", "action"),
-  gui_property: c("symbol-field", "Field", "default"),
-  gui_enum_value: c("symbol-enum-member", "EnumMember", "default"),
-  descriptor_field: c("symbol-field", "Field", "default"),
-  // Datafunction layer. Blue is a thing you have, purple is a call you make;
-  // a member promote used to be a grey wrench and a global promote a blue
-  // variable, for no reason.
-  data_type: c("symbol-class", "Class", "action"),
-  promote: c("symbol-variable", "Variable", "data"),
-  datafn: c("symbol-method", "Method", "condition"),
-  format_suffix: c("symbol-enum-member", "EnumMember", "default"),
+  // purple: asks a question.
+  trigger: c("symbol-method", "Method"),
+  scripted_trigger: c("symbol-method", "Method"),
+  datafn: c("symbol-method", "Method"),
+
+  // orange: makes it happen.
+  effect: c("symbol-event", "Event"),
+  scripted_effect: c("symbol-event", "Event"),
+  event: c("symbol-class", "Class"),
+  decision: c("symbol-class", "Class"),
+  gui_type: c("symbol-class", "Class"),
+  data_type: c("symbol-class", "Class"),
+  on_action: c("symbol-interface", "Interface", "Class"),
+  trait: c("symbol-value", "Value"),
+
+  // blue: you stored it. A name that resolves to a scope or a stored value.
+  variable: c("symbol-variable", "Variable"),
+  local_variable: c("symbol-variable", "Variable"),
+  global_variable: c("symbol-variable", "Variable"),
+  promote: c("symbol-variable", "Variable"),
+  saved_scope: c("symbol-field", "Field"),
+  event_target: c("symbol-interface", "Interface"),
+  list: c("symbol-enum-member", "EnumMember"),
+  variable_list: c("symbol-enum-member", "EnumMember"),
+  local_variable_list: c("symbol-enum-member", "EnumMember"),
+  global_variable_list: c("symbol-enum-member", "EnumMember"),
+
+  // grey: syntax and everything else.
+  scope_word: c("symbol-constant", "Constant"),
+  structure_key: c("symbol-struct", "Struct"),
+  descriptor_field: c("symbol-struct", "Struct"),
+  keyword: c("symbol-keyword", "Keyword"),
+  modifier: c("symbol-property", "Property"),
+  scripted_modifier: c("symbol-property", "Property"),
+  gui_property: c("symbol-property", "Property"),
+  script_value: c("symbol-operator", "Operator"),
+  define: c("symbol-unit", "Unit"),
+  namespace: c("symbol-module", "Module"),
+  loc_key: c("symbol-text", "Text"),
+  macro_param: c("symbol-type-parameter", "TypeParameter"),
+  text_format: c("symbol-color", "Color"),
+  gui_enum_value: c("symbol-constant", "Constant"),
+  format_suffix: c("symbol-constant", "Constant"),
+  gui_template: c("symbol-snippet", "Snippet"),
+  // The picture-frame glyph no completion kind can draw: the hover and the tree
+  // get `file-media`, the completion row falls back to the plain file glyph.
+  texture: c("file-media", "File"),
 };
 
 /** Anything the map does not name: a definition we have no opinion about. */
-export const DEFAULT_KIND_STYLE: KindStyle = c("go-to-file", "Reference", "default");
+export const DEFAULT_KIND_STYLE: KindStyle = c("go-to-file", "Reference");
 
-/** Glyph, completion kind and colour family for a kind name. Never throws. */
+/** Glyph, completion kind and badge colour for a kind name. Never throws. */
 export function kindStyle(kind: string): KindStyle {
   return SCRIPT[kind] ?? DEFAULT_KIND_STYLE;
 }

--- a/packages/protocol/src/kinds.ts
+++ b/packages/protocol/src/kinds.ts
@@ -1,0 +1,121 @@
+/**
+ * One kind map, three surfaces.
+ *
+ * Every place the product names a concept - the hover badge, the completion
+ * list icon, the tree leaf - reads its glyph and colour from here, so a trigger
+ * looks like a trigger everywhere. Before this map the three disagreed: the
+ * hover drew coloured `■` squares from one table, completion picked
+ * `CompletionItemKind` values from another, and `views.ts` painted every leaf
+ * `symbol-field` regardless of kind.
+ *
+ * Two facts shape the table and are easy to re-break:
+ *
+ *  1. **Codicon aliases collapse.** `symbol-method`, `symbol-function` and
+ *     `symbol-constructor` are one codepoint, so they are one picture. Same for
+ *     `symbol-enum`/`symbol-value` and `symbol-key`/`symbol-text`. Check a
+ *     proposed mapping against codepoints, not against the enum names. The old
+ *     `trigger -> Function` / `effect -> Method` split drew a condition and an
+ *     action identically, which is the single worst case in Paradox script.
+ *  2. **Only `CompletionItemKind` reaches the suggest widget.** 26 values, ~22
+ *     distinct pictures after the collapse. A concept that appears in a
+ *     completion list cannot use a glyph from outside that set without the two
+ *     surfaces disagreeing, which is the thing this map exists to end.
+ *
+ * Uniqueness is promised *within a completion list*, not globally: script and
+ * datafunction completions never appear together, so they may share glyphs.
+ *
+ * No imports: this is shared by the server and the VS Code client.
+ */
+
+/** Colour family. VS Code's own symbol palette is three colours plus default. */
+export type KindFamily = "condition" | "action" | "data" | "default";
+
+export interface KindStyle {
+  /** Codicon id, drawn in the hover badge and the tree. */
+  codicon: string;
+  /** `CompletionItemKind` member name; the server maps it to the enum. */
+  completionKind: string;
+  family: KindFamily;
+}
+
+/** `--vscode-*` colour per family. "default" emits no span at all. */
+export const FAMILY_COLOR: Record<Exclude<KindFamily, "default">, string> = {
+  condition: "var(--vscode-symbolIcon-functionForeground)",
+  action: "var(--vscode-symbolIcon-classForeground)",
+  data: "var(--vscode-symbolIcon-variableForeground)",
+};
+
+const c = (codicon: string, completionKind: string, family: KindFamily): KindStyle => ({
+  codicon,
+  completionKind,
+  family,
+});
+
+/**
+ * Script layer. Engine and mod versions of one concept share a glyph on
+ * purpose; the head tail (`· mod`, `· engine`) carries the difference.
+ */
+const SCRIPT: Record<string, KindStyle> = {
+  trigger: c("symbol-method", "Function", "condition"),
+  scripted_trigger: c("symbol-method", "Method", "condition"),
+  effect: c("symbol-event", "Event", "action"),
+  scripted_effect: c("symbol-event", "Event", "action"),
+  event: c("symbol-class", "Class", "action"),
+  on_action: c("symbol-operator", "Operator", "action"),
+  decision: c("symbol-structure", "Struct", "action"),
+  trait: c("symbol-enum-member", "EnumMember", "default"),
+  modifier: c("symbol-property", "Property", "default"),
+  scripted_modifier: c("symbol-ruler", "Unit", "default"),
+  script_value: c("symbol-enum", "Value", "default"),
+  define: c("symbol-constant", "Constant", "default"),
+  namespace: c("symbol-namespace", "Module", "default"),
+  // One family, one glyph: a name that resolves to a scope or a stored value.
+  saved_scope: c("symbol-variable", "Variable", "data"),
+  variable: c("symbol-variable", "Variable", "data"),
+  local_variable: c("symbol-variable", "Variable", "data"),
+  global_variable: c("symbol-variable", "Variable", "data"),
+  variable_list: c("symbol-variable", "Variable", "data"),
+  local_variable_list: c("symbol-variable", "Variable", "data"),
+  global_variable_list: c("symbol-variable", "Variable", "data"),
+  list: c("symbol-variable", "Variable", "data"),
+  event_target: c("symbol-variable", "Variable", "data"),
+  scope_word: c("symbol-variable", "Variable", "data"),
+  macro_param: c("symbol-parameter", "TypeParameter", "default"),
+  structure_key: c("symbol-field", "Field", "default"),
+  keyword: c("symbol-keyword", "Keyword", "default"),
+  loc_key: c("symbol-key", "Text", "default"),
+  text_format: c("symbol-color", "Color", "default"),
+  texture: c("symbol-file", "File", "default"),
+  // GUI layer. `gui_type` and `gui_property` used to fall through to the
+  // "definition kinds read green" default, which nobody chose.
+  gui_type: c("symbol-class", "Class", "action"),
+  gui_template: c("symbol-snippet", "Snippet", "action"),
+  gui_property: c("symbol-field", "Field", "default"),
+  gui_enum_value: c("symbol-enum-member", "EnumMember", "default"),
+  descriptor_field: c("symbol-field", "Field", "default"),
+  // Datafunction layer. Blue is a thing you have, purple is a call you make;
+  // a member promote used to be a grey wrench and a global promote a blue
+  // variable, for no reason.
+  data_type: c("symbol-class", "Class", "action"),
+  promote: c("symbol-variable", "Variable", "data"),
+  datafn: c("symbol-method", "Method", "condition"),
+  format_suffix: c("symbol-enum-member", "EnumMember", "default"),
+};
+
+/** Anything the map does not name: a definition we have no opinion about. */
+export const DEFAULT_KIND_STYLE: KindStyle = c("go-to-file", "Reference", "default");
+
+/** Glyph, completion kind and colour family for a kind name. Never throws. */
+export function kindStyle(kind: string): KindStyle {
+  return SCRIPT[kind] ?? DEFAULT_KIND_STYLE;
+}
+
+/** True when the map has an opinion, i.e. the kind is not falling through. */
+export function hasKindStyle(kind: string): boolean {
+  return Object.prototype.hasOwnProperty.call(SCRIPT, kind);
+}
+
+/** Every mapped kind, for the coverage test that keeps this table honest. */
+export function mappedKinds(): string[] {
+  return Object.keys(SCRIPT);
+}

--- a/packages/protocol/src/protocol.ts
+++ b/packages/protocol/src/protocol.ts
@@ -186,6 +186,10 @@ export interface StatusPayload {
    * (data/<gameId>/script_docs) rather than the user's own dump. */
   tokensFromBundledDumps?: boolean;
   definitions: number;
+  /** Tokens the bundled wiki added that script_docs did not have. The wiki is
+   * merged even when the user has their own dump, but its real contribution is
+   * usage examples; the extra NAMES are mostly deprecated API. */
+  tokensWikiOnly?: number;
   /** True while a (re)scan is running. */
   indexing: boolean;
 }

--- a/packages/protocol/src/protocol.ts
+++ b/packages/protocol/src/protocol.ts
@@ -30,6 +30,12 @@ export interface ParadoxSettings {
   locLanguage: string;
   /** Show inferred scope after scope-changing block openers (off by default). */
   scopeInlayHints: boolean;
+  /**
+   * How much a hover shows. `standard` applies every cap in the design;
+   * `compact` drops prose and examples; `full` lifts the example cap and shows
+   * every distinct meaning.
+   */
+  hoverDetail?: "compact" | "standard" | "full";
   /** Our diagnostic codes to suppress everywhere. */
   diagnosticsIgnore: string[];
   /** Glob patterns (workspace-relative paths) whose diagnostics are suppressed. */
@@ -68,6 +74,14 @@ export interface ParadoxClientCapabilities {
    * registers one whenever the client supports dynamic registration.
    */
   ownFileWatcher?: boolean;
+  /**
+   * The client renders `$(codicon)` theme icons in hover markdown, i.e. it sets
+   * `supportThemeIcons` on the MarkdownString. Default false, and the default
+   * matters: a client without it prints the literal text `$(symbol-method)`,
+   * which is worse than the plain `■` it would otherwise get. Implies
+   * {@link ParadoxClientCapabilities.hoverHtml} is respected for colour.
+   */
+  hoverIcons?: boolean;
 }
 
 /** initializationOptions passed at LanguageClient start. All fields optional:

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -11,11 +11,42 @@ changes. Before the split it moved inside the extension's version (up to
 ### Added
 
 - `producersOf(data, typeName)` in `data/dataTypes.ts`: the reverse of
-  `membersOf`, listing every global and member whose return type is
-  `typeName`, as qualified names. Built lazily per `DataTypesData` and cached
-  against it, so a reloaded `data_types.log` gets a fresh index with no
-  explicit invalidation. The datafunction hover uses it for its new
-  `Produced by:` line.
+  `membersOf`, listing every global and member whose return type is `typeName`.
+  Built lazily per `DataTypesData` and cached against it, so a reloaded
+  `data_types.log` gets a fresh index with no explicit invalidation.
+- `features/definitionBody.ts`: the source block of an indexed definition, for
+  the hover. Brace-scans from the definition's own line (O(block), not O(file))
+  and caches the file already split into lines plus every block it extracted,
+  keyed on path and mtime. Benched against vanilla `common/scripted_triggers`
+  (3,119 definitions, 127 files): 390 µs cold, **25 µs warm**, a 16x speedup.
+  Caching the raw text instead measured 66 µs, because every hover re-split a
+  multi-thousand-line file and re-ran the scan.
+- `hoverIcons` client capability: the client renders `$(codicon)` in hover
+  markdown. Default false, and the default matters, since a client without it
+  prints the literal text `$(symbol-method)`.
+- `ParadoxSettings.hoverDetail` (`compact` | `standard` | `full`).
+
+### Changed
+
+- **One kind map, in `@px-lsp/protocol/kinds`.** Glyph, completion-item kind and
+  colour family per concept, read by the hover badge, the completion list and
+  the client's tree views. It replaced two hand-maintained tables that disagreed
+  with each other and with the trees.
+- `features/hoverRender.ts` rewritten around four slots (head, doc, example,
+  facts) plus one shared footer line per hover instead of a footer per card.
+  Badges render in three tiers by capability: codicon, `■` square, or plain
+  text. `CardInput.traits` becomes `facts`; `CardInput.footer: string[]` becomes
+  `provenance: string`, used only by multi-card hovers.
+- Long fenced blocks cap inline and disclose the rest with `<details>`, which is
+  on VS Code's markdown sanitizer allowlist and does expand in place in a real
+  hover. This is the workaround for `editorHoverVerbosityLevel` still being a
+  proposed API that cannot ship to the Marketplace. The disclosure is capped
+  too, because a hover cannot grow past the editor viewport.
+
+### Removed
+
+- `isShortExample()`, dead since it was written: exported and unit-tested but
+  never called. The example cap it was meant for now lives in `fencedBlock`.
 
 ## 0.1.0
 

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -6,6 +6,17 @@ changes. Before the split it moved inside the extension's version (up to
 0.3.2); that history is in the extension changelog
 (`packages/vscode/CHANGELOG.md`).
 
+## Unreleased
+
+### Added
+
+- `producersOf(data, typeName)` in `data/dataTypes.ts`: the reverse of
+  `membersOf`, listing every global and member whose return type is
+  `typeName`, as qualified names. Built lazily per `DataTypesData` and cached
+  against it, so a reloaded `data_types.log` gets a fresh index with no
+  explicit invalidation. The datafunction hover uses it for its new
+  `Produced by:` line.
+
 ## 0.1.0
 
 First npm release. The full language server (parser, index, scope engine,

--- a/packages/server/src/clientMode.ts
+++ b/packages/server/src/clientMode.ts
@@ -17,6 +17,8 @@ export interface ClientCapabilities {
   commands: ReadonlySet<string>;
   /** Client watches the mod tree itself and pushes paradox/modFileChanged. */
   ownFileWatcher: boolean;
+  /** Client renders `$(codicon)` in hover markdown (supportThemeIcons). */
+  hoverIcons: boolean;
 }
 
 /**
@@ -31,12 +33,18 @@ export function resolveClientCapabilities(init: Partial<ParadoxInitOptions>): Cl
       hoverHtml: init.client.hoverHtml === true,
       commands: new Set(init.client.commands ?? []),
       ownFileWatcher: init.client.ownFileWatcher === true,
+      hoverIcons: init.client.hoverIcons === true,
     };
   }
   if (init.clientCommands === true) {
-    return { hoverHtml: true, commands: new Set(allClientCommandIds), ownFileWatcher: true };
+    return {
+      hoverHtml: true,
+      commands: new Set(allClientCommandIds),
+      ownFileWatcher: true,
+      hoverIcons: true,
+    };
   }
-  return { hoverHtml: false, commands: new Set(), ownFileWatcher: false };
+  return { hoverHtml: false, commands: new Set(), ownFileWatcher: false, hoverIcons: false };
 }
 
 let caps: ClientCapabilities = resolveClientCapabilities({ clientCommands: true });
@@ -52,6 +60,11 @@ export function clientCapabilities(): ClientCapabilities {
 /** Whether hover markdown may carry the sanitized colored spans. */
 export function hoverHtml(): boolean {
   return caps.hoverHtml;
+}
+
+/** Whether hover badges may use `$(codicon)` glyphs instead of a `■` square. */
+export function hoverIcons(): boolean {
+  return caps.hoverIcons;
 }
 
 /** Whether the client registers `id`, so a `command:` link or command action reaches it. */

--- a/packages/server/src/data/dataTypes.ts
+++ b/packages/server/src/data/dataTypes.ts
@@ -277,3 +277,64 @@ export function resolveChainType(data: DataTypesData, segments: string[]): strin
   }
   return current;
 }
+
+// ---------------------------------------------------------------------------
+// Reverse index: which functions produce a given type
+// ---------------------------------------------------------------------------
+
+/**
+ * `Return type` -> the globals and members that yield it, so a hover on a data
+ * type can answer "how do I get one of these here". The forward direction
+ * (what does `Story` give me) is `membersOf`; this is the inverse, and it is
+ * the only way to see that `Story` has exactly two producers while `bool` has
+ * thousands.
+ *
+ * Built once per `DataTypesData` and cached against it, so reloading a
+ * `data_types.log` produces a fresh object and a fresh index without any
+ * explicit invalidation.
+ */
+interface ProducerIndex {
+  /** Canonical return-type name -> qualified producer names, sorted. */
+  byType: Map<string, string[]>;
+  /** Lowercased return-type name -> canonical casing. */
+  lower: Map<string, string>;
+}
+
+const producerIndex = new WeakMap<DataTypesData, ProducerIndex>();
+
+function buildProducerIndex(data: DataTypesData): ProducerIndex {
+  const byType = new Map<string, string[]>();
+  const lower = new Map<string, string>();
+  const add = (ret: string | null, qualified: string) => {
+    if (!ret) return;
+    let names = byType.get(ret);
+    if (!names) {
+      byType.set(ret, (names = []));
+      lower.set(ret.toLowerCase(), ret);
+    }
+    names.push(qualified);
+  };
+  for (const [name, member] of data.globals) add(member.ret, name);
+  for (const [type, members] of data.types) {
+    for (const [name, member] of members) add(member.ret, `${type}.${name}`);
+  }
+  for (const names of byType.values()) names.sort();
+  return { byType, lower };
+}
+
+/**
+ * Every global or member whose return type is `typeName`, as qualified names
+ * (`Scope.Story`, `GetPlayer`), sorted. Empty when nothing produces the type
+ * or the name is unknown. Callers do their own ranking and capping.
+ *
+ * Case-tolerant against both the declared type names and the return-type names
+ * seen in the dump: a type can be produced without ever being declared as a
+ * `Definition type: Type`, and the wiki tables spell some names differently.
+ */
+export function producersOf(data: DataTypesData, typeName: string): string[] {
+  let index = producerIndex.get(data);
+  if (!index) producerIndex.set(data, (index = buildProducerIndex(data)));
+  const key = typeName.toLowerCase();
+  const canonical = data.typeNamesLower.get(key) ?? index.lower.get(key) ?? typeName;
+  return index.byType.get(canonical) ?? [];
+}

--- a/packages/server/src/data/dataTypes.ts
+++ b/packages/server/src/data/dataTypes.ts
@@ -305,12 +305,17 @@ const producerIndex = new WeakMap<DataTypesData, ProducerIndex>();
 function buildProducerIndex(data: DataTypesData): ProducerIndex {
   const byType = new Map<string, string[]>();
   const lower = new Map<string, string>();
+  // Bucket by lowercased return type: the dump spells the same type both ways
+  // (a declared `Story` whose returns read `story`), and `producersOf` resolves
+  // through the declared spelling, so case variants must land in ONE bucket.
   const add = (ret: string | null, qualified: string) => {
     if (!ret) return;
-    let names = byType.get(ret);
+    const key = ret.toLowerCase();
+    const canonical = data.typeNamesLower.get(key) ?? lower.get(key) ?? ret;
+    let names = byType.get(canonical);
     if (!names) {
-      byType.set(ret, (names = []));
-      lower.set(ret.toLowerCase(), ret);
+      byType.set(canonical, (names = []));
+      lower.set(key, canonical);
     }
     names.push(qualified);
   };

--- a/packages/server/src/data/wikiDocs.ts
+++ b/packages/server/src/data/wikiDocs.ts
@@ -169,7 +169,7 @@ export interface WikiMergeOptions {
    * `script_docs` is what the engine registered when the game ran, so a name it
    * omits does not exist in that patch. The bundled wiki lists say as much
    * themselves ("be aware that it is outdated. Some effects have been
-   * deprecated"). Measured against a real CK3 install: of 2,336 wiki tokens,
+   * deprecated"). Measured against a real install: of 2,336 wiki tokens,
    * 2,262 were already in the dump and 74 were not, and the ones sampled from
    * that 74 (`every_activity_invited`, `every_participant`,
    * `accept_invitation_for_character`) appear in zero vanilla files. They are

--- a/packages/server/src/data/wikiDocs.ts
+++ b/packages/server/src/data/wikiDocs.ts
@@ -161,27 +161,85 @@ export function loadWikiTokens(dir: string): TokenData[] {
   return tokens;
 }
 
-/**
- * Merge script_docs tokens (authoritative) with wiki tokens (fallback/enrichment):
- * wiki-only tokens are added with a provenance note; tokens present in both keep
- * the script_docs doc and scopes but gain the wiki's usage example.
- */
-export function mergeWikiTokens(scriptDocs: TokenData[], wiki: TokenData[]): TokenData[] {
-  const byKey = new Map<string, TokenData>();
-  for (const t of scriptDocs) byKey.set(`${t.kind}:${t.name}`, t);
+export interface WikiMergeOptions {
+  /**
+   * Drop wiki NAMES that the script_docs dump does not have, instead of adding
+   * them. Pass this ONLY for the user's own dump.
+   *
+   * `script_docs` is what the engine registered when the game ran, so a name it
+   * omits does not exist in that patch. The bundled wiki lists say as much
+   * themselves ("be aware that it is outdated. Some effects have been
+   * deprecated"). Measured against a real CK3 install: of 2,336 wiki tokens,
+   * 2,262 were already in the dump and 74 were not, and the ones sampled from
+   * that 74 (`every_activity_invited`, `every_participant`,
+   * `accept_invitation_for_character`) appear in zero vanilla files. They are
+   * pre-Tours-and-Tournaments activity API, and offering them in completion is
+   * how a modder writes an effect that silently does nothing.
+   *
+   * The wiki's real contribution survives either way: 127 usage examples for
+   * tokens the dump already had.
+   */
+  dropUnknownNames?: boolean;
+}
 
-  const merged = [...scriptDocs];
+export interface WikiMergeResult {
+  tokens: TokenData[];
+  /** Wiki-only names added (0 when `dropUnknownNames` suppressed them). */
+  added: number;
+  /** Wiki-only names dropped as absent from the authoritative dump. */
+  dropped: number;
+  /** Tokens that gained a usage example they did not have. */
+  enriched: number;
+}
+
+/**
+ * Merge script_docs tokens (authoritative) with wiki tokens (fallback and
+ * enrichment): tokens present in both keep the script_docs doc and scopes but
+ * gain the wiki's usage example, and wiki-only tokens are either added with a
+ * provenance note or dropped (see {@link WikiMergeOptions.dropUnknownNames}).
+ *
+ * NOTE: this MUTATES the `scriptDocs` tokens it is handed, which is how
+ * enrichment lands on them. Calling it twice on the same array therefore
+ * reports `enriched: 0` the second time, because the usage examples are already
+ * there. Production calls it once per load; a comparison harness must reload.
+ */
+export function mergeWikiTokens(
+  scriptDocs: TokenData[],
+  wiki: TokenData[],
+  options: WikiMergeOptions = {}
+): WikiMergeResult {
+  const byKey = new Map<string, TokenData>();
+  /** Kinds the dump actually covers, so a wiki file for a kind script_docs does
+   *  not dump is never mistaken for "these all stopped existing". */
+  const coveredKinds = new Set<string>();
+  for (const t of scriptDocs) {
+    byKey.set(`${t.kind}:${t.name}`, t);
+    coveredKinds.add(t.kind);
+  }
+
+  const tokens = [...scriptDocs];
   const wikiNote = activeProfile().wikiNote;
+  let added = 0;
+  let dropped = 0;
+  let enriched = 0;
   for (const w of wiki) {
     const existing = byKey.get(`${w.kind}:${w.name}`);
     if (!existing) {
+      if (options.dropUnknownNames && coveredKinds.has(w.kind)) {
+        dropped++;
+        continue;
+      }
       const note = w.traits ? `${w.traits}\n${wikiNote}` : wikiNote;
-      merged.push({ ...w, traits: note });
+      tokens.push({ ...w, traits: note });
+      added++;
       continue;
     }
     if (existing.doc === "" && w.doc !== "") existing.doc = w.doc;
     // script_docs is authoritative; the wiki fills a missing syntax example.
-    if (!existing.usage && w.usage) existing.usage = w.usage;
+    if (!existing.usage && w.usage) {
+      existing.usage = w.usage;
+      enriched++;
+    }
   }
-  return merged;
+  return { tokens, added, dropped, enriched };
 }

--- a/packages/server/src/features/completion.ts
+++ b/packages/server/src/features/completion.ts
@@ -90,7 +90,7 @@ export interface CompletionResult {
  * font and take the same colour, so a condition and an action were drawn
  * identically in the suggest widget.
  */
-function itemKind(kind: string): CompletionItemKind {
+export function itemKind(kind: string): CompletionItemKind {
   const name = kindStyle(kind).completionKind as keyof typeof CompletionItemKind;
   return CompletionItemKind[name] ?? CompletionItemKind.Reference;
 }

--- a/packages/server/src/features/completion.ts
+++ b/packages/server/src/features/completion.ts
@@ -39,6 +39,7 @@
  * two-digit frequency bucket F (log2×6 scale; dense rank for structure keys),
  * source tiebreak S ("0" mod, "1" other), label as final alphabetical tiebreak.
  */
+import { kindStyle } from "@px-lsp/protocol/kinds";
 import {
   CompletionItemKind,
   InsertTextFormat,
@@ -78,33 +79,21 @@ export interface CompletionResult {
   items: CompletionItem[];
 }
 
-const TOKEN_ITEM_KINDS: Record<TokenData["kind"], CompletionItemKind> = {
-  trigger: CompletionItemKind.Function,
-  effect: CompletionItemKind.Method,
-  event_target: CompletionItemKind.Variable,
-  modifier: CompletionItemKind.Property,
-};
-
-// Distinct kinds so user/vanilla definitions are visually different from engine tokens.
-// Schema-driven kinds are an open set; unlisted ones fall back to Reference.
-const DEF_ITEM_KINDS: Record<string, CompletionItemKind> = {
-  scripted_effect: CompletionItemKind.Struct,
-  scripted_trigger: CompletionItemKind.Interface,
-  event: CompletionItemKind.Event,
-  on_action: CompletionItemKind.Event,
-  script_value: CompletionItemKind.Value,
-  scripted_modifier: CompletionItemKind.Unit,
-  loc_key: CompletionItemKind.Text,
-  trait: CompletionItemKind.EnumMember,
-  decision: CompletionItemKind.Operator,
-  saved_scope: CompletionItemKind.Variable,
-  variable: CompletionItemKind.Variable,
-  local_variable: CompletionItemKind.Variable,
-  global_variable: CompletionItemKind.Variable,
-  variable_list: CompletionItemKind.Variable,
-  local_variable_list: CompletionItemKind.Variable,
-  global_variable_list: CompletionItemKind.Variable,
-};
+/**
+ * The suggest-widget icon for a kind, from the one shared map in
+ * `@px-lsp/protocol/kinds`, so the completion list and the hover badge cannot
+ * drift apart. Kinds the map does not name fall back to `Reference`, which is
+ * also what the map's own default resolves to.
+ *
+ * This replaced two hand-maintained tables. The old one sent `trigger` to
+ * `Function` and `effect` to `Method`, which share a codepoint in the codicon
+ * font and take the same colour, so a condition and an action were drawn
+ * identically in the suggest widget.
+ */
+function itemKind(kind: string): CompletionItemKind {
+  const name = kindStyle(kind).completionKind as keyof typeof CompletionItemKind;
+  return CompletionItemKind[name] ?? CompletionItemKind.Reference;
+}
 
 const TIER_STRUCTURE = "0";
 const TIER_VALID = "1";
@@ -150,7 +139,7 @@ function structureItem(spec: KeySpec, kind: string, rank: number): CompletionIte
 }
 
 function tokenItem(t: TokenData): CompletionItem {
-  const item: CompletionItem = { label: t.name, kind: TOKEN_ITEM_KINDS[t.kind] };
+  const item: CompletionItem = { label: t.name, kind: itemKind(t.kind) };
   item.detail = t.kind + (t.scopes.length > 0 ? ` (${t.scopes.join(", ")})` : "");
   item.data = { t: "tok", k: t.kind, n: t.name };
   return item;
@@ -159,7 +148,7 @@ function tokenItem(t: TokenData): CompletionItem {
 function defItem(d: Definition, origin: string = d.source): CompletionItem {
   const item: CompletionItem = {
     label: d.name,
-    kind: DEF_ITEM_KINDS[d.kind] ?? CompletionItemKind.Reference,
+    kind: itemKind(d.kind),
   };
   item.detail = `${d.kind.replace(/_/g, " ")} (${origin})`;
   item.data = { t: "def", k: d.kind, n: d.name };

--- a/packages/server/src/features/datafunction.ts
+++ b/packages/server/src/features/datafunction.ts
@@ -480,14 +480,22 @@ const MAX_PRODUCERS = 6;
  * The cap matters because the spread is extreme: `Story` has two producers and
  * `Character` has 320. A bare count would answer neither; six ranked names plus
  * the remainder answers both.
+ *
+ * A member producer is ranked by the QUALIFIED pair count (`Scope` -> `Story`),
+ * not by the bare member name: the bare name also counts `Story` as a chain
+ * start and as a member of other owners, which is a different thing. The bare
+ * count is the fallback only where vanilla never wrote that pair.
  */
 function producerLines(data: DataTypesData, usage: DataFnUsage, type: string): string[] {
   const all = producersOf(data, type);
   if (all.length === 0) return [];
-  const ranked = [...all].sort((a, b) => {
-    const rank = (q: string) => usageCount(usage, q.slice(q.indexOf(".") + 1));
-    return rank(b) - rank(a) || a.localeCompare(b);
-  });
+  const rank = (q: string) => {
+    const dot = q.indexOf(".");
+    if (dot < 0) return usageCount(usage, q);
+    const pair = usage.pairs.get(q.slice(0, dot))?.get(q.slice(dot + 1));
+    return pair ?? usageCount(usage, q.slice(dot + 1));
+  };
+  const ranked = [...all].sort((a, b) => rank(b) - rank(a) || a.localeCompare(b));
   const shown = ranked
     .slice(0, MAX_PRODUCERS)
     .map((n) => `\`${n}\``)

--- a/packages/server/src/features/datafunction.ts
+++ b/packages/server/src/features/datafunction.ts
@@ -13,7 +13,13 @@
  */
 import { CompletionItemKind, type CompletionItem, type SignatureHelp } from "vscode-languageserver/node";
 import { describeDataFn } from "../data/dataFnDocs";
-import { membersOf, resolveChainType, type DataTypeMember, type DataTypesData } from "../data/dataTypes";
+import {
+  membersOf,
+  producersOf,
+  resolveChainType,
+  type DataTypeMember,
+  type DataTypesData,
+} from "../data/dataTypes";
 import type { DataFnUsage } from "../data/dataFnUsage";
 import type { DefinitionIndex } from "../index/indexer";
 import { finalize, MAX_ITEMS, type CompletionResult } from "./completion";
@@ -463,6 +469,33 @@ function provenance(member: DataTypeMember | null): string {
   return "deduced from vanilla usage";
 }
 
+/** Producers listed by name in a hover before the tail becomes a count. */
+const MAX_PRODUCERS = 6;
+
+/**
+ * "Produced by" line for a data type: the inverse of the member list, i.e. how
+ * you obtain one of these in the first place. Ranked by vanilla usage, so the
+ * names people actually write come first, then capped with a `+N more` tail.
+ *
+ * The cap matters because the spread is extreme: `Story` has two producers and
+ * `Character` has 320. A bare count would answer neither; six ranked names plus
+ * the remainder answers both.
+ */
+function producerLines(data: DataTypesData, usage: DataFnUsage, type: string): string[] {
+  const all = producersOf(data, type);
+  if (all.length === 0) return [];
+  const ranked = [...all].sort((a, b) => {
+    const rank = (q: string) => usageCount(usage, q.slice(q.indexOf(".") + 1));
+    return rank(b) - rank(a) || a.localeCompare(b);
+  });
+  const shown = ranked
+    .slice(0, MAX_PRODUCERS)
+    .map((n) => `\`${n}\``)
+    .join(" ");
+  const rest = all.length - MAX_PRODUCERS;
+  return ["", `Produced by: ${shown}${rest > 0 ? ` +${rest.toLocaleString("en-US")} more` : ""}`];
+}
+
 /** Top-8 `.member` names observed after `name` in vanilla, as one hover line. */
 function topMemberLines(usage: DataFnUsage, name: string, label: string): string[] {
   const pairs = usage.pairs.get(name);
@@ -546,6 +579,7 @@ export function provideDataFnHover(
     const typeMembers = membersOf(data, segment);
     if (typeMembers) {
       lines.push(`\`${segment}\` — data type (${typeMembers.size} known members)`);
+      lines.push(...producerLines(data, usage, segment));
       lines.push(...topMemberLines(usage, segment, "Common members"));
       lines.push(...exampleLines(usage, segment, gameRoot));
     } else {

--- a/packages/server/src/features/definitionBody.ts
+++ b/packages/server/src/features/definitionBody.ts
@@ -1,0 +1,119 @@
+/**
+ * The source block of an indexed definition, for the hover.
+ *
+ * Asked for by a user: "I would love if it showed what the scripted trigger is
+ * on hover." The index stores a definition's `file` and `line` but not its
+ * body, so the hover reads it back on demand.
+ *
+ * Two things keep this off the hot path:
+ *
+ *  - **Scan, do not parse.** A full `parseScript` is O(file); brace-counting
+ *    from the definition's own line is O(block). Vanilla `common/` files run to
+ *    thousands of lines and a hover must not pay for all of them.
+ *  - **Cache by path and mtime.** A hover repeats on every mouse move inside
+ *    the same word, so the same block is asked for many times in a row. The
+ *    cache is small and bounded; the mtime key means an edited file re-reads
+ *    itself with no explicit invalidation.
+ *
+ * Measured against vanilla `common/scripted_triggers` (3,152 definitions):
+ * median body 10 lines, p90 32, longest 232. Only 11% are 3 lines or shorter,
+ * which is why the caller caps the inline part and discloses the rest rather
+ * than truncating.
+ *
+ * No `vscode` imports: unit-tested in plain Node.
+ */
+import * as fs from "fs";
+
+/**
+ * Bounded cache; hovers repeat on the same file far more often than they move.
+ *
+ * The cache holds the file already SPLIT INTO LINES, and memoizes each block it
+ * has extracted. Caching the raw text instead measured 66 µs per warm hover,
+ * because every call re-split a multi-thousand-line vanilla file and re-ran the
+ * brace scan. Both are now paid once per file per mtime.
+ */
+const CACHE_MAX = 32;
+interface Entry {
+  mtimeMs: number;
+  lines: string[];
+  /** Extracted blocks by start line, so a repeated hover costs a Map lookup. */
+  blocks: Map<number, string | null>;
+}
+const cache = new Map<string, Entry>();
+
+function entryFor(file: string): Entry | null {
+  let stat: fs.Stats;
+  try {
+    stat = fs.statSync(file);
+  } catch {
+    return null;
+  }
+  const hit = cache.get(file);
+  if (hit && hit.mtimeMs === stat.mtimeMs) return hit;
+  let text: string;
+  try {
+    text = fs.readFileSync(file, "utf8");
+  } catch {
+    return null;
+  }
+  if (cache.size >= CACHE_MAX) {
+    const first = cache.keys().next().value;
+    if (first !== undefined) cache.delete(first);
+  }
+  const entry: Entry = { mtimeMs: stat.mtimeMs, lines: text.split(/\r?\n/), blocks: new Map() };
+  cache.set(file, entry);
+  return entry;
+}
+
+/** Drop `#` comments and quoted strings so their braces do not count. */
+function significant(line: string): string {
+  return line.replace(/"(?:[^"\\]|\\.)*"/g, '""').replace(/#.*$/, "");
+}
+
+/**
+ * The full `name = { … }` block that starts at `line`, as source text.
+ *
+ * Returns null when the file cannot be read, the line does not open a block, or
+ * the block never closes (a malformed file must not make the hover hang or
+ * return the rest of the document). Assignments with no block, like
+ * `my_value = 5`, return the single line.
+ */
+export function definitionBody(file: string, line: number, maxLines = 400): string | null {
+  const entry = entryFor(file);
+  if (entry === null) return null;
+  const memo = entry.blocks.get(line);
+  if (memo !== undefined) return memo;
+  const body = extract(entry.lines, line, maxLines);
+  entry.blocks.set(line, body);
+  return body;
+}
+
+function extract(lines: string[], line: number, maxLines: number): string | null {
+  if (line < 0 || line >= lines.length) return null;
+
+  const first = significant(lines[line]);
+  if (!first.includes("{")) {
+    const trimmed = lines[line].trim();
+    return trimmed === "" ? null : trimmed;
+  }
+
+  let depth = 0;
+  const out: string[] = [];
+  for (let i = line; i < lines.length && out.length < maxLines; i++) {
+    out.push(lines[i]);
+    for (const ch of significant(lines[i])) {
+      if (ch === "{") depth++;
+      else if (ch === "}") depth--;
+    }
+    if (depth <= 0 && i > line) break;
+    // A block that opens and closes on its own first line.
+    if (depth === 0 && i === line) break;
+  }
+  if (depth > 0 && out.length < maxLines) return null; // never closed
+  return out.join("\n").replace(/\s+$/, "");
+}
+
+/** Test seam: drop the cache so a test can rewrite a file and re-read it. */
+export function clearDefinitionBodyCache(): void {
+  cache.clear();
+}

--- a/packages/server/src/features/guiLanguage.ts
+++ b/packages/server/src/features/guiLanguage.ts
@@ -5,19 +5,13 @@
  * property usage counts) plus the definition index's gui_type entries
  * (mod + vanilla `template X { }` / `type x = base { }` declarations).
  */
-import {
-  CompletionItemKind,
-  MarkupKind,
-  type CompletionItem,
-  type Hover,
-  type Position,
-} from "vscode-languageserver/node";
+import { MarkupKind, type CompletionItem, type Hover, type Position } from "vscode-languageserver/node";
 import type { TextDocument } from "vscode-languageserver-textdocument";
 import { activeProfile } from "../games/active";
 import type { ServerData } from "../serverData";
 import { blockStackFromParse } from "../context";
 import { getParse } from "../parseCache";
-import { finalize, MAX_ITEMS, type CompletionResult } from "./completion";
+import { finalize, itemKind, MAX_ITEMS, type CompletionResult } from "./completion";
 import { provideDataFnCompletion, provideDataFnHover } from "./datafunction";
 import { guiDefSources, type GuiPaths } from "./guiNavigation";
 import { collectOverridableBlocks, resolveGuiDef, typeBaseChain, type GuiTypeDef } from "../gui/guiDefs";
@@ -101,7 +95,7 @@ function provideEnumCompletion(linePrefix: string): CompletionResult | null {
     if (used.has(v)) return;
     items.push({
       label: v,
-      kind: CompletionItemKind.EnumMember,
+      kind: itemKind("gui_enum_value"),
       detail: `${key} value${combinable ? " · combine with |" : ""}`,
       sortText: TIER_PROP + rank2(i) + v,
     });
@@ -143,7 +137,7 @@ export function provideGuiCompletion(
       for (const d of data.index.entries((def) => def.kind === "gui_type")) {
         items.push({
           label: d.name,
-          kind: CompletionItemKind.Class,
+          kind: itemKind("gui_type"),
           detail: `gui template/type (${d.source})`,
           sortText: TIER_PROP + (d.source === "mod" ? "0" : "1") + d.name,
           data: { t: "def", k: "gui_type", n: d.name },
@@ -179,7 +173,7 @@ export function provideGuiCompletion(
     const alsoType = key in guiSchema().types;
     items.push({
       label: key,
-      kind: alsoType ? CompletionItemKind.Class : CompletionItemKind.Property,
+      kind: itemKind(alsoType ? "gui_type" : "gui_property"),
       detail: typeInfo
         ? `${alsoType ? "child widget" : "property"} of ${enclosing} · ${count}× in vanilla`
         : `gui ${alsoType ? "widget" : "property"} · ${count}× in vanilla`,
@@ -193,7 +187,7 @@ export function provideGuiCompletion(
     if (seen.has(name)) return;
     items.push({
       label: name,
-      kind: CompletionItemKind.Class,
+      kind: itemKind("gui_type"),
       detail: `widget type · ${info.count}× in vanilla`,
       sortText: TIER_TYPE + rank2(Math.min(99, i)) + name,
     });

--- a/packages/server/src/features/guiLanguage.ts
+++ b/packages/server/src/features/guiLanguage.ts
@@ -268,7 +268,7 @@ export function provideGuiHover(
       const combinable = enumCombinable().has(enumKey);
       cards.push(
         renderCard({
-          kind: "keyword",
+          kind: "gui_enum_value",
           badgeLabel: "gui enum value",
           name: lower,
           headTail: `of \`${enumKey}\``,
@@ -325,12 +325,12 @@ export function provideGuiHover(
       }
       cards.push(
         renderCard({
-          kind: "gui_type",
+          kind: resolved.kind === "template" ? "gui_template" : "gui_type",
           badgeLabel: resolved.kind,
           name: resolved.kind === "template" ? word : resolved.name,
           headTail: resolved.kind === "type" ? `= ${(def as GuiTypeDef).base}` : undefined,
           doc: docParts.length > 0 ? docParts.join("\n\n") : undefined,
-          footer: footer.length > 0 ? footer : undefined,
+          provenance: footer.length > 0 ? footer.join(" · ") : undefined,
         })
       );
     }
@@ -349,7 +349,7 @@ export function provideGuiHover(
           badgeLabel: "template / type",
           name: def.name,
           headTail: `· ${data.originLabel(def)}`,
-          footer: [link],
+          provenance: link,
         })
       );
     }

--- a/packages/server/src/features/hover.ts
+++ b/packages/server/src/features/hover.ts
@@ -98,34 +98,36 @@ export function provideHover(
   const current = currentScopes(data, document, position, rootScopes, entry);
 
   // `scope:x` / `var:x` reference under the cursor → saved-scope card (§B3).
+  // For a `var:` hover the value type is worked out here but rendered on the
+  // indexed-definition card further down, so one variable produces one card.
+  let varTypeTail: string | undefined;
+  let varPrefixKinds: string[] | undefined;
   const prefix = scopePrefixBefore(lineText, range);
   if (prefix === "scope") {
     const card = savedScopeCard(data, document, word, rootScopes, entry);
     if (card) cards.push(card);
   } else if (prefix === "var" || prefix === "local_var" || prefix === "global_var") {
-    // Typed variable card: value type from the mod-wide set-site analysis, plus
-    // set-site links (namespace-correct: var/local_var/global_var are distinct).
+    // The variable's value type, from the mod-wide set-site analysis
+    // (namespace-correct: var/local_var/global_var are distinct).
     const varInfo = variableTypes(data, data.rootScopesForFile);
     const typed = varInfo.types.get(`${prefix}:${word}`);
     const itemTyped = varInfo.listItemTypes.get(`${prefix}:${word}`);
-    const headTail = typed
+    varTypeTail = typed
       ? `→ ${[...typed].map(scopeType).join(" | ")}`
       : itemTyped
         ? `→ list of ${[...itemTyped].map(scopeType).join(" | ")}`
         : itemTyped === null
           ? `→ list`
           : `· ${prefix.replace(/_/g, " ")}`;
-    const setDefs = data.index
-      .lookup(word)
-      .filter((d) => VAR_PREFIX_KINDS[prefix].includes(d.kind))
-      .slice(0, 3);
-    const doc =
-      setDefs.length > 0
-        ? setDefs
-            .map((d) => `set in [${path.basename(d.file)}:${d.line + 1}](${URI.file(d.file)}#L${d.line + 1})`)
-            .join("  \n")
-        : undefined;
-    cards.push({ kind: "saved_scope", badgeLabel: "variable", name: word, headTail, doc });
+    // The set sites used to be listed here as "set in file:line" AND again on
+    // the indexed-definition card below, as its provenance links, so a hovered
+    // `var:` showed the same variable twice. The definition card wins: it also
+    // carries the owning mod, the site count and the references link. This card
+    // is the fallback for a variable the index has never seen set.
+    varPrefixKinds = VAR_PREFIX_KINDS[prefix];
+    if (!data.index.lookup(word).some((d) => varPrefixKinds!.includes(d.kind))) {
+      cards.push({ kind: "saved_scope", badgeLabel: "variable", name: word, headTail: varTypeTail });
+    }
   }
 
   // When the word is the VALUE of a schema ref field (`theme = faith`,
@@ -158,7 +160,19 @@ export function provideHover(
     if (keyPos && (cards.length > 0 || defs.some((d) => !VALUE_IDENTITY_KINDS.has(d.kind)))) {
       shownDefs = defs.filter((d) => !VALUE_IDENTITY_KINDS.has(d.kind));
     }
-    cards.push(...definitionCards(data, shownDefs, at));
+    // A `var:` hover only wants the variable, not every same-named symbol.
+    if (varPrefixKinds) shownDefs = shownDefs.filter((d) => varPrefixKinds!.includes(d.kind));
+    const defCards = definitionCards(data, shownDefs, at);
+    // The value type belongs on the definition card, which is the one card the
+    // reader gets. Prepend rather than replace: the card's own tail names the
+    // owning mod and the site count.
+    if (varTypeTail && defCards.length > 0) {
+      defCards[0] = {
+        ...defCards[0],
+        headTail: defCards[0].headTail ? `${varTypeTail} ${defCards[0].headTail}` : varTypeTail,
+      };
+    }
+    cards.push(...defCards);
   }
 
   // Fallback cards, only when nothing else matched, so a real token/def with

--- a/packages/server/src/features/hover.ts
+++ b/packages/server/src/features/hover.ts
@@ -31,6 +31,9 @@ import { KEYWORD_DOCS, scopeWordDoc } from "../data/keywordDocs";
 import { matchTemplatedModifier, templatedModifierDoc } from "../data/modifierTemplates";
 import type { Scope } from "../scopes/model";
 import {
+  fencedBlock,
+  hoverCaps,
+  hoverFooter,
   renderCard,
   renderDocBody,
   renderHover,
@@ -39,6 +42,7 @@ import {
   scopeType,
   type CardInput,
 } from "./hoverRender";
+import { definitionBody } from "./definitionBody";
 import type { Definition } from "@px-lsp/protocol/types";
 import type { DefineEntry } from "../data/defines";
 
@@ -61,7 +65,7 @@ export function provideHover(
     const card = definesCard(data, defineHit.namespace, defineHit.name);
     if (card) {
       return {
-        contents: { kind: MarkupKind.Markdown, value: renderHover([card], null) },
+        contents: { kind: MarkupKind.Markdown, value: renderHover([renderCard(card)], null) },
         range: {
           start: { line: position.line, character: defineHit.start },
           end: { line: position.line, character: defineHit.end },
@@ -87,7 +91,7 @@ export function provideHover(
   }
   const word = range.word;
 
-  const cards: string[] = [];
+  const cards: CardInput[] = [];
 
   // Current scope at the cursor, computed once and shared by the pills and the
   // single footer line (§D2/§D3). null when we can't infer.
@@ -121,7 +125,7 @@ export function provideHover(
             .map((d) => `set in [${path.basename(d.file)}:${d.line + 1}](${URI.file(d.file)}#L${d.line + 1})`)
             .join("  \n")
         : undefined;
-    cards.push(renderCard({ kind: "saved_scope", badgeLabel: "variable", name: word, headTail, doc }));
+    cards.push({ kind: "saved_scope", badgeLabel: "variable", name: word, headTail, doc });
   }
 
   // When the word is the VALUE of a schema ref field (`theme = faith`,
@@ -177,18 +181,32 @@ export function provideHover(
 
   if (cards.length === 0) return null;
 
-  // Scope context appears once, last (§D2). Suppressed for a `scope:` hover
-  // (its own card already carries the scope) to match the prior behavior.
-  let footer: string | null = null;
+  // Scope context appears once, last. Suppressed for a `scope:` hover (its own
+  // card already carries the scope) to match the prior behavior.
+  let scopeLine: string | null = null;
   if (prefix !== "scope") {
     const scopes = current && current.size > 0 ? [...current].join(" | ") : "unknown";
     const inference = scopeInference(data, document, position, rootScopes, entry);
     const chain = inference.chain.length > 1 ? inference.chain.join(" · ") : null;
-    footer = scopeHereLine(scopes, chain);
+    scopeLine = scopeHereLine(scopes, chain);
+  }
+
+  // A single-card hover has no separate footer block: its provenance and
+  // reference links ride the scope line, which has to exist anyway. That is
+  // worth three lines (the row, its blank, and the rule above it) on the most
+  // common hover there is. Multi-card hovers keep provenance per card, because
+  // there it belongs to one meaning rather than to the hover.
+  const actions: string[] = [];
+  if (cards.length === 1 && cards[0].provenance) {
+    actions.push(cards[0].provenance);
+    cards[0] = { ...cards[0], provenance: undefined };
   }
 
   return {
-    contents: { kind: MarkupKind.Markdown, value: renderHover(cards, footer) },
+    contents: {
+      kind: MarkupKind.Markdown,
+      value: renderHover(cards.map(renderCard), hoverFooter(scopeLine, actions)),
+    },
     range: {
       start: { line: position.line, character: range.start },
       end: { line: position.line, character: range.end },
@@ -202,7 +220,7 @@ export function provideHover(
  * it runs in / the scope it returns. No vanilla-frequency line — engine tokens
  * never carry one and the user does not want it.
  */
-function tokenCard(token: TokenData, current: ReadonlySet<string> | null): string {
+function tokenCard(token: TokenData, current: ReadonlySet<string> | null): CardInput {
   const card: CardInput = { kind: token.kind, name: token.name };
   const { input, output, plain } = partitionScopes(token.scopes);
 
@@ -210,27 +228,27 @@ function tokenCard(token: TokenData, current: ReadonlySet<string> | null): strin
   // this token's real "datatype".
   if (output.length > 0) card.headTail = `→ ${output.map(scopeType).join(" | ")}`;
 
-  // Description, then the expected value datatype (the user's core ask).
-  const docParts: string[] = [];
-  if (token.doc) docParts.push(token.doc);
-  const shape = valueShape(token);
-  if (shape) docParts.push(`Value: ${shape}`);
-  if (docParts.length > 0) card.doc = docParts.join("\n\n");
+  // Prose only. The value datatype used to sit here as its own `Value:` line
+  // and then say much the same thing again in the traits line under the
+  // example; both now fold into the single facts line below.
+  if (token.doc) card.doc = token.doc;
 
-  // Syntax example, fenced (from a script_docs `usage:` block or the wiki).
-  if (token.usage) card.example = token.usage;
+  // Syntax example from a script_docs `usage:` block or the wiki, capped.
+  const caps = hoverCaps();
+  if (token.usage) card.example = fencedBlock(token.usage, caps.exampleLines, caps.disclosedLines);
 
-  // Remaining metadata (targets, categories, requires-data, wiki note); the
-  // `Traits:` line is already folded into the value datatype above.
-  const meta = otherTraitBits(token.traits);
-  if (meta.length > 0) card.traits = meta.join(" · ");
-
-  // Input scope(s) you call it from — matched against the current cursor scope.
+  // One facts line: the scopes you call it from (matched against the cursor
+  // scope), the shape its value takes, then whatever metadata is left.
+  const facts: string[] = [];
   const scopeVals = plain.length > 0 ? plain : input;
   if (scopeVals.length > 0) {
-    card.footer = [`Supported scopes: ${scopeVals.map((s) => scopePill(s, current)).join(" ")}`];
+    facts.push(`${scopeVals.map((s) => scopePill(s, current)).join(" | ")} scope`);
   }
-  return renderCard(card);
+  const shape = valueShape(token);
+  if (shape) facts.push(shape);
+  facts.push(...otherTraitBits(token.traits));
+  if (facts.length > 0) card.facts = facts.join(" · ");
+  return card;
 }
 
 /** Split raw scope strings into the input / output / plain buckets. */
@@ -311,7 +329,7 @@ function definitionCards(
   data: ServerData,
   defs: Array<ReturnType<ServerData["index"]["lookup"]>[number]>,
   at?: { uri: string; line: number; character: number }
-): string[] {
+): CardInput[] {
   const order: string[] = [];
   const byKind = new Map<string, typeof defs>();
   for (const def of defs) {
@@ -322,7 +340,7 @@ function definitionCards(
     }
     group.push(def);
   }
-  const cards: string[] = [];
+  const cards: CardInput[] = [];
   let withRefs = true;
   for (const kind of order) {
     const group = byKind.get(kind)!;
@@ -359,7 +377,7 @@ function definitionGroupCard(
   group: Array<ReturnType<ServerData["index"]["lookup"]>[number]>,
   at?: { uri: string; line: number; character: number },
   withRefs = true
-): string {
+): CardInput {
   const def = group[0];
   const origins = [...new Set(group.map((d) => data.originLabel(d)))];
   const card: CardInput = {
@@ -371,15 +389,30 @@ function definitionGroupCard(
         ? `· ${origins[0]} (${group.length} sites)`
         : `· ${group.length} sites in ${origins.join(", ")}`,
   };
-  const footer = group.slice(0, 3).map(provenance);
-  if (group.length > 3) footer.push(`+${group.length - 3} more`);
+  const links = group.slice(0, 3).map(provenance);
+  if (group.length > 3) links.push(`+${group.length - 3} more`);
   if (withRefs) {
     const refs = referencesFooter(data, def.name, at);
-    if (refs) footer.push(refs);
+    if (refs) links.push(refs);
   }
-  card.footer = footer;
-  return renderCard(card);
+  card.provenance = links.join(" · ");
+  return card;
 }
+
+/**
+ * Kinds whose source block is worth showing in the hover. A scripted trigger or
+ * effect IS its body, so reading it back answers the question without a jump. A
+ * loc key's "body" is one string already in the doc slot, and an event's is
+ * hundreds of lines of option blocks that no cap makes useful.
+ */
+const BODY_KINDS = new Set([
+  "scripted_trigger",
+  "scripted_effect",
+  "scripted_modifier",
+  "script_value",
+  "scripted_list",
+  "scripted_rule",
+]);
 
 /** An indexed-definition card: badge, name, `· source`, provenance link (§D2 mock 2). */
 function definitionCard(
@@ -387,7 +420,7 @@ function definitionCard(
   def: ReturnType<ServerData["index"]["lookup"]>[number],
   at?: { uri: string; line: number; character: number },
   withRefs = true
-): string {
+): CardInput {
   const card: CardInput = { kind: def.kind, badgeLabel: def.kind.replace(/_/g, " "), name: def.name };
   // Origin: the owning mod's descriptor name where known ("· My Mod"), the raw
   // source tag ("· vanilla") otherwise.
@@ -406,10 +439,21 @@ function definitionCard(
   // fills the fenced slot; `@deprecated` strikes the name. Empty when absent.
   const body = extractDoc(def);
   if (body.doc) card.doc = body.doc;
-  if (body.example) card.example = body.example;
   if (body.deprecated) card.name = `~~${def.name}~~`;
 
-  const footer: string[] = [provenance(def)];
+  // The fenced slot: an explicit `@example` wins, otherwise the definition's
+  // own source block, which is what "show me what this scripted trigger is"
+  // actually means. Capped inline and disclosed beyond that, because only 11%
+  // of vanilla scripted triggers are 3 lines or shorter.
+  const caps = hoverCaps();
+  if (body.example) {
+    card.example = fencedBlock(body.example, caps.exampleLines, caps.disclosedLines);
+  } else if (caps.bodyLines > 0 && BODY_KINDS.has(def.kind)) {
+    const src = definitionBody(def.file, def.line);
+    if (src) card.example = fencedBlock(src, caps.bodyLines, caps.disclosedLines);
+  }
+
+  const links: string[] = [provenance(def)];
   // Full count including key-position call sites (usageCount excludes those).
   // A command link opens the references view; the client's hover middleware
   // trusts exactly this command (extension.ts). Plain text without an anchor.
@@ -417,10 +461,10 @@ function definitionCard(
   // the NAME, so repeating it per meaning taught nothing.
   if (withRefs) {
     const refs = referencesFooter(data, def.name, at);
-    if (refs) footer.push(refs);
+    if (refs) links.push(refs);
   }
-  card.footer = footer;
-  return renderCard(card);
+  card.provenance = links.join(" · ");
+  return card;
 }
 
 /** `file.txt:line` provenance, as a markdown link when a file URI is feasible. */
@@ -450,7 +494,7 @@ function savedScopeCard(
   name: string,
   rootScopes: Set<Scope> | null,
   entry: SchemaEntry | null
-): string {
+): CardInput {
   const ambient = entry?.ambientScopes?.find((a) => a.name === name);
   const ictx = inferenceContextFor(data, entry);
   const saved = getSavedScopes(document, data.scopeModel, rootScopes, entry?.ambientScopes, ictx);
@@ -490,7 +534,7 @@ function savedScopeCard(
   }
 
   if (doc.length > 0) card.doc = doc.join("  \n");
-  return renderCard(card);
+  return card;
 }
 
 /** Line (0-based) of the first `save_scope_as`/`save_temporary_scope_as`/
@@ -517,7 +561,7 @@ function structureKeyCard(
   word: string,
   entry: SchemaEntry,
   getSchema: () => SchemaData
-): string | null {
+): CardInput | null {
   const { result, lineIndex } = getParse(document);
   const offset = lineIndex.offsetAt(position);
   const ctx = structureContextAt(result, offset, entry.kind, getSchema().structures);
@@ -533,7 +577,7 @@ function structureKeyCard(
   };
   if (where) card.headTail = where;
   card.doc = spec.doc ? `${spec.doc} *(${source})*` : `*(${source})*`;
-  return renderCard(card);
+  return card;
 }
 
 /** `type = character_event` — the value is a member of the key's structure enum. */
@@ -543,7 +587,7 @@ function enumValueCard(
   word: string,
   entry: SchemaEntry,
   getSchema: () => SchemaData
-): string | null {
+): CardInput | null {
   const { result, lineIndex } = getParse(document);
   const offset = lineIndex.offsetAt(position);
   const hit = nodeAtOffset(result.root, offset);
@@ -556,12 +600,12 @@ function enumValueCard(
   if (!spec?.values?.startsWith("enum:")) return null;
   const members = spec.values.slice(5).split("|");
   if (!members.includes(word)) return null;
-  return renderCard({
+  return {
     kind: "structure_key",
     badgeLabel: `${last.key.text} value`,
     name: word,
     doc: `One of: ${members.map((m) => (m === word ? `**${m}**` : m)).join(" · ")}`,
-  });
+  };
 }
 
 /** `my_effect = { AMOUNT = 3 }` — the key is a $PARAM$ of the called scripted effect/trigger. */
@@ -570,7 +614,7 @@ function macroParamCard(
   document: TextDocument,
   position: Position,
   word: string
-): string | null {
+): CardInput | null {
   const { result, lineIndex } = getParse(document);
   const offset = lineIndex.offsetAt(position);
   const hit = nodeAtOffset(result.root, offset);
@@ -583,13 +627,13 @@ function macroParamCard(
   for (const def of data.index.lookup(callee)) {
     if (def.kind !== "scripted_effect" && def.kind !== "scripted_trigger") continue;
     if (!def.params?.includes(word)) continue;
-    return renderCard({
+    return {
       kind: "macro_param",
       badgeLabel: "parameter",
       name: word,
       headTail: `of ${def.kind.replace(/_/g, " ")} \`${callee}\``,
       doc: `Replaces \`$${word}$\` in the ${def.kind.replace(/_/g, " ")}'s body.`,
-    });
+    };
   }
   return null;
 }
@@ -598,7 +642,7 @@ function macroParamCard(
  * `has_relation_dao_guide` — triggers/effects the engine generates per scripted
  * relation (`has_relation_X`, `set_relation_X`, `remove_relation_X`).
  */
-function relationTriggerCard(data: ServerData, word: string): string | null {
+function relationTriggerCard(data: ServerData, word: string): CardInput | null {
   const m = /^(has|set|remove)_relation_([A-Za-z0-9_]+)$/.exec(word);
   if (!m) return null;
   const def = data.index.lookup(m[2]).find((d) => d.kind === "scripted_relation");
@@ -609,12 +653,12 @@ function relationTriggerCard(data: ServerData, word: string): string | null {
       : m[1] === "set"
         ? "Effect: gives the scoped character"
         : "Effect: removes the scoped character's";
-  return renderCard({
+  return {
     kind: m[1] === "has" ? "trigger" : "effect",
     name: word,
     headTail: `· generated from \`${m[2]}\``,
     doc: `${verb} the scripted relation \`${m[2]}\` (${path.basename(def.file)}:${def.line + 1}) with the target character.`,
-  });
+  };
 }
 
 /**
@@ -623,7 +667,7 @@ function relationTriggerCard(data: ServerData, word: string): string | null {
  * definition index (never materialized: AGOT-scale mods define thousands of
  * cultures).
  */
-function templatedModifierCard(data: ServerData, word: string): string | null {
+function templatedModifierCard(data: ServerData, word: string): CardInput | null {
   const m = matchTemplatedModifier(word, data.modifierTemplates, (n) => data.index.lookup(n));
   if (!m) return null;
   const card: CardInput = {
@@ -632,8 +676,8 @@ function templatedModifierCard(data: ServerData, word: string): string | null {
     headTail: `· generated from \`${m.template.name}\``,
     doc: templatedModifierDoc(m),
   };
-  if (m.template.traits) card.traits = m.template.traits.split("\n").join(" · ");
-  return renderCard(card);
+  if (m.template.traits) card.facts = m.template.traits.split("\n").join(" · ");
+  return card;
 }
 
 /**
@@ -646,7 +690,7 @@ function effectArgumentCard(
   document: TextDocument,
   position: Position,
   word: string
-): string | null {
+): CardInput | null {
   const { result, lineIndex } = getParse(document);
   const offset = lineIndex.offsetAt(position);
   const hit = nodeAtOffset(result.root, offset);
@@ -664,18 +708,18 @@ function effectArgumentCard(
     headTail: `of ${token.kind.replace(/_/g, " ")} \`${token.name}\``,
   };
   if (token.doc) card.doc = token.doc;
-  return renderCard(card);
+  return card;
 }
 
 /** `cultivation_ruin` in `trigger_event = cultivation_ruin.5` etc. — a declared event namespace. */
-function namespaceCard(data: ServerData, word: string): string | null {
+function namespaceCard(data: ServerData, word: string): CardInput | null {
   if (!data.modNamespaces.has(word)) return null;
-  return renderCard({
+  return {
     kind: "namespace",
     badgeLabel: "event namespace",
     name: word,
     doc: `Events in this namespace are named \`${word}.<n>\`.`,
-  });
+  };
 }
 
 /** The `define:NS|CONST` reference spanning the cursor, or null. */
@@ -694,18 +738,18 @@ function defineRefAt(
 }
 
 /** A define card: name, resolved value, source file + layer, "overrides <layer>". */
-function definesCard(data: ServerData, namespace: string, name: string): string | null {
+function definesCard(data: ServerData, namespace: string, name: string): CardInput | null {
   const res = data.defines.resolve(namespace, name);
   if (!res) return null;
-  const footer = [defineSourceLink(res.winner)];
-  if (res.shadowed.length > 0) footer.push(`overrides ${res.shadowed.map((s) => s.layer).join(", ")}`);
-  return renderCard({
+  const links = [defineSourceLink(res.winner)];
+  if (res.shadowed.length > 0) links.push(`overrides ${res.shadowed.map((s) => s.layer).join(", ")}`);
+  return {
     kind: "define",
     badgeLabel: "define",
     name: `${namespace}|${name}`,
     headTail: `= ${res.winner.value}`,
-    footer,
-  });
+    provenance: links.join(" · "),
+  };
 }
 
 /** `<layer> · [common/defines/…:line](uri)` provenance for a define entry. */
@@ -720,17 +764,17 @@ function defineSourceLink(e: DefineEntry): string {
 }
 
 /** root/ROOT/this/prev(prev…)/from(from…) — scope navigation keywords. */
-function scopeWordCard(word: string): string | null {
+function scopeWordCard(word: string): CardInput | null {
   const hit = scopeWordDoc(word);
   if (!hit) return null;
-  return renderCard({ kind: "scope_word", badgeLabel: "scope", name: hit.name, doc: hit.doc });
+  return { kind: "scope_word", badgeLabel: "scope", name: hit.name, doc: hit.doc };
 }
 
 /** Grammar/math glue vocabulary (limit, NOT, base, days…): curated docs. */
-function keywordCard(word: string): string | null {
+function keywordCard(word: string): CardInput | null {
   const doc = KEYWORD_DOCS[word];
   if (!doc) return null;
-  return renderCard({ kind: "keyword", name: word, doc });
+  return { kind: "keyword", name: word, doc };
 }
 
 /**

--- a/packages/server/src/features/hoverRender.ts
+++ b/packages/server/src/features/hoverRender.ts
@@ -91,7 +91,7 @@ export type HoverDetail = "compact" | "standard" | "full";
 
 /**
  * Caps per detail level. The two example caps are separate because the two
- * distributions are nothing alike, measured against a real CK3 install:
+ * distributions are nothing alike, measured against a real install:
  *
  *  - engine `usage:` blocks: two thirds are 3 lines or shorter, and no block is
  *    exactly 4 lines, so 3 and 4 truncate the identical 22 tokens.

--- a/packages/server/src/features/hoverRender.ts
+++ b/packages/server/src/features/hoverRender.ts
@@ -1,55 +1,39 @@
 /**
- * Hover markdown builders (§D). Pure string assembly, no LSP or `vscode` types,
- * so the card layout is unit-testable in plain Node against the D2 mocks.
+ * Hover card markdown. Pure string assembly, no LSP or `vscode` types, so the
+ * layout is unit-testable in plain Node.
  *
- * Rendering contract (§D1): the only HTML emitted is sanitized
- * `<span style="color:var(--vscode-*)">…</span>` — VS Code renders the color
- * when `supportHtml` is on and strips the tag (keeping the plain text) when it
- * is not. Every span's *content* is therefore self-sufficient plain text (a
- * "■ trigger" badge, a scope name), so older clients degrade to markdown with
- * no loss of meaning. Do not introduce any other HTML here.
+ * The card is four slots in a fixed order, and only the first is mandatory:
+ *
+ *   <glyph> <kind> **name** <tail>     head
+ *   prose                              doc
+ *   ```paradox …```                    example
+ *   scope · value shape · traits       facts
+ *
+ * The hover then writes ONE footer line for the whole hover, never one per
+ * card: the scope context with the action links on the end of it. A separate
+ * action row would cost three lines (itself, a blank, and a rule above it) to
+ * say what fits on a line that has to exist anyway.
+ *
+ * Rendering contract, three tiers, driven by client capabilities:
+ *
+ *   hoverIcons + hoverHtml  `<span style="color:…">$(symbol-method) trigger</span>`
+ *   hoverHtml only          `<span style="color:…">■ trigger</span>`
+ *   neither                 `■ trigger`
+ *
+ * Every span's *content* is self-sufficient plain text, so a client that strips
+ * the tag keeps the meaning. The only HTML emitted is that span plus the
+ * `<details>` disclosure; both are on VS Code's markdown sanitizer allowlist.
+ * Do not introduce any other HTML: the sanitizer permits `style` on `<span>`
+ * alone, and only `color`, `background-color` and `border-radius`.
  */
 
-/** `--vscode-charts-*` / semantic color slot per kind family (§D2). */
-type ChartColor = "purple" | "red" | "yellow" | "green" | "orange" | "blue" | "foreground";
+import { FAMILY_COLOR, kindStyle, type KindFamily } from "@px-lsp/protocol/kinds";
+import { hoverHtml, hoverIcons } from "../clientMode";
 
-import { hoverHtml } from "../clientMode";
-
-function colorVar(c: ChartColor): string {
-  return c === "foreground" ? "var(--vscode-charts-foreground)" : `var(--vscode-charts-${c})`;
-}
-
-/** A sanitized colored span. Content is plain text so it survives HTML stripping.
- * Plain-markdown clients (no `client.hoverHtml`) get the bare text. */
-function span(color: ChartColor, text: string): string {
-  if (!hoverHtml()) return text;
-  return `<span style="color:${colorVar(color)};">${text}</span>`;
-}
-
-/** Kind → badge color (fixed per kind family, §D2). Definition kinds default green. */
-function badgeColor(kind: string): ChartColor {
-  switch (kind) {
-    case "trigger":
-      return "purple";
-    case "effect":
-      return "red";
-    case "structure_key":
-    case "keyword":
-    case "text_format":
-      return "yellow";
-    case "define":
-      return "blue";
-    case "saved_scope":
-    case "scope_word":
-    case "macro_param":
-      return "orange";
-    case "loc_key":
-      return "foreground";
-    default:
-      // Definition kinds (scripted_effect/trigger/modifier, script_value, event,
-      // decision, …) all read green.
-      return "green";
-  }
+/** A sanitized colored span. Content is plain text so it survives stripping. */
+function span(family: KindFamily, text: string): string {
+  if (family === "default" || !hoverHtml()) return text;
+  return `<span style="color:${FAMILY_COLOR[family]};">${text}</span>`;
 }
 
 /** Human label for a kind badge ("scripted trigger", "trigger", "saved scope"). */
@@ -58,25 +42,31 @@ function kindLabel(kind: string): string {
   return kind.replace(/_/g, " ");
 }
 
-/** `■ kind` badge, colored per family. */
+/**
+ * The head-line badge: glyph (or square) plus the kind word. The kind word
+ * stays even once glyphs carry meaning, because a glyph alone is only legible
+ * after you have learned it.
+ */
 export function kindBadge(kind: string, label = kindLabel(kind)): string {
-  return span(badgeColor(kind), `■ ${label}`);
+  const style = kindStyle(kind);
+  const mark = hoverIcons() ? `$(${style.codicon})` : "■";
+  return span(style.family, `${mark} ${label}`);
 }
 
 /**
- * A scope pill: blue when it matches the current cursor scope, muted otherwise
- * (§D3). Content is the plain scope name so stripping the span leaves it legible.
+ * A scope pill: blue when it matches the current cursor scope, muted otherwise.
+ * Content is the plain scope name so stripping the span leaves it legible.
  */
 export function scopePill(scope: string, current: ReadonlySet<string> | null): string {
   const matches = current !== null && current.has(scope.toLowerCase());
-  if (matches) return span("blue", scope);
+  if (matches) return span("data", scope);
   if (!hoverHtml()) return scope;
   return `<span style="color:var(--vscode-descriptionForeground);">${scope}</span>`;
 }
 
 /** Blue scope-type span for the "→ character" tail on badges/pills. */
 export function scopeType(type: string): string {
-  return span("blue", type);
+  return span("data", type);
 }
 
 /**
@@ -91,6 +81,106 @@ export function colorSwatch(rgb: [number, number, number]): string {
 }
 
 // ---------------------------------------------------------------------------
+// Detail levels and caps
+// ---------------------------------------------------------------------------
+
+export type HoverDetail = "compact" | "standard" | "full";
+
+/**
+ * Caps per detail level. The two example caps are separate because the two
+ * distributions are nothing alike, measured against a real CK3 install:
+ *
+ *  - engine `usage:` blocks: two thirds are 3 lines or shorter, and no block is
+ *    exactly 4 lines, so 3 and 4 truncate the identical 22 tokens.
+ *  - scripted definition bodies: only 11% are 3 lines or shorter, median 10,
+ *    p90 32, longest 232. A 3-line cap here would truncate 89% of them, which
+ *    is why the overflow goes into a `<details>` disclosure rather than being
+ *    dropped.
+ */
+export interface HoverCaps {
+  /** Cards shown before "N more meanings". */
+  cards: number;
+  /** Fenced lines from an engine `usage:` block. */
+  exampleLines: number;
+  /** Fenced lines from a definition body before the disclosure opens. */
+  bodyLines: number;
+  /** Lines inside the disclosure; a hover cannot grow past the viewport. */
+  disclosedLines: number;
+  /** Doc paragraphs. */
+  docParagraphs: number;
+}
+
+export const CAPS: Record<HoverDetail, HoverCaps> = {
+  compact: { cards: 1, exampleLines: 0, bodyLines: 0, disclosedLines: 0, docParagraphs: 0 },
+  standard: { cards: 3, exampleLines: 3, bodyLines: 3, disclosedLines: 40, docParagraphs: 2 },
+  full: { cards: 6, exampleLines: Infinity, bodyLines: 24, disclosedLines: 200, docParagraphs: 4 },
+};
+
+let detail: HoverDetail = "standard";
+
+export function setHoverDetail(value: HoverDetail): void {
+  detail = value;
+}
+
+export function hoverCaps(): HoverCaps {
+  return CAPS[detail];
+}
+
+export function hoverDetail(): HoverDetail {
+  return detail;
+}
+
+/** The language id our TextMate grammar registers (package.json `languages`). */
+const FENCE_LANG = "paradox";
+
+/** Strip the indentation every non-empty line shares, so a nested body reads flush. */
+export function stripCommonIndent(body: string): string {
+  const lines = body.split("\n");
+  let common = Infinity;
+  for (const line of lines) {
+    if (line.trim() === "") continue;
+    const indent = line.length - line.replace(/^[\t ]+/, "").length;
+    if (indent < common) common = indent;
+  }
+  if (!isFinite(common) || common === 0) return body;
+  return lines.map((l) => (l.trim() === "" ? l : l.slice(common))).join("\n");
+}
+
+/**
+ * A fenced block, capped. Overflow beyond `head` goes into a `<details>`
+ * disclosure when the client renders HTML.
+ *
+ * `<details>`/`<summary>` are on VS Code's markdown sanitizer allowlist, and
+ * the hover widget really does render the twisty, expand in place and stay
+ * open, verified by hand in a live editor. That is in-place hover expansion
+ * without the `editorHoverVerbosityLevel` proposed API, which cannot ship to
+ * the Marketplace. The one measured limit: a hover cannot grow past the editor
+ * viewport, so the disclosed body is capped too.
+ */
+export function fencedBlock(body: string, head: number, disclosed: number): string {
+  const text = stripCommonIndent(body.replace(/\s+$/, ""));
+  const lines = text.split("\n");
+  if (head <= 0) return "";
+  if (lines.length <= head) return fence(lines);
+
+  const shown = fence([...lines.slice(0, head), "…"]);
+  if (!hoverHtml() || disclosed <= 0) return shown;
+
+  const rest = lines.slice(head);
+  const inside = rest.slice(0, disclosed);
+  const hidden = rest.length - inside.length;
+  const summary = `${rest.length.toLocaleString("en-US")} more line${rest.length === 1 ? "" : "s"}`;
+  const body2 = hidden > 0 ? [...inside, `… and ${hidden.toLocaleString("en-US")} further`] : inside;
+  return [shown, "", `<details><summary>${summary}</summary>`, "", fence(body2), "", "</details>"].join(
+    "\n"
+  );
+}
+
+function fence(lines: string[]): string {
+  return `\`\`\`${FENCE_LANG}\n${lines.join("\n")}\n\`\`\``;
+}
+
+// ---------------------------------------------------------------------------
 // Card model
 // ---------------------------------------------------------------------------
 
@@ -99,64 +189,67 @@ export interface CardInput {
   /** Badge label override (e.g. "scripted trigger" for a mod def). */
   badgeLabel?: string;
   name: string;
-  /** Rendered inline after the name on line 1: pills, `· mod`, `→ character`. */
+  /** Rendered inline after the name on line 1: `· mod`, `→ character`, `= 0.5`. */
   headTail?: string;
-  /** Doc prose (blank slot workstream E extends). */
+  /** Doc prose. */
   doc?: string;
-  /** Italic traits line ("*Traits: yes/no · comparison ok*"). */
-  traits?: string;
-  /** A fenced example body (rendered ```paradox); short bodies only (§D2 mock 2). */
+  /** Already-fenced example block (build it with {@link fencedBlock}). */
   example?: string;
-  /** Footer fragments merged into one compact line (provenance, refs). */
-  footer?: string[];
+  /** One muted line: scopes, value shape and traits, joined with ` · `. */
+  facts?: string;
+  /**
+   * Per-card provenance, rendered as a muted line with no rule above it. Only
+   * multi-card hovers use it; a single-card hover puts its links on the shared
+   * footer line instead, which is two lines cheaper.
+   */
+  provenance?: string;
 }
 
-/** The language id our TextMate grammar registers (package.json `languages`). */
-const FENCE_LANG = "paradox";
-
-/** Build one card's markdown per the D2 layout. */
+/** Build one card's markdown. */
 export function renderCard(card: CardInput): string {
   const badge = kindBadge(card.kind, card.badgeLabel);
-  const head = card.headTail ? `${badge} **${card.name}** ${card.headTail}` : `${badge} **${card.name}**`;
-  const lines: string[] = [head];
-
-  if (card.doc) lines.push(card.doc);
-  if (card.example) lines.push(`\`\`\`${FENCE_LANG}\n${card.example}\n\`\`\``);
-  if (card.traits) lines.push(`*${card.traits}*`);
-
-  let md = lines.join("\n\n");
-  if (card.footer && card.footer.length > 0) {
-    md += `\n\n---\n${card.footer.join(" · ")}`;
-  }
-  return md;
+  const head = card.headTail
+    ? `${badge} **${card.name}** ${card.headTail}`
+    : `${badge} **${card.name}**`;
+  const parts: string[] = [head];
+  if (card.doc) parts.push(card.doc);
+  if (card.example) parts.push(card.example);
+  if (card.facts) parts.push(`*${card.facts}*`);
+  if (card.provenance) parts.push(card.provenance);
+  return parts.join("\n\n");
 }
 
 /**
- * Join up to `MAX_CARDS` cards, appending "*n more meanings*" when capped, then
- * the single shared scope-context footer line (§D2: scope context always last,
- * once per hover).
+ * Join cards and append the single shared footer line. Cards are separated by a
+ * rule; nothing is written above the first card or below the last one except
+ * that footer, which carries the scope context and the action links.
  */
-export const MAX_CARDS = 3;
-
-export function renderHover(cards: string[], scopeFooter: string | null): string {
-  const shown = cards.slice(0, MAX_CARDS);
+export function renderHover(cards: string[], footer: string | null): string {
+  const max = hoverCaps().cards;
+  const shown = cards.slice(0, max);
   const parts = [...shown];
   const extra = cards.length - shown.length;
   if (extra > 0) parts.push(`*${extra} more meaning${extra === 1 ? "" : "s"}*`);
   let md = parts.join("\n\n---\n\n");
-  if (scopeFooter) md += `\n\n${scopeFooter}`;
+  if (footer) md += `\n\n${footer}`;
   return md;
 }
 
-/** "Scope here: **X** (chain)" — the shared footer line appended once (§D2). */
-export function scopeHereLine(scopes: string, chain: string | null): string {
-  return chain ? `Scope here: **${scopes}** (${chain})` : `Scope here: **${scopes}**`;
+/**
+ * The shared last line: scope context, then the action links. They ride here
+ * rather than in a row of their own because this line always exists, so the
+ * links cost nothing.
+ */
+export function hoverFooter(scope: string | null, actions: string[]): string | null {
+  const parts: string[] = [];
+  if (scope) parts.push(scope);
+  parts.push(...actions);
+  return parts.length > 0 ? parts.join(" · ") : null;
 }
 
-/** True when a definition body is short enough to inline as an example (§D2). */
-export function isShortExample(body: string): boolean {
-  const lines = body.split("\n").filter((l) => l.trim() !== "");
-  return lines.length > 0 && lines.length < 4;
+/** "Scope here: **X** (chain)" — the scope half of the footer. */
+export function scopeHereLine(scopes: string, chain: string | null): string {
+  return chain ? `Scope here: **${scopes}** (${chain})` : `Scope here: **${scopes}**`;
 }
 
 // ---------------------------------------------------------------------------
@@ -169,20 +262,19 @@ interface DocTagLike {
 }
 
 export interface DocBody {
-  /** Prose + structured-tag markdown for the card's `doc` slot. Empty → undefined. */
+  /** Prose + structured-tag markdown for the card's `doc` slot. */
   doc?: string;
-  /** `@example` body for the card's fenced `example` slot. */
+  /** `@example` body, unfenced; the caller caps and fences it. */
   example?: string;
-  /** True when `@deprecated` is present — the card renders the name prominently. */
+  /** True when `@deprecated` is present. */
   deprecated?: boolean;
 }
 
 /**
- * Turn PdxDoc prose + tags (§E) into the card's `doc`/`example` slots.
- * Prose renders first, then structured tags compactly (§E3): `@param` as
- * `*@param NAME — desc*` lines, `@deprecated` as a prominent ⚠ line, other
- * recognized/unknown tags as compact italic lines. `@example` fills the fenced
- * slot. Fail-soft: absent fields yield an empty body.
+ * Turn PdxDoc prose + tags (§E) into the card's `doc`/`example` slots. Prose
+ * first, then structured tags compactly: `@param` as `*@param NAME — desc*`,
+ * `@deprecated` as a prominent ⚠ line, other tags as compact italic lines.
+ * Fail-soft: absent fields yield an empty body.
  */
 export function renderDocBody(def: { doc?: string; tags?: DocTagLike[] }): DocBody {
   const out: DocBody = {};
@@ -200,7 +292,6 @@ export function renderDocBody(def: { doc?: string; tags?: DocTagLike[] }): DocBo
         tagLines.push(t.text ? `⚠ **Deprecated** — ${t.text}` : `⚠ **Deprecated**`);
         break;
       case "param": {
-        // `@param NAME desc` → `*@param NAME — desc*`.
         const m = /^(\S+)\s*(.*)$/.exec(t.text);
         if (m) {
           const desc = m[2].trim();
@@ -211,12 +302,12 @@ export function renderDocBody(def: { doc?: string; tags?: DocTagLike[] }): DocBo
         break;
       }
       default:
-        // @scope, @saves, @returns, and unknown tags: compact italic line.
         tagLines.push(t.text ? `*@${t.tag} ${t.text}*` : `*@${t.tag}*`);
     }
   }
   if (tagLines.length > 0) lines.push(tagLines.join("  \n"));
 
-  if (lines.length > 0) out.doc = lines.join("\n\n");
+  const capped = lines.slice(0, Math.max(1, hoverCaps().docParagraphs));
+  if (hoverCaps().docParagraphs > 0 && capped.length > 0) out.doc = capped.join("\n\n");
   return out;
 }

--- a/packages/server/src/features/hoverRender.ts
+++ b/packages/server/src/features/hoverRender.ts
@@ -27,13 +27,16 @@
  * alone, and only `color`, `background-color` and `border-radius`.
  */
 
-import { FAMILY_COLOR, kindStyle, type KindFamily } from "@px-lsp/protocol/kinds";
+import { kindStyle } from "@px-lsp/protocol/kinds";
 import { hoverHtml, hoverIcons } from "../clientMode";
 
+/** The colour a stored value reads in: the same token a `Variable` row takes. */
+const STORED = "var(--vscode-symbolIcon-variableForeground)";
+
 /** A sanitized colored span. Content is plain text so it survives stripping. */
-function span(family: KindFamily, text: string): string {
-  if (family === "default" || !hoverHtml()) return text;
-  return `<span style="color:${FAMILY_COLOR[family]};">${text}</span>`;
+function span(color: string | null, text: string): string {
+  if (color === null || !hoverHtml()) return text;
+  return `<span style="color:${color};">${text}</span>`;
 }
 
 /** Human label for a kind badge ("scripted trigger", "trigger", "saved scope"). */
@@ -50,7 +53,7 @@ function kindLabel(kind: string): string {
 export function kindBadge(kind: string, label = kindLabel(kind)): string {
   const style = kindStyle(kind);
   const mark = hoverIcons() ? `$(${style.codicon})` : "■";
-  return span(style.family, `${mark} ${label}`);
+  return span(style.color, `${mark} ${label}`);
 }
 
 /**
@@ -59,14 +62,14 @@ export function kindBadge(kind: string, label = kindLabel(kind)): string {
  */
 export function scopePill(scope: string, current: ReadonlySet<string> | null): string {
   const matches = current !== null && current.has(scope.toLowerCase());
-  if (matches) return span("data", scope);
+  if (matches) return span(STORED, scope);
   if (!hoverHtml()) return scope;
   return `<span style="color:var(--vscode-descriptionForeground);">${scope}</span>`;
 }
 
 /** Blue scope-type span for the "→ character" tail on badges/pills. */
 export function scopeType(type: string): string {
-  return span("data", type);
+  return span(STORED, type);
 }
 
 /**
@@ -171,9 +174,7 @@ export function fencedBlock(body: string, head: number, disclosed: number): stri
   const hidden = rest.length - inside.length;
   const summary = `${rest.length.toLocaleString("en-US")} more line${rest.length === 1 ? "" : "s"}`;
   const body2 = hidden > 0 ? [...inside, `… and ${hidden.toLocaleString("en-US")} further`] : inside;
-  return [shown, "", `<details><summary>${summary}</summary>`, "", fence(body2), "", "</details>"].join(
-    "\n"
-  );
+  return [shown, "", `<details><summary>${summary}</summary>`, "", fence(body2), "", "</details>"].join("\n");
 }
 
 function fence(lines: string[]): string {
@@ -208,9 +209,7 @@ export interface CardInput {
 /** Build one card's markdown. */
 export function renderCard(card: CardInput): string {
   const badge = kindBadge(card.kind, card.badgeLabel);
-  const head = card.headTail
-    ? `${badge} **${card.name}** ${card.headTail}`
-    : `${badge} **${card.name}**`;
+  const head = card.headTail ? `${badge} **${card.name}** ${card.headTail}` : `${badge} **${card.name}**`;
   const parts: string[] = [head];
   if (card.doc) parts.push(card.doc);
   if (card.example) parts.push(card.example);

--- a/packages/server/src/features/locFormatting.ts
+++ b/packages/server/src/features/locFormatting.ts
@@ -114,7 +114,7 @@ export function provideFormatTagHover(
   if (rgb) doc.push(`Color: ${colorSwatch(rgb)} ${rgbCss(rgb)}`);
   if (entry.layer === "builtin") doc.push("Engine built-in format.");
   if (doc.length > 0) card.doc = doc.join("  \n");
-  if (entry.file) card.footer = [sourceLink(entry)];
+  if (entry.file) card.provenance = sourceLink(entry);
   return { markdown: renderCard(card), start: hit.start, end: hit.end };
 }
 

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -140,6 +140,7 @@ import { URI } from "vscode-uri";
 import { ServerData } from "./serverData";
 import { CompletionFeature } from "./features/completion";
 import { provideHover } from "./features/hover";
+import { setHoverDetail } from "./features/hoverRender";
 import { provideTextureHover } from "./features/textureHover";
 import { provideDefinition, provideLocDefinition } from "./features/definition";
 import { SEMANTIC_LEGEND, provideSemanticTokens } from "./features/semanticTokens";
@@ -253,6 +254,7 @@ function defaultSettings(): ParadoxSettings {
     workspaceMods: [],
     locLanguage: "english",
     scopeInlayHints: false,
+    hoverDetail: "standard",
     diagnosticsIgnore: [],
     diagnosticsIgnorePatterns: [],
     diagnosticsVanilla: false,
@@ -1092,6 +1094,7 @@ connection.onInitialize((params: InitializeParams): InitializeResult => {
   // Merge onto the defaults: bare clients may send partial settings (e.g.
   // only gameId), and every downstream consumer assumes the full shape.
   if (init.settings) settings = { ...defaultSettings(), ...init.settings };
+  setHoverDetail(settings.hoverDetail ?? "standard");
   setActiveProfile(resolveProfile(settings.gameId));
   deriveBundledDataDirs();
   if (!storageDir) {
@@ -1195,6 +1198,7 @@ connection.onNotification(configChangedNotification, (incoming: ParadoxSettings)
       JSON.stringify(settings.diagnosticsIgnorePatterns) ||
     newSettings.diagnosticsVanilla !== settings.diagnosticsVanilla;
   settings = newSettings;
+  setHoverDetail(settings.hoverDetail ?? "standard");
   completion.setSettings(settings);
   if (pathsChanged) {
     log("paths changed; rebuilding data...");

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -267,6 +267,7 @@ let wikidocsDir = "";
 let freqsDir = "";
 let tokensFromScriptDocs = false;
 let tokensFromBundledDumps = false;
+let tokensWikiOnly = 0;
 let indexing = false;
 /** Bumped whenever paths change; in-flight scans abort when superseded. */
 let scanGeneration = 0;
@@ -459,6 +460,7 @@ function sendStatus(): void {
     tokensFromScriptDocs,
     tokensFromBundledDumps,
     definitions: total,
+    tokensWikiOnly,
     indexing,
   };
   void connection.sendNotification(statusNotification, payload);
@@ -582,6 +584,7 @@ function loadDocs(force: boolean): void {
   const t1 = Date.now();
   const wikiTokens = loadWikiTokens(wikidocsDir);
   const merged = mergeWikiTokens(scriptTokens, wikiTokens);
+  tokensWikiOnly = merged.length - scriptTokens.length;
   data.setTokens(merged);
   log(`wiki docs: ${wikiTokens.length} tokens, merged total ${merged.length} (${Date.now() - t1}ms)`);
 

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -583,10 +583,19 @@ function loadDocs(force: boolean): void {
   }
   const t1 = Date.now();
   const wikiTokens = loadWikiTokens(wikidocsDir);
-  const merged = mergeWikiTokens(scriptTokens, wikiTokens);
-  tokensWikiOnly = merged.length - scriptTokens.length;
-  data.setTokens(merged);
-  log(`wiki docs: ${wikiTokens.length} tokens, merged total ${merged.length} (${Date.now() - t1}ms)`);
+  // With the user's OWN dump loaded, a name the dump does not have does not
+  // exist in their patch, so the wiki's extras are dropped rather than offered.
+  // The bundled snapshot does not get this treatment: it may be older than the
+  // user's game, so "not in the snapshot" is not evidence of anything.
+  const ownDump = tokensFromScriptDocs && !tokensFromBundledDumps;
+  const merged = mergeWikiTokens(scriptTokens, wikiTokens, { dropUnknownNames: ownDump });
+  tokensWikiOnly = merged.added;
+  data.setTokens(merged.tokens);
+  log(
+    `wiki docs: ${wikiTokens.length} tokens, ${merged.enriched} usage examples merged in, ` +
+      `${merged.added} added${merged.dropped > 0 ? `, ${merged.dropped} dropped as absent from your script_docs` : ""}, ` +
+      `total ${merged.tokens.length} (${Date.now() - t1}ms)`
+  );
 
   // on_actions.log sits next to the other script_docs dumps; same fallback.
   const onActionsDir =

--- a/packages/server/test/clientMode.test.ts
+++ b/packages/server/test/clientMode.test.ts
@@ -32,13 +32,19 @@ const fileUri = (p: string): string => URI.file(p).toString();
 afterEach(() => asClient({ clientCommands: true }));
 
 describe("capability resolution", () => {
-  const allOff = { hoverHtml: false, commands: new Set<string>(), ownFileWatcher: false };
+  const allOff = {
+    hoverHtml: false,
+    commands: new Set<string>(),
+    ownFileWatcher: false,
+    hoverIcons: false,
+  };
 
   it("deprecated clientCommands: true means every capability", () => {
     expect(resolveClientCapabilities({ clientCommands: true })).toEqual({
       hoverHtml: true,
       commands: new Set(allClientCommandIds),
       ownFileWatcher: true,
+      hoverIcons: true,
     });
   });
 
@@ -59,6 +65,10 @@ describe("capability resolution", () => {
     expect(resolveClientCapabilities({ client: { ownFileWatcher: true } })).toEqual({
       ...allOff,
       ownFileWatcher: true,
+    });
+    expect(resolveClientCapabilities({ client: { hoverIcons: true } })).toEqual({
+      ...allOff,
+      hoverIcons: true,
     });
     expect(resolveClientCapabilities({ client: {} })).toEqual(allOff);
   });

--- a/packages/server/test/dataTypes.test.ts
+++ b/packages/server/test/dataTypes.test.ts
@@ -10,6 +10,7 @@ import {
   parseDataTypesDump,
   resolveChainType,
   membersOf,
+  producersOf,
 } from "../src/data/dataTypes";
 import {
   chainAtEnd,
@@ -684,11 +685,111 @@ describe("datatype-name completion and hover in cast literals", () => {
   });
 });
 
+
+describe("producersOf: the inverse of the member list", () => {
+  const dump = [
+    "Scope",
+    "Definition type: Type",
+    "",
+    "-----------------------",
+    "",
+    "Scope.Story",
+    "Definition type: Promote",
+    "Return type: Story",
+    "",
+    "-----------------------",
+    "",
+    "SituationItem.GetStoryCycle",
+    "Definition type: Function",
+    "Return type: Story",
+    "",
+    "-----------------------",
+    "",
+    "GetPlayer",
+    "Definition type: Global promote",
+    "Return type: Character",
+    "",
+    "-----------------------",
+    "",
+    "Character.IsAlive",
+    "Definition type: Function",
+    "Return type: bool",
+    "",
+    "-----------------------",
+    "",
+    "Story",
+    "Definition type: Type",
+    "",
+    "-----------------------",
+    "",
+    "Story.GetName",
+    "Definition type: Function",
+    "Return type: CString",
+    "",
+  ].join("\n");
+
+  it("lists every global and member that returns the type, qualified and sorted", () => {
+    const data = parseDataTypesDump(dump);
+    expect(producersOf(data, "Story")).toEqual(["Scope.Story", "SituationItem.GetStoryCycle"]);
+    expect(producersOf(data, "Character")).toEqual(["GetPlayer"]);
+  });
+
+  it("is case-tolerant on the type name and empty for unknown or unproduced types", () => {
+    const data = parseDataTypesDump(dump);
+    expect(producersOf(data, "story")).toEqual(["Scope.Story", "SituationItem.GetStoryCycle"]);
+    expect(producersOf(data, "NotAType")).toEqual([]);
+  });
+
+  it("hovering a data type says how to obtain one", () => {
+    const data = parseDataTypesDump(dump);
+    const line = 'text = "[Story.GetName]"';
+    const hover = provideDataFnHover(data, emptyUsage(), line, line.indexOf("Story") + 1)!;
+    expect(hover.markdown).toContain("Produced by:");
+    expect(hover.markdown).toContain("SituationItem.GetStoryCycle");
+  });
+
+  it("caps the list and says how many more there are", () => {
+    const many = [
+      "Widget",
+      "Definition type: Type",
+      "",
+      "-----------------------",
+      "",
+      "Widget.Get0",
+      "Definition type: Function",
+      "Return type: CString",
+      "",
+      "-----------------------",
+      "",
+    ];
+    for (let i = 0; i < 9; i++) {
+      many.push(
+        `Maker${i}.GetWidget`,
+        "Definition type: Function",
+        "Return type: Widget",
+        "",
+        "-----------------------",
+        ""
+      );
+    }
+    const data = parseDataTypesDump(many.join(String.fromCharCode(10)));
+    expect(producersOf(data, "Widget")).toHaveLength(9);
+
+    const line = 'text = "[Widget.Get0]"';
+    const hover = provideDataFnHover(data, emptyUsage(), line, line.indexOf("Widget") + 1)!;
+    expect(hover.markdown).toContain("Produced by:");
+    expect(hover.markdown).toContain("+3 more");
+  });
+});
+
 /**
  * Dump-dependent regression against the user's actual DumpDataTypes output.
  * Gated on the logs folder (devPaths.ts) so it runs on the maintainer's machine
  * and skips in CI, following the corpus-gated test pattern.
  */
+/** Mirrors MAX_PRODUCERS in datafunction.ts: above this the hover shows a count. */
+const MAX_PRODUCERS_IN_HOVER = 6;
+
 const LOGS = devPath("logsPath");
 const hasDump = LOGS !== null && fs.existsSync(path.join(LOGS, "data_types"));
 (hasDump ? describe : describe.skip)("real DumpDataTypes: user's expression resolves", () => {
@@ -698,6 +799,18 @@ const hasDump = LOGS !== null && fs.existsSync(path.join(LOGS, "data_types"));
     const result = provideDataFnCompletion(data, emptyUsage(), 'visible = "[GetPlayer.')!;
     expect(result.items.length).toBeGreaterThan(100);
     expect(result.items.map((i) => i.label)).toContain("MakeScope");
+  });
+
+  it("a narrow type lists its producers, a broad one degrades to a count", () => {
+    // The whole point of the feature: Story has a handful of producers and the
+    // names fit in a hover, bool has thousands and only the count is useful.
+    expect(producersOf(data, "Story").length).toBeLessThanOrEqual(MAX_PRODUCERS_IN_HOVER);
+    expect(producersOf(data, "bool").length).toBeGreaterThan(1000);
+
+    const line = 'text = "[Story.GetName]"';
+    const hover = provideDataFnHover(data, emptyUsage(), line, line.indexOf("Story") + 1)!;
+    expect(hover.markdown).toContain("Produced by:");
+    expect(hover.markdown).toContain("Scope.Story");
   });
 
   it("GetPlayer.MakeScope. offers Scope members including ScriptValue", () => {

--- a/packages/server/test/dataTypes.test.ts
+++ b/packages/server/test/dataTypes.test.ts
@@ -685,7 +685,6 @@ describe("datatype-name completion and hover in cast literals", () => {
   });
 });
 
-
 describe("producersOf: the inverse of the member list", () => {
   const dump = [
     "Scope",
@@ -738,6 +737,47 @@ describe("producersOf: the inverse of the member list", () => {
     const data = parseDataTypesDump(dump);
     expect(producersOf(data, "story")).toEqual(["Scope.Story", "SituationItem.GetStoryCycle"]);
     expect(producersOf(data, "NotAType")).toEqual([]);
+  });
+
+  it("merges case variants of a return type into one producer bucket", () => {
+    // The dump declares `Story` as a Type but spells some returns `story`.
+    const mixed = [
+      "Story",
+      "Definition type: Type",
+      "",
+      "-----------------------",
+      "",
+      "Scope.Story",
+      "Definition type: Promote",
+      "Return type: story",
+      "",
+      "-----------------------",
+      "",
+      "SituationItem.GetStoryCycle",
+      "Definition type: Function",
+      "Return type: Story",
+      "",
+    ].join("\n");
+    const data = parseDataTypesDump(mixed);
+    expect(producersOf(data, "Story")).toEqual(["Scope.Story", "SituationItem.GetStoryCycle"]);
+  });
+
+  it("ranks member producers by the qualified pair, not the bare member name", () => {
+    const data = parseDataTypesDump(dump);
+    const usage = emptyUsage();
+    // `Story` as a bare member name is written 11 times, but only once after
+    // `Scope`; `GetStoryCycle` is written 5 times, all after `SituationItem`.
+    const lines = [
+      ...Array<string>(5).fill('text = "[SituationItem.GetStoryCycle]"'),
+      'text = "[Scope.Story]"',
+      ...Array<string>(10).fill('text = "[Character.Story]"'),
+    ];
+    lines.forEach((l, i) => harvestLine(usage, l, "gui/test.gui", i + 1));
+
+    const line = 'text = "[Story.GetName]"';
+    const hover = provideDataFnHover(data, usage, line, line.indexOf("Story") + 1)!;
+    const produced = hover.markdown.split("\n").find((l) => l.startsWith("Produced by:"))!;
+    expect(produced.indexOf("SituationItem.GetStoryCycle")).toBeLessThan(produced.indexOf("Scope.Story"));
   });
 
   it("hovering a data type says how to obtain one", () => {

--- a/packages/server/test/definitionBody.test.ts
+++ b/packages/server/test/definitionBody.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Reading a definition's source block back for the hover, and the cache that
+ * keeps it off the hot path.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { clearDefinitionBodyCache, definitionBody } from "../src/features/definitionBody";
+
+const NL = String.fromCharCode(10);
+const made: string[] = [];
+
+function write(lines: string[]): string {
+  const file = path.join(
+    fs.mkdtempSync(path.join(os.tmpdir(), "px-body-")),
+    "00_scripted_triggers.txt"
+  );
+  fs.writeFileSync(file, lines.join(NL));
+  made.push(path.dirname(file));
+  return file;
+}
+
+afterEach(() => {
+  clearDefinitionBodyCache();
+  for (const dir of made.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe("definitionBody", () => {
+  it("returns the whole block, braces included", () => {
+    const file = write([
+      "# a comment",
+      "is_human = {",
+      "  NOT = { has_trait = beast }",
+      "}",
+      "",
+      "other = { always = yes }",
+    ]);
+    expect(definitionBody(file, 1)).toBe(
+      ["is_human = {", "  NOT = { has_trait = beast }", "}"].join(NL)
+    );
+  });
+
+  it("handles a block that opens and closes on one line", () => {
+    const file = write(["other = { always = yes }", "next = { }"]);
+    expect(definitionBody(file, 0)).toBe("other = { always = yes }");
+  });
+
+  it("returns the single line for an assignment with no block", () => {
+    const file = write(["my_value = 5"]);
+    expect(definitionBody(file, 0)).toBe("my_value = 5");
+  });
+
+  it("does not count braces inside comments or quoted strings", () => {
+    const file = write([
+      "tricky = {",
+      "  desc = \"a } brace in a string {\"",
+      "  # a } brace in a comment",
+      "  value = 1",
+      "}",
+      "after = yes",
+    ]);
+    const body = definitionBody(file, 0);
+    expect(body).toContain("value = 1");
+    expect(body!.split(NL)).toHaveLength(5);
+    expect(body).not.toContain("after");
+  });
+
+  it("gives up on a block that never closes rather than returning the rest of the file", () => {
+    const file = write(["broken = {", "  a = 1", "  b = 2"]);
+    expect(definitionBody(file, 0)).toBeNull();
+  });
+
+  it("stops at maxLines so one malformed file cannot dominate a hover", () => {
+    const file = write(["big = {", ...Array.from({ length: 500 }, (_, i) => `  a${i} = 1`), "}"]);
+    const body = definitionBody(file, 0, 20);
+    expect(body!.split(NL)).toHaveLength(20);
+  });
+
+  it("returns null for a missing file or an out-of-range line", () => {
+    const file = write(["a = { b = 1 }"]);
+    expect(definitionBody(path.join(path.dirname(file), "nope.txt"), 0)).toBeNull();
+    expect(definitionBody(file, 99)).toBeNull();
+  });
+
+  it("re-reads a file after it changes, with no explicit invalidation", () => {
+    const file = write(["a = {", "  first = 1", "}"]);
+    expect(definitionBody(file, 0)).toContain("first = 1");
+    // A different mtime is what invalidates; writing twice in the same
+    // millisecond would not, so set it explicitly.
+    fs.writeFileSync(file, ["a = {", "  second = 2", "}"].join(NL));
+    const later = new Date(Date.now() + 2000);
+    fs.utimesSync(file, later, later);
+    expect(definitionBody(file, 0)).toContain("second = 2");
+  });
+});

--- a/packages/server/test/definitionBody.test.ts
+++ b/packages/server/test/definitionBody.test.ts
@@ -12,10 +12,7 @@ const NL = String.fromCharCode(10);
 const made: string[] = [];
 
 function write(lines: string[]): string {
-  const file = path.join(
-    fs.mkdtempSync(path.join(os.tmpdir(), "px-body-")),
-    "00_scripted_triggers.txt"
-  );
+  const file = path.join(fs.mkdtempSync(path.join(os.tmpdir(), "px-body-")), "00_scripted_triggers.txt");
   fs.writeFileSync(file, lines.join(NL));
   made.push(path.dirname(file));
   return file;
@@ -36,9 +33,7 @@ describe("definitionBody", () => {
       "",
       "other = { always = yes }",
     ]);
-    expect(definitionBody(file, 1)).toBe(
-      ["is_human = {", "  NOT = { has_trait = beast }", "}"].join(NL)
-    );
+    expect(definitionBody(file, 1)).toBe(["is_human = {", "  NOT = { has_trait = beast }", "}"].join(NL));
   });
 
   it("handles a block that opens and closes on one line", () => {
@@ -54,7 +49,7 @@ describe("definitionBody", () => {
   it("does not count braces inside comments or quoted strings", () => {
     const file = write([
       "tricky = {",
-      "  desc = \"a } brace in a string {\"",
+      '  desc = "a } brace in a string {"',
       "  # a } brace in a comment",
       "  value = 1",
       "}",

--- a/packages/server/test/engineHover.test.ts
+++ b/packages/server/test/engineHover.test.ts
@@ -65,23 +65,27 @@ function engineHover(token: TokenData, rendered = `${token.name} = yes`): string
 }
 
 describe("engine-token hover teaches usage", () => {
+  // The scopes, the value shape and the leftover metadata used to be three
+  // separate lines (a `Value:` paragraph, an italic traits line, and a
+  // `Supported scopes:` footer after a rule). They are now one muted facts
+  // line, so these assert on the facts line rather than on the old slots.
   it("effect: fences the syntax example and names the value datatype", () => {
     const md = engineHover(EFFECT);
     expect(md).toContain("Adds a hook on a character");
-    expect(md).toContain("Value: a block");
+    expect(md).toContain("a block");
     expect(md).toContain("```paradox\nadd_hook = { type = X, target = Y }\n```");
-    expect(md).toContain("Supported scopes:");
     expect(md).toContain("character");
   });
 
   it("boolean trigger: value shape reads yes/no (boolean)", () => {
     const md = engineHover(TRIGGER_BOOL);
-    expect(md).toContain("Value: `yes`/`no` (boolean)");
+    // On the facts line next to the scope, not in a paragraph of its own.
+    expect(md).toContain(" scope · `yes`/`no` (boolean)*");
   });
 
   it("comparison trigger: value shape names number/script value + operators", () => {
     const md = engineHover(TRIGGER_CMP);
-    expect(md).toContain("Value: a number or script value");
+    expect(md).toContain("a number or script value");
     expect(md).toContain("<=");
   });
 

--- a/packages/server/test/hoverRender.test.ts
+++ b/packages/server/test/hoverRender.test.ts
@@ -1,161 +1,215 @@
 /**
- * §D hover-render fixtures, derived from the three D2 mocks. These pin the card
- * structure (badge spans, scope pills, single shared footer) and the plain-text
- * fallback (span *content* stays legible when the tag is stripped).
+ * Hover card layout. These pin the three-tier rendering contract (glyph, square,
+ * plain), the single shared footer, the caps, and the `<details>` disclosure.
+ *
+ * The fixtures call `renderCard` directly, which is NOT what production does:
+ * `hover.ts` builds a `CardInput` through `tokenCard`/`definitionCard` first,
+ * and those filter fields out. Do not read a "what the hover looks like today"
+ * claim off this file.
  */
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import {
-  isShortExample,
+  CAPS,
+  fencedBlock,
+  hoverFooter,
   kindBadge,
   renderCard,
   renderHover,
   scopeHereLine,
   scopePill,
   scopeType,
+  setHoverDetail,
+  stripCommonIndent,
 } from "../src/features/hoverRender";
+import { resolveClientCapabilities, setClientCapabilities } from "../src/clientMode";
+import { kindStyle, mappedKinds } from "@px-lsp/protocol/kinds";
 
-describe("kind badges (§D2)", () => {
-  it("colors each kind family per the plan", () => {
-    expect(kindBadge("trigger")).toBe('<span style="color:var(--vscode-charts-purple);">■ trigger</span>');
-    expect(kindBadge("effect")).toBe('<span style="color:var(--vscode-charts-red);">■ effect</span>');
-    expect(kindBadge("structure_key", "character interaction key")).toBe(
-      '<span style="color:var(--vscode-charts-yellow);">■ character interaction key</span>'
+const NL = String.fromCharCode(10);
+
+/** Capability tiers, as the degradation matrix in the design sheet describes them. */
+const TIERS = {
+  vscode: { client: { hoverHtml: true, hoverIcons: true, commands: [] } },
+  html: { client: { hoverHtml: true, hoverIcons: false, commands: [] } },
+  bare: { client: { hoverHtml: false, hoverIcons: false, commands: [] } },
+};
+const tier = (t: keyof typeof TIERS) => setClientCapabilities(resolveClientCapabilities(TIERS[t]));
+
+afterEach(() => {
+  setClientCapabilities(resolveClientCapabilities({ clientCommands: true }));
+  setHoverDetail("standard");
+});
+
+describe("kind badges: one glyph per concept, three tiers", () => {
+  it("draws a codicon when the client renders theme icons", () => {
+    tier("vscode");
+    expect(kindBadge("trigger")).toBe(
+      '<span style="color:var(--vscode-symbolIcon-functionForeground);">$(symbol-method) trigger</span>'
     );
-    expect(kindBadge("scripted_trigger")).toContain("var(--vscode-charts-green)");
-    expect(kindBadge("saved_scope")).toContain("var(--vscode-charts-orange)");
-    expect(kindBadge("loc_key")).toContain("var(--vscode-charts-foreground)");
+    expect(kindBadge("effect")).toBe(
+      '<span style="color:var(--vscode-symbolIcon-classForeground);">$(symbol-event) effect</span>'
+    );
+    expect(kindBadge("saved_scope")).toBe(
+      '<span style="color:var(--vscode-symbolIcon-variableForeground);">$(symbol-variable) saved scope</span>'
+    );
   });
 
-  it("badge content is plain text so HTML stripping stays legible", () => {
-    const stripped = kindBadge("trigger").replace(/<[^>]+>/g, "");
-    expect(stripped).toBe("■ trigger");
+  it("falls back to a square when the client renders HTML but not icons", () => {
+    tier("html");
+    expect(kindBadge("trigger")).toBe(
+      '<span style="color:var(--vscode-symbolIcon-functionForeground);">■ trigger</span>'
+    );
+  });
+
+  it("falls back to plain text on a bare LSP client", () => {
+    tier("bare");
+    expect(kindBadge("trigger")).toBe("■ trigger");
+    expect(kindBadge("structure_key", "character interaction key")).toBe("■ character interaction key");
+  });
+
+  it("emits no span at all for the default colour family", () => {
+    tier("vscode");
+    // 12 of the mapped kinds are deliberately uncoloured; they should cost no markup.
+    expect(kindBadge("define")).toBe("$(symbol-constant) define");
+    expect(kindBadge("loc_key")).toBe("$(symbol-key) loc key");
+  });
+
+  it("badge content stays legible once the tag is stripped", () => {
+    tier("vscode");
+    expect(kindBadge("trigger").replace(/<[^>]+>/g, "")).toBe("$(symbol-method) trigger");
   });
 });
 
-describe("scope pills (§D3)", () => {
-  it("blue when the scope matches the current cursor scope, muted otherwise", () => {
-    const current = new Set(["character"]);
-    expect(scopePill("character", current)).toBe(
-      '<span style="color:var(--vscode-charts-blue);">character</span>'
-    );
-    expect(scopePill("province", current)).toBe(
-      '<span style="color:var(--vscode-descriptionForeground);">province</span>'
-    );
+describe("the kind map", () => {
+  it("never draws a condition and an action with the same glyph", () => {
+    // The old map sent trigger to Function and effect to Method, which are one
+    // codepoint in the codicon font, so the two opposite concepts in Paradox
+    // script were drawn identically.
+    expect(kindStyle("trigger").codicon).not.toBe(kindStyle("effect").codicon);
+    expect(kindStyle("trigger").family).toBe("condition");
+    expect(kindStyle("effect").family).toBe("action");
   });
 
-  it("muted when no current scope is known", () => {
-    expect(scopePill("character", null)).toContain("descriptionForeground");
+  it("gives the engine and mod versions of one concept the same glyph", () => {
+    expect(kindStyle("scripted_trigger").codicon).toBe(kindStyle("trigger").codicon);
+    expect(kindStyle("scripted_effect").codicon).toBe(kindStyle("effect").codicon);
+  });
+
+  it("keeps every mapped kind on a real codicon and a real completion kind", () => {
+    for (const k of mappedKinds()) {
+      const style = kindStyle(k);
+      expect(style.codicon).toMatch(/^[a-z][a-z0-9-]*$/);
+      expect(style.completionKind).toMatch(/^[A-Z][A-Za-z]+$/);
+    }
+  });
+
+  it("falls through to a neutral style for a kind it does not name", () => {
+    expect(kindStyle("something_new").codicon).toBe("go-to-file");
+    expect(kindStyle("something_new").family).toBe("default");
   });
 });
 
-describe("Mock 1 — engine trigger (is_ai-shaped)", () => {
-  const md = renderCard({
-    kind: "trigger",
-    name: "is_ai",
-    doc: "Is the character AI-controlled? A player-controlled character returns no.",
-    traits: "Traits: yes/no · comparison ok",
-    footer: [`Supported scopes: ${scopePill("character", new Set(["character"]))}`],
+describe("card layout", () => {
+  it("puts the badge, bold name and tail on line 1", () => {
+    tier("vscode");
+    const md = renderCard({
+      kind: "trigger",
+      name: "is_ai",
+      doc: "is the character played by AI?",
+      facts: "character scope · yes/no",
+    });
+    const lines = md.split(NL);
+    expect(lines[0]).toContain("$(symbol-method) trigger");
+    expect(lines[0]).toContain("**is_ai**");
+    expect(md).toContain("*character scope · yes/no*");
   });
 
-  it("badge + bold name on line 1", () => {
-    expect(md.startsWith('<span style="color:var(--vscode-charts-purple);">■ trigger</span> **is_ai**')).toBe(
-      true
-    );
-  });
-
-  it("prose, italic traits, and a --- footer with a blue scope pill", () => {
-    expect(md).toContain("Is the character AI-controlled?");
-    expect(md).toContain("*Traits: yes/no · comparison ok*");
-    expect(md).toContain(
-      '\n---\nSupported scopes: <span style="color:var(--vscode-charts-blue);">character</span>'
-    );
+  it("writes per-card provenance with no rule above it", () => {
+    const md = renderCard({
+      kind: "scripted_trigger",
+      badgeLabel: "scripted trigger",
+      name: "is_human",
+      headTail: "· mod",
+      provenance: "[00_triggers.txt:1](file:///x) · 4,116 references",
+    });
+    expect(md).toContain("4,116 references");
+    expect(md).not.toContain("---");
   });
 });
 
-describe("Mock 2 — mod scripted trigger with reference count", () => {
-  const md = renderCard({
-    kind: "scripted_trigger",
-    badgeLabel: "scripted trigger",
-    name: "is_human",
-    headTail: "· mod",
-    example: "is_shown = { scope:secondary_recipient = { is_human = yes } }",
-    footer: ["[00_agot_character_triggers.txt:1](file:///x)", "4,116 references"],
+describe("the shared footer", () => {
+  it("puts the action links on the end of the scope line, not in a row", () => {
+    const footer = hoverFooter(scopeHereLine("character", null), ["[file.txt:12](file:///x)"]);
+    expect(footer).toBe("Scope here: **character** · [file.txt:12](file:///x)");
+    expect(footer!.split(NL)).toHaveLength(1);
   });
 
-  it("green badge, name, · mod on line 1", () => {
-    expect(
-      md.startsWith(
-        '<span style="color:var(--vscode-charts-green);">■ scripted trigger</span> **is_human** · mod'
-      )
-    ).toBe(true);
+  it("is null when there is nothing to say", () => {
+    expect(hoverFooter(null, [])).toBeNull();
   });
 
-  it("fences the example with the paradox language id", () => {
-    expect(md).toContain("```paradox\nis_shown = { scope:secondary_recipient = { is_human = yes } }\n```");
+  it("separates cards with a rule and appends the footer once", () => {
+    const md = renderHover(["A", "B"], "Scope here: **character**");
+    expect(md).toBe(["A", "", "---", "", "B", "", "Scope here: **character**"].join(NL));
   });
 
-  it("merges provenance link and reference count into one footer line", () => {
-    expect(md).toContain("\n---\n[00_agot_character_triggers.txt:1](file:///x) · 4,116 references");
+  it("caps the cards and says how many meanings were dropped", () => {
+    const md = renderHover(["A", "B", "C", "D"], null);
+    expect(md).toContain("*1 more meaning*");
+    setHoverDetail("compact");
+    expect(renderHover(["A", "B", "C"], null)).toContain("*2 more meanings*");
   });
 });
 
-describe("Mock 3 — saved scope", () => {
-  const md = renderCard({
-    kind: "saved_scope",
-    name: "scope:secondary_recipient",
-    headTail: `→ ${scopeType("character")}`,
-    doc: "Saved in this file: 00_agot_bastard_interactions.txt:13",
+describe("fenced blocks and the disclosure", () => {
+  const body = ["a = {", "  b = 1", "  c = 2", "  d = 3", "  e = 4", "}"].join(NL);
+
+  it("fences a short block whole, with no disclosure", () => {
+    const md = fencedBlock("x = yes", 3, 40);
+    expect(md).toBe(["```paradox", "x = yes", "```"].join(NL));
+    expect(md).not.toContain("<details>");
   });
 
-  it("orange badge, name, blue → type on line 1", () => {
-    expect(md).toContain(
-      '<span style="color:var(--vscode-charts-orange);">■ saved scope</span> **scope:secondary_recipient**'
+  it("caps the inline part and discloses the rest", () => {
+    tier("vscode");
+    const md = fencedBlock(body, 3, 40);
+    expect(md).toContain(["```paradox", "a = {", "  b = 1", "  c = 2", "…", "```"].join(NL));
+    expect(md).toContain("<details><summary>3 more lines</summary>");
+    expect(md).toContain("  e = 4");
+  });
+
+  it("truncates inside the disclosure too, because a hover cannot outgrow the viewport", () => {
+    tier("vscode");
+    const md = fencedBlock(body, 1, 2);
+    expect(md).toContain("… and 3 further");
+  });
+
+  it("drops the disclosure entirely on a client that strips HTML", () => {
+    tier("bare");
+    const md = fencedBlock(body, 3, 40);
+    expect(md).not.toContain("<details>");
+    expect(md).toContain("…");
+  });
+
+  it("strips the indentation every line shares", () => {
+    expect(stripCommonIndent(["    a", "      b", "", "    c"].join(NL))).toBe(
+      ["a", "  b", "", "c"].join(NL)
     );
-    expect(md).toContain('→ <span style="color:var(--vscode-charts-blue);">character</span>');
   });
 
-  it("carries the save-site line in prose", () => {
-    expect(md).toContain("Saved in this file: 00_agot_bastard_interactions.txt:13");
+  it("shows no example at all in compact mode", () => {
+    setHoverDetail("compact");
+    expect(CAPS.compact.exampleLines).toBe(0);
+    expect(fencedBlock(body, CAPS.compact.bodyLines, CAPS.compact.disclosedLines)).toBe("");
   });
 });
 
-describe("hover assembly (§D2)", () => {
-  it("appends the scope footer exactly once, after the cards", () => {
-    const md = renderHover(
-      [renderCard({ kind: "trigger", name: "a" }), renderCard({ kind: "effect", name: "b" })],
-      scopeHereLine("character", "root · every_vassal")
+describe("scope pills", () => {
+  it("is blue when it matches the cursor scope and muted otherwise", () => {
+    tier("vscode");
+    expect(scopePill("character", new Set(["character"]))).toBe(
+      '<span style="color:var(--vscode-symbolIcon-variableForeground);">character</span>'
     );
-    expect(md.match(/Scope here:/g)).toHaveLength(1);
-    expect(md.trimEnd().endsWith("Scope here: **character** (root · every_vassal)")).toBe(true);
-    // Cards are joined by the --- separator.
-    expect(md).toContain("\n\n---\n\n");
-  });
-
-  it("caps at 3 cards and reports the remainder", () => {
-    const cards = ["a", "b", "c", "d", "e"].map((n) => renderCard({ kind: "trigger", name: n }));
-    const md = renderHover(cards, null);
-    expect(md).toContain("*2 more meanings*");
-    expect(md).not.toContain("**d**");
-  });
-
-  it("singular remainder wording", () => {
-    const cards = ["a", "b", "c", "d"].map((n) => renderCard({ kind: "trigger", name: n }));
-    expect(renderHover(cards, null)).toContain("*1 more meaning*");
-  });
-
-  it("omits the footer when scope inference is unavailable (fail-soft)", () => {
-    const md = renderHover([renderCard({ kind: "trigger", name: "a" })], null);
-    expect(md).not.toContain("Scope here");
-  });
-});
-
-describe("isShortExample (§D2)", () => {
-  it("true for bodies under 4 non-blank lines", () => {
-    expect(isShortExample("is_human = yes")).toBe(true);
-    expect(isShortExample("a\nb\nc")).toBe(true);
-  });
-  it("false for longer bodies or empty ones", () => {
-    expect(isShortExample("a\nb\nc\nd")).toBe(false);
-    expect(isShortExample("")).toBe(false);
+    expect(scopePill("province", new Set(["character"]))).toContain("descriptionForeground");
+    expect(scopeType("character")).toContain("symbolIcon-variableForeground");
   });
 });

--- a/packages/server/test/hoverRender.test.ts
+++ b/packages/server/test/hoverRender.test.ts
@@ -43,20 +43,20 @@ describe("kind badges: one glyph per concept, three tiers", () => {
   it("draws a codicon when the client renders theme icons", () => {
     tier("vscode");
     expect(kindBadge("trigger")).toBe(
-      '<span style="color:var(--vscode-symbolIcon-functionForeground);">$(symbol-method) trigger</span>'
+      '<span style="color:var(--vscode-symbolIcon-methodForeground);">$(symbol-method) trigger</span>'
     );
     expect(kindBadge("effect")).toBe(
-      '<span style="color:var(--vscode-symbolIcon-classForeground);">$(symbol-event) effect</span>'
+      '<span style="color:var(--vscode-symbolIcon-eventForeground);">$(symbol-event) effect</span>'
     );
     expect(kindBadge("saved_scope")).toBe(
-      '<span style="color:var(--vscode-symbolIcon-variableForeground);">$(symbol-variable) saved scope</span>'
+      '<span style="color:var(--vscode-symbolIcon-fieldForeground);">$(symbol-field) saved scope</span>'
     );
   });
 
   it("falls back to a square when the client renders HTML but not icons", () => {
     tier("html");
     expect(kindBadge("trigger")).toBe(
-      '<span style="color:var(--vscode-symbolIcon-functionForeground);">■ trigger</span>'
+      '<span style="color:var(--vscode-symbolIcon-methodForeground);">■ trigger</span>'
     );
   });
 
@@ -66,11 +66,11 @@ describe("kind badges: one glyph per concept, three tiers", () => {
     expect(kindBadge("structure_key", "character interaction key")).toBe("■ character interaction key");
   });
 
-  it("emits no span at all for the default colour family", () => {
+  it("emits no span at all for a kind VS Code does not tint", () => {
     tier("vscode");
-    // 12 of the mapped kinds are deliberately uncoloured; they should cost no markup.
-    expect(kindBadge("define")).toBe("$(symbol-constant) define");
-    expect(kindBadge("loc_key")).toBe("$(symbol-key) loc key");
+    // Most of the map is grey, and grey is the editor foreground: no markup.
+    expect(kindBadge("define")).toBe("$(symbol-unit) define");
+    expect(kindBadge("loc_key")).toBe("$(symbol-text) loc key");
   });
 
   it("badge content stays legible once the tag is stripped", () => {
@@ -85,8 +85,8 @@ describe("the kind map", () => {
     // codepoint in the codicon font, so the two opposite concepts in Paradox
     // script were drawn identically.
     expect(kindStyle("trigger").codicon).not.toBe(kindStyle("effect").codicon);
-    expect(kindStyle("trigger").family).toBe("condition");
-    expect(kindStyle("effect").family).toBe("action");
+    expect(kindStyle("trigger").color).toBe("var(--vscode-symbolIcon-methodForeground)");
+    expect(kindStyle("effect").color).toBe("var(--vscode-symbolIcon-eventForeground)");
   });
 
   it("gives the engine and mod versions of one concept the same glyph", () => {
@@ -102,9 +102,48 @@ describe("the kind map", () => {
     }
   });
 
+  it("paints the badge with the completion kind's own colour token", () => {
+    // The suggest widget colours a row from the CompletionItemKind we send, and
+    // an extension cannot override it, so the badge takes the same token and the
+    // two surfaces agree by construction. `on_action` is the one exception.
+    const tinted: Record<string, string> = {
+      Method: "method",
+      Class: "class",
+      Event: "event",
+      Value: "enumerator",
+      Variable: "variable",
+      Field: "field",
+      Interface: "interface",
+      EnumMember: "enumeratorMember",
+    };
+    for (const k of mappedKinds()) {
+      if (k === "on_action") continue;
+      const style = kindStyle(k);
+      const cls = tinted[style.completionKind];
+      expect(style.color).toBe(cls ? `var(--vscode-symbolIcon-${cls}Foreground)` : null);
+    }
+  });
+
+  it("keeps the two deliberate exceptions", () => {
+    // on_action: the interface glyph, in the orange of the group it belongs to.
+    // The completion row is blue anyway, because VS Code owns that colour.
+    expect(kindStyle("on_action")).toEqual({
+      codicon: "symbol-interface",
+      completionKind: "Interface",
+      color: "var(--vscode-symbolIcon-classForeground)",
+    });
+    // texture: no completion kind draws `file-media`, so the row takes the
+    // plain file glyph while the hover and the tree get the picture frame.
+    expect(kindStyle("texture")).toEqual({
+      codicon: "file-media",
+      completionKind: "File",
+      color: null,
+    });
+  });
+
   it("falls through to a neutral style for a kind it does not name", () => {
     expect(kindStyle("something_new").codicon).toBe("go-to-file");
-    expect(kindStyle("something_new").family).toBe("default");
+    expect(kindStyle("something_new").color).toBeNull();
   });
 });
 

--- a/packages/server/test/rankEvalCore.ts
+++ b/packages/server/test/rankEvalCore.ts
@@ -146,7 +146,7 @@ export function buildEvalEnv(opts: {
   const data = new ServerData();
   const wikiTokens = loadWikiTokens(opts.wikidocsDir);
   const scriptTokens = opts.scriptDocsDir ? loadTokenDataFromLogs(opts.scriptDocsDir).tokens : [];
-  data.setTokens(scriptTokens.length > 0 ? mergeWikiTokens(scriptTokens, wikiTokens) : wikiTokens);
+  data.setTokens(scriptTokens.length > 0 ? mergeWikiTokens(scriptTokens, wikiTokens).tokens : wikiTokens);
   const schema = loadSchema(opts.modPath);
   data.completableKinds = new Set([
     ...schema.entries.filter((e) => e.completable !== false).map((e) => e.kind),

--- a/packages/server/test/structure.test.ts
+++ b/packages/server/test/structure.test.ts
@@ -344,7 +344,7 @@ describe("a `var:` hover shows one card, not two", () => {
 
   function hoverOnVar(data: ServerData): string {
     const text = "my.1 = {\n\timmediate = {\n\t\tset_variable = { name = delve_room value = 2 }\n\t}\n}";
-    const line = '\t\tif = { limit = { var:delve_room = 2 } }';
+    const line = "\t\tif = { limit = { var:delve_room = 2 } }";
     const full = text + "\n" + line;
     const doc = TextDocument.create(uri(), "paradox", 1, full);
     const lineNo = full.split("\n").length - 1;

--- a/packages/server/test/structure.test.ts
+++ b/packages/server/test/structure.test.ts
@@ -329,3 +329,51 @@ describe("schema data shape (§B2/§B3)", () => {
     expect(schema.structures.source("character_interaction")).toBe("character_interactions");
   });
 });
+
+describe("a `var:` hover shows one card, not two", () => {
+  /** A variable set in three places, as the index would have recorded it. */
+  function dataWithVar(): ServerData {
+    const data = new ServerData();
+    data.index.addAll([
+      { name: "delve_room", kind: "variable", file: "D:/mod/a.txt", line: 404, source: "mod" },
+      { name: "delve_room", kind: "variable", file: "D:/mod/b.txt", line: 141, source: "mod" },
+      { name: "delve_room", kind: "variable", file: "D:/mod/b.txt", line: 149, source: "mod" },
+    ]);
+    return data;
+  }
+
+  function hoverOnVar(data: ServerData): string {
+    const text = "my.1 = {\n\timmediate = {\n\t\tset_variable = { name = delve_room value = 2 }\n\t}\n}";
+    const line = '\t\tif = { limit = { var:delve_room = 2 } }';
+    const full = text + "\n" + line;
+    const doc = TextDocument.create(uri(), "paradox", 1, full);
+    const lineNo = full.split("\n").length - 1;
+    const col = line.indexOf("delve_room");
+    const hover = provideHover(
+      data,
+      doc,
+      { line: lineNo, character: col + 1 },
+      new Set(["character"]),
+      eventEntry,
+      () => schema
+    );
+    expect(hover).not.toBeNull();
+    return (hover!.contents as { value: string }).value;
+  }
+
+  it("renders the set sites once, on the definition card", () => {
+    const md = hoverOnVar(dataWithVar());
+    // One card: exactly one badge, so no `---` rule between duplicates.
+    expect(md.split("**delve_room**")).toHaveLength(2);
+    expect(md).not.toContain("---");
+    // The set sites appear as provenance links, not also as "set in" prose.
+    expect(md).not.toContain("set in");
+    expect(md).toContain("a.txt:405");
+  });
+
+  it("still answers for a variable the index has never seen set", () => {
+    const md = hoverOnVar(new ServerData());
+    expect(md).toContain("**delve_room**");
+    expect(md).toContain("variable");
+  });
+});

--- a/packages/server/test/wikiDocs.test.ts
+++ b/packages/server/test/wikiDocs.test.ts
@@ -92,26 +92,69 @@ describe("mergeWikiTokens", () => {
   ];
 
   it("keeps script_docs authoritative but adds wiki examples", () => {
-    const merged = mergeWikiTokens(scriptDocs, wiki);
+    const merged = mergeWikiTokens(scriptDocs, wiki).tokens;
     const addGold = merged.find((t) => t.name === "add_gold" && t.kind === "effect")!;
     expect(addGold.doc).toBe("authoritative doc");
     expect(addGold.usage).toContain("add_gold = X");
   });
 
   it("fills empty docs and adds wiki-only tokens with a provenance note", () => {
-    const merged = mergeWikiTokens(scriptDocs, wiki);
+    const merged = mergeWikiTokens(scriptDocs, wiki).tokens;
     expect(merged.find((t) => t.name === "empty_doc")!.doc).toBe("wiki fills this");
     const wikiOnly = merged.find((t) => t.name === "wiki_only_effect")!;
     expect(wikiOnly.traits).toContain("CK3 wiki");
   });
 
   it("treats kind as part of identity", () => {
-    const merged = mergeWikiTokens(scriptDocs, wiki);
+    const merged = mergeWikiTokens(scriptDocs, wiki).tokens;
     expect(merged.filter((t) => t.name === "add_gold")).toHaveLength(2);
   });
 
   it("with no script_docs at all, wiki provides the full baseline", () => {
-    const merged = mergeWikiTokens([], wiki);
+    const merged = mergeWikiTokens([], wiki).tokens;
     expect(merged).toHaveLength(4);
+  });
+});
+
+describe("mergeWikiTokens with the user's own dump (dropUnknownNames)", () => {
+  const scriptDocs: TokenData[] = [
+    { name: "add_gold", kind: "effect", doc: "authoritative", scopes: ["character"] },
+    { name: "is_ai", kind: "trigger", doc: "authoritative", scopes: ["character"] },
+  ];
+  const wiki: TokenData[] = [
+    // Already in the dump: contributes only its usage example.
+    { name: "add_gold", kind: "effect", doc: "wiki", scopes: [], usage: "add_gold = X" },
+    // Not in the dump. script_docs is what the engine registered, so this
+    // effect does not exist in the user's patch. The real case that motivated
+    // this: every_activity_invited and friends, absent from a current dump AND
+    // from every vanilla file, left over from before the activity rework.
+    { name: "every_activity_invited", kind: "effect", doc: "removed API", scopes: [] },
+  ];
+
+  it("keeps the usage example but drops the name the dump does not have", () => {
+    const merged = mergeWikiTokens(scriptDocs, wiki, { dropUnknownNames: true });
+    expect(merged.tokens.map((t) => t.name)).toEqual(["add_gold", "is_ai"]);
+    expect(merged.tokens.find((t) => t.name === "add_gold")!.usage).toBe("add_gold = X");
+    expect(merged.dropped).toBe(1);
+    expect(merged.added).toBe(0);
+    expect(merged.enriched).toBe(1);
+  });
+
+  it("adds the same token when the flag is off, which is the bundled-snapshot case", () => {
+    const merged = mergeWikiTokens(scriptDocs, wiki);
+    expect(merged.tokens.map((t) => t.name)).toContain("every_activity_invited");
+    expect(merged.added).toBe(1);
+    expect(merged.dropped).toBe(0);
+  });
+
+  it("never drops a kind the dump does not cover at all", () => {
+    // If script_docs stopped dumping a whole category, every wiki token of that
+    // kind would look "removed". Absence of the KIND is not evidence about its
+    // members, so those are still added.
+    const onlyEffects: TokenData[] = [{ name: "add_gold", kind: "effect", doc: "", scopes: [] }];
+    const wikiTriggers: TokenData[] = [{ name: "is_ai", kind: "trigger", doc: "", scopes: [] }];
+    const merged = mergeWikiTokens(onlyEffects, wikiTriggers, { dropUnknownNames: true });
+    expect(merged.tokens.map((t) => t.name)).toContain("is_ai");
+    expect(merged.dropped).toBe(0);
   });
 });

--- a/packages/vscode/CHANGELOG.md
+++ b/packages/vscode/CHANGELOG.md
@@ -41,6 +41,21 @@
 
 ### Fixed
 
+- **A `var:` hover showed the same variable twice**: once as a typed card
+  listing "set in file:line", then again as the indexed-definition card whose
+  provenance links were the same sites. One card now, the definition card,
+  which also carries the owning mod, the site count and the references link;
+  the value type moves onto its head. The standalone card remains only for a
+  variable the index has never seen set.
+- **The status bar tooltip listed each load twice and kept saying "…" after it
+  finished.** "harvesting engine tokens…" and "engine tokens: 4,624" were the
+  same fact on two lines, and the phase row kept its ellipsis once done, so a
+  finished load still read as ongoing. Each phase now reports into its own
+  value row: `○ harvesting engine tokens…` while it runs, then
+  `✓ engine tokens: 4,624 (your script_docs, plus the wiki)`. Loading rows come
+  first, configuration after, counts are thousands-separated, and the token
+  source says what to do about it when it is the bundled fallback.
+
 - A datafunction promote was drawn as a blue variable when global and a grey
   wrench when it was a member, decided by nothing but which branch of the
   completion builder produced it. Both are blue now: blue is a thing you have,

--- a/packages/vscode/CHANGELOG.md
+++ b/packages/vscode/CHANGELOG.md
@@ -6,7 +6,13 @@
 
 - **Hovers have icons, and the icons mean something.** Kind badges are real
   codicons instead of a coloured square, and the same glyph now appears in the
-  completion list and the tree for the same concept. This fixed a live defect:
+  completion list and the tree for the same concept. Colour comes with the
+  kind, because VS Code paints a completion row from the `CompletionItemKind`
+  the server sends and an extension cannot override it, so the four groups are
+  the ones the editor already draws: purple asks a question (triggers), orange
+  makes it happen (effects, events, decisions, on_actions, traits), blue is
+  something you stored (variables, saved scopes, event targets, lists), grey is
+  syntax and everything else. This fixed a live defect:
   `trigger` mapped to `CompletionItemKind.Function` and `effect` to `Method`,
   which share one codepoint in the codicon font and take the same colour, so a
   condition and an action, the one distinction in Paradox script that causes
@@ -27,7 +33,7 @@
 ### Changed
 
 - **Hovers are quieter.** Seven chart colours become the three VS Code uses for
-  its own symbols plus plain default, which is what 12 of the 23 script kinds
+  its own symbols plus plain default, which is what 17 of the 38 mapped kinds
   now render as, so most badges emit no colour markup at all. Scopes, the value
   shape and the traits line merge into one muted facts line. A single-card hover
   writes no footer block: its provenance and reference links ride the scope line
@@ -37,7 +43,16 @@
   switch, so they fell through to the "definition kinds read green" default and
   a widget type read the same green as a scripted trigger. They now have their
   own entries, as do datafunction data types, promotes and functions, GUI
-  templates and enum values, and text format tags.
+  templates and enum values, and text format tags. GUI completions read their
+  kind from the same map, so a widget type is one picture in the hover and one
+  in the suggest widget.
+- A texture path shows the picture-frame glyph (`file-media`) in the hover and
+  the tree. Its completion row keeps the plain file glyph: no
+  `CompletionItemKind` draws `file-media`, and only those 25 values reach the
+  suggest widget.
+- An `on_action` shows the interface glyph, in the orange of the group it
+  belongs to. Its completion row is blue, because the row's colour belongs to
+  the kind and `Interface` is blue.
 
 ### Fixed
 

--- a/packages/vscode/CHANGELOG.md
+++ b/packages/vscode/CHANGELOG.md
@@ -4,14 +4,47 @@
 
 ### Added
 
-- **Hovering a data type now says how to obtain one.** The hover for a
-  datafunction type (`Story`, `Character`) already listed what the type gives
-  you; it now also lists what gives you the type, ranked by vanilla usage:
-  `Produced by: GetPlayer WarOverviewWindow.GetPlayer … +314 more`. The spread
-  is what makes it useful: `Story` has exactly two producers, so the answer
-  fits on the line, while `Character` has 320 and the six most-used ones plus
-  a count still beats nothing. Suggested by a user who wanted to know what
-  can and cannot be used in a GUI expression.
+- **Hovers have icons, and the icons mean something.** Kind badges are real
+  codicons instead of a coloured square, and the same glyph now appears in the
+  completion list and the tree for the same concept. This fixed a live defect:
+  `trigger` mapped to `CompletionItemKind.Function` and `effect` to `Method`,
+  which share one codepoint in the codicon font and take the same colour, so a
+  condition and an action, the one distinction in Paradox script that causes
+  silent bugs, were drawn identically in the suggest widget.
+- **Hovering a scripted trigger or effect shows what it is.** The card now
+  carries the definition's own source block, so you do not have to jump to the
+  file to see what a mod's `is_human` actually tests. Long bodies open in place
+  through a disclosure: only 11% of vanilla scripted triggers are three lines or
+  shorter, median 10, longest 232.
+- **Hovering a data type says how to obtain one.** The datafunction hover for
+  `Story` or `Character` already listed what the type gives you; it now also
+  lists what gives you the type, ranked by vanilla usage. `Story` has exactly
+  two producers, `Character` has 320.
+- **`px.hover.detail`** (`compact` | `standard` | `full`, default `standard`)
+  controls how much a hover shows. Nothing is hidden permanently: longer
+  examples stay one click away inside the hover.
+
+### Changed
+
+- **Hovers are quieter.** Seven chart colours become the three VS Code uses for
+  its own symbols plus plain default, which is what 12 of the 23 script kinds
+  now render as, so most badges emit no colour markup at all. Scopes, the value
+  shape and the traits line merge into one muted facts line. A single-card hover
+  writes no footer block: its provenance and reference links ride the scope line
+  that has to exist anyway, which is worth three lines on the most common hover
+  there is.
+- GUI widget types and GUI properties had never been added to the badge colour
+  switch, so they fell through to the "definition kinds read green" default and
+  a widget type read the same green as a scripted trigger. They now have their
+  own entries, as do datafunction data types, promotes and functions, GUI
+  templates and enum values, and text format tags.
+
+### Fixed
+
+- A datafunction promote was drawn as a blue variable when global and a grey
+  wrench when it was a member, decided by nothing but which branch of the
+  completion builder produced it. Both are blue now: blue is a thing you have,
+  purple is a call you make.
 
 ## 0.3.3 (beta) - tiger download fix
 

--- a/packages/vscode/CHANGELOG.md
+++ b/packages/vscode/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- **Hovering a data type now says how to obtain one.** The hover for a
+  datafunction type (`Story`, `Character`) already listed what the type gives
+  you; it now also lists what gives you the type, ranked by vanilla usage:
+  `Produced by: GetPlayer WarOverviewWindow.GetPlayer … +314 more`. The spread
+  is what makes it useful: `Story` has exactly two producers, so the answer
+  fits on the line, while `Character` has 320 and the six most-used ones plus
+  a count still beats nothing. Suggested by a user who wanted to know what
+  can and cannot be used in a GUI expression.
+
 ## 0.3.3 (beta) - tiger download fix
 
 ### Fixed

--- a/packages/vscode/CHANGELOG.md
+++ b/packages/vscode/CHANGELOG.md
@@ -41,6 +41,19 @@
 
 ### Fixed
 
+- **Completion no longer offers effects the game removed.** The bundled wiki
+  lists were merged into the engine tokens even when your own `script_docs`
+  dump was loaded, and that added names your patch does not have. Measured on a
+  real install: of 2,336 wiki tokens, 2,262 were already in the dump and 74 were
+  not, and the ones sampled from that 74 (`every_activity_invited`,
+  `every_participant`, `accept_invitation_for_character`) appear in **zero**
+  vanilla files. They are pre-Tours-and-Tournaments activity API. The bundled
+  `Effects_list.md` warns about this itself. With your own dump loaded those 74
+  are now dropped, since `script_docs` is what the engine actually registered.
+  The wiki's real contribution is untouched: all 127 usage examples for tokens
+  the dump already had still merge in. Nothing changes when you have no dump of
+  your own, because then the bundled snapshot may be older than your game and
+  "absent" proves nothing.
 - **A `var:` hover showed the same variable twice**: once as a typed card
   listing "set in file:line", then again as the indexed-definition card whose
   provenance links were the same sites. One card now, the definition card,

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -660,7 +660,11 @@
         "properties": {
           "px.hover.detail": {
             "type": "string",
-            "enum": ["compact", "standard", "full"],
+            "enum": [
+              "compact",
+              "standard",
+              "full"
+            ],
             "enumDescriptions": [
               "Head, facts and provenance only. No prose, no example, one meaning.",
               "Everything, with caps: 3 meanings, 3 example lines, 2 doc paragraphs.",

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -658,6 +658,18 @@
         "title": "Editor",
         "order": 4,
         "properties": {
+          "px.hover.detail": {
+            "type": "string",
+            "enum": ["compact", "standard", "full"],
+            "enumDescriptions": [
+              "Head, facts and provenance only. No prose, no example, one meaning.",
+              "Everything, with caps: 3 meanings, 3 example lines, 2 doc paragraphs.",
+              "Example cap lifted, every distinct meaning, scope chain always shown."
+            ],
+            "default": "standard",
+            "order": 0,
+            "markdownDescription": "How much a hover shows. Longer examples and extra meanings stay reachable from the disclosure inside the hover, so `standard` hides nothing permanently."
+          },
           "px.scopeInlayHints": {
             "type": "boolean",
             "default": false,

--- a/packages/vscode/src/config.ts
+++ b/packages/vscode/src/config.ts
@@ -36,6 +36,7 @@ export interface PxConfig {
   excludedMods: string[];
   locLanguage: string;
   scopeInlayHints: boolean;
+  hoverDetail: "compact" | "standard" | "full";
   tigerRunOn: "save" | "manual";
   enableForWorkspace: boolean;
   /** Diagnostic codes (ours + tiger keys) to suppress everywhere. */
@@ -278,6 +279,7 @@ export function readConfig(): PxConfig {
     excludedMods,
     locLanguage: (cfg.get<string>("locLanguage") ?? "english").trim().toLowerCase() || "english",
     scopeInlayHints: cfg.get<boolean>("scopeInlayHints") ?? false,
+    hoverDetail: cfg.get<"compact" | "standard" | "full">("hover.detail") ?? "standard",
     tigerRunOn,
     enableForWorkspace,
     diagnosticsIgnore: sanitizeStringList(cfg.get("diagnostics.ignore")),

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -251,6 +251,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       tokensFromScriptDocs: lastServerStatus.tokensFromScriptDocs,
       tokensFromBundledDumps: lastServerStatus.tokensFromBundledDumps ?? false,
       definitions: lastServerStatus.definitions,
+      tokensWikiOnly: lastServerStatus.tokensWikiOnly,
       indexing: lastServerStatus.indexing,
       gameOk: cfg.gamePath !== null,
       modOk: cfg.modPath !== null,

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -319,7 +319,12 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     // HTML, and runs its own tuned file watcher (pushing paradox/modFileChanged).
     // Clients declaring less get plain markdown, WorkspaceEdits instead of
     // command actions, and a server-side watcher.
-    client: { hoverHtml: true, commands: allClientCommandIds, ownFileWatcher: true },
+    client: {
+      hoverHtml: true,
+      hoverIcons: true,
+      commands: allClientCommandIds,
+      ownFileWatcher: true,
+    },
     settings: toSettings(cfg),
   };
   // Server deaths were invisible: the client restarts silently up to five
@@ -375,6 +380,12 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
           for (const content of hover.contents) {
             if (content instanceof vscode.MarkdownString) {
               content.isTrusted = { enabledCommands: ["px.showReferences"] };
+              // Theme icons must be enabled per MarkdownString: the
+              // `markdown: { supportHtml: true }` client option above does NOT
+              // cover them. Without this the kind badges arrive as the literal
+              // text `$(symbol-method)`, which is why the server gates them on
+              // the `hoverIcons` capability we declare in initOptions.
+              content.supportThemeIcons = true;
             }
           }
         }

--- a/packages/vscode/src/statusBar.ts
+++ b/packages/vscode/src/statusBar.ts
@@ -48,6 +48,13 @@ export class PxStatusBar implements vscode.Disposable {
     if (this.last) this.update(this.last);
   }
 
+  /** A phase that has a value row of its own, so it never gets a second line. */
+  private phaseState(phase: string): "running" | "done" | "absent" {
+    const p = this.phases.get(phase);
+    if (!p) return "absent";
+    return p.done ? "done" : "running";
+  }
+
   update(s: PxStatus): void {
     this.last = s;
     const healthy = s.gameOk && s.modOk && (s.tigerName === null || s.tigerOk) && s.tokens > 0;
@@ -58,30 +65,55 @@ export class PxStatusBar implements vscode.Disposable {
         : healthy
           ? "$(check) PX Toolkit"
           : "$(warning) PX Toolkit";
+
+    const n = (v: number) => v.toLocaleString();
+    /** `○` while the work is running, then `✓`/`✗` on the result. */
+    const mark = (phase: string, ok: boolean) =>
+      this.phaseState(phase) === "running" ? "○" : ok ? "✓" : "✗";
+
+    const tokenSource = s.tokensFromBundledDumps
+      ? "bundled script_docs snapshot, dump your own to match your patch"
+      : s.tokensFromScriptDocs
+        ? "your script_docs, plus the wiki"
+        : "bundled wiki only, run DumpDataTypes for your patch";
+
+    // Loading rows first, then configuration. Each phase reports INTO its own
+    // value row rather than adding a second one: "harvesting engine tokens…"
+    // and "engine tokens: 4,624" were the same fact on two lines, and the
+    // phase row kept its "…" after it finished, so a finished load still read
+    // as ongoing.
     const lines = [
       `**Paradox Modding Toolkit** — click to run setup & health check`,
       "",
-      `${s.tokens > 0 ? "✓" : "✗"} engine tokens: ${s.tokens}${
-        s.tokens > 0
-          ? s.tokensFromBundledDumps
-            ? " (bundled script_docs snapshot — dump your own to match your patch)"
-            : s.tokensFromScriptDocs
-              ? " (script_docs + wiki)"
-              : " (bundled wiki only)"
-          : ""
-      }`,
-      `${s.definitions > 0 ? "✓" : "✗"} indexed definitions: ${s.definitions}`,
-      `${s.gameOk ? "✓" : "✗"} game path ${s.gameOk ? "configured" : "missing"}`,
-      `${s.modOk ? "✓" : "✗"} mod folder ${s.modOk ? "found" : "missing"}`,
+      this.phaseState("engine") === "running"
+        ? `○ harvesting engine tokens…`
+        : `${mark("engine", s.tokens > 0)} engine tokens: ${n(s.tokens)}${s.tokens > 0 ? ` (${tokenSource})` : ""}`,
+      s.indexing || this.phaseState("index") === "running"
+        ? `○ indexing definitions… ${n(s.definitions)} so far`
+        : `${mark("index", s.definitions > 0)} indexed definitions: ${n(s.definitions)}`,
     ];
+    if (this.phaseState("guiStore") !== "absent") {
+      lines.push(
+        this.phaseState("guiStore") === "running"
+          ? "○ building the GUI template store…"
+          : "✓ GUI template store built"
+      );
+    }
+    lines.push(
+      "",
+      `${s.gameOk ? "✓" : "✗"} game path ${s.gameOk ? "configured" : "not set"}`,
+      `${s.modOk ? "✓" : "✗"} mod folder ${s.modOk ? "found" : "not found"}`
+    );
     if (s.tigerName !== null) {
       lines.push(`${s.tigerOk ? "✓" : "✗"} ${s.tigerName} ${s.tigerOk ? "available" : "not set up"}`);
     }
-    // What the server is still doing. A phase stays listed once done, with a
-    // check, so the rows do not jump around while a cold workspace loads.
-    for (const p of this.phases.values()) lines.push(`${p.done ? "✓" : "○"} ${p.label}`);
-    const md = new vscode.MarkdownString(lines.join("\n\n"));
-    this.item.tooltip = md;
+    // Any phase the server adds later still gets a row, so a new one is never
+    // silently dropped; the three above are the ones with a value row.
+    for (const [name, p] of this.phases) {
+      if (name === "engine" || name === "index" || name === "guiStore") continue;
+      lines.push(`${p.done ? "✓" : "○"} ${p.label.replace(/…$/, "")}`);
+    }
+    this.item.tooltip = new vscode.MarkdownString(lines.join("\n\n"));
   }
 
   dispose(): void {

--- a/packages/vscode/src/statusBar.ts
+++ b/packages/vscode/src/statusBar.ts
@@ -12,6 +12,8 @@ export interface PxStatus {
   /** The script_docs tokens are the bundled snapshot, not the user's dump. */
   tokensFromBundledDumps: boolean;
   definitions: number;
+  /** Tokens the bundled wiki added on top of script_docs (mostly deprecated). */
+  tokensWikiOnly?: number;
   gameOk: boolean;
   modOk: boolean;
   tigerOk: boolean;
@@ -71,11 +73,18 @@ export class PxStatusBar implements vscode.Disposable {
     const mark = (phase: string, ok: boolean) =>
       this.phaseState(phase) === "running" ? "○" : ok ? "✓" : "✗";
 
+    // Say where the tokens came from, with the split, because "script_docs +
+    // wiki" reads as though the wiki is doing half the work. It is not: with a
+    // real dump loaded the wiki contributes a handful of extra NAMES (mostly
+    // deprecated API the current patch no longer has) on top of usage examples
+    // for tokens the dump already had.
+    const wikiOnly = s.tokensWikiOnly ?? 0;
+    const own = s.tokens - wikiOnly;
     const tokenSource = s.tokensFromBundledDumps
-      ? "bundled script_docs snapshot, dump your own to match your patch"
+      ? "bundled snapshot — run script_docs in the game console to match your patch"
       : s.tokensFromScriptDocs
-        ? "your script_docs, plus the wiki"
-        : "bundled wiki only, run DumpDataTypes for your patch";
+        ? `${n(own)} from your script_docs${wikiOnly > 0 ? `, ${n(wikiOnly)} wiki-only` : ""}`
+        : "bundled wiki only — run script_docs in the game console";
 
     // Loading rows first, then configuration. Each phase reports INTO its own
     // value row rather than adding a second one: "harvesting engine tokens…"

--- a/packages/vscode/src/views.ts
+++ b/packages/vscode/src/views.ts
@@ -7,6 +7,7 @@
  * (formerly Tools) is a webview — see webviews/dashboard/view.ts.
  */
 import * as vscode from "vscode";
+import { kindStyle } from "@px-lsp/protocol/kinds";
 import * as path from "path";
 import type { LanguageClient } from "vscode-languageclient/node";
 import {
@@ -162,12 +163,12 @@ class OverviewProvider extends BaseProvider {
         `${k.kind.replace(/_/g, " ")} (${k.count})`,
         vscode.TreeItemCollapsibleState.Collapsed
       );
-      node.iconPath = new vscode.ThemeIcon("symbol-class");
+      node.iconPath = new vscode.ThemeIcon(kindStyle(k.kind).codicon);
       node.children = k.defs.map((d) => {
         const child = new Node(d.name);
         child.description = path.basename(d.file);
         child.command = openCommand(d.file, d.line);
-        child.iconPath = new vscode.ThemeIcon("symbol-field");
+        child.iconPath = new vscode.ThemeIcon(kindStyle(k.kind).codicon);
         return child;
       });
       if (k.count > k.defs.length) {
@@ -405,12 +406,12 @@ class DependenciesProvider extends BaseProvider {
         `${g.kind.replace(/_/g, " ")} (${g.items.length})`,
         vscode.TreeItemCollapsibleState.Collapsed
       );
-      kindNode.iconPath = new vscode.ThemeIcon("symbol-class");
+      kindNode.iconPath = new vscode.ThemeIcon(kindStyle(g.kind).codicon);
       kindNode.children = g.items.map((it) => {
         const leaf = new Node(it.name);
         leaf.description = path.basename(it.file);
         leaf.command = openCommand(it.file, it.line);
-        leaf.iconPath = new vscode.ThemeIcon("symbol-field");
+        leaf.iconPath = new vscode.ThemeIcon(kindStyle(g.kind).codicon);
         return leaf;
       });
       return kindNode;

--- a/scripts/audit-mod-coverage.ts
+++ b/scripts/audit-mod-coverage.ts
@@ -168,7 +168,7 @@ async function main(): Promise<void> {
       mergeWikiTokens(
         logTokens.tokens,
         loadWikiTokens(path.join(__dirname, "..", "packages", "server", "data", "ck3", "wikidocs"))
-      )
+      ).tokens
     );
   }
   console.log(

--- a/scripts/audit-scope-inference.ts
+++ b/scripts/audit-scope-inference.ts
@@ -216,7 +216,7 @@ async function main(): Promise<void> {
       mergeWikiTokens(
         logTokens.tokens,
         loadWikiTokens(path.join(__dirname, "..", "packages", "server", "data", "ck3", "wikidocs"))
-      )
+      ).tokens
     );
   }
   console.log(`env ready in ${((Date.now() - t0) / 1000).toFixed(1)}s: ${env.data.tokens.length} tokens`);

--- a/scripts/bench-hover-body.ts
+++ b/scripts/bench-hover-body.ts
@@ -1,0 +1,82 @@
+/**
+ * Hover cost bench for the definition-body slot.
+ *
+ * The hover used to do no file I/O at all. Showing a scripted trigger's source
+ * means reading its file back, so this measures what that costs and whether the
+ * cache earns its keep. Three cases, all against real vanilla files:
+ *
+ *   cold   every definition in a different file, cache always missing
+ *   warm   the same definition repeatedly, which is what a real hover does
+ *          (a hover re-fires on every mouse move inside the same word)
+ *   spread a realistic mix: 32 files round-robin, i.e. the cache's own size
+ *
+ * Run: npx esbuild scripts/bench-hover-body.ts --bundle --platform=node \
+ *        --outfile=dist/bench-hover-body.cjs && node dist/bench-hover-body.cjs
+ */
+import * as fs from "fs";
+import * as path from "path";
+import { clearDefinitionBodyCache, definitionBody } from "../packages/server/src/features/definitionBody";
+import { requireDevPath } from "./devPaths";
+
+const gamePath = process.argv[2] ?? requireDevPath("gamePath", "bench-hover-body");
+const dir = path.join(gamePath, "common", "scripted_triggers");
+
+/** Every `name = {` at column 0, i.e. what the index would have recorded. */
+function definitions(): Array<{ file: string; line: number }> {
+  const out: Array<{ file: string; line: number }> = [];
+  for (const f of fs.readdirSync(dir).filter((n) => n.endsWith(".txt"))) {
+    const file = path.join(dir, f);
+    const lines = fs.readFileSync(file, "utf8").split(/\r?\n/);
+    for (let i = 0; i < lines.length; i++) {
+      if (/^[A-Za-z_][A-Za-z0-9_]*\s*=\s*\{/.test(lines[i])) out.push({ file, line: i });
+    }
+  }
+  return out;
+}
+
+function time(label: string, runs: number, fn: (i: number) => void): number {
+  const t0 = process.hrtime.bigint();
+  for (let i = 0; i < runs; i++) fn(i);
+  const us = Number(process.hrtime.bigint() - t0) / 1000 / runs;
+  console.log(`${label.padEnd(34)} ${us.toFixed(1).padStart(8)} µs/hover`);
+  return us;
+}
+
+const defs = definitions();
+const files = [...new Set(defs.map((d) => d.file))];
+console.log(`${defs.length} definitions across ${files.length} files in common/scripted_triggers`);
+console.log();
+
+// Cold: a fresh cache every call. The pathological case, never seen in practice.
+const cold = time("cold (cache cleared each time)", 300, (i) => {
+  clearDefinitionBodyCache();
+  const d = defs[i % defs.length];
+  definitionBody(d.file, d.line);
+});
+
+// Warm: the same definition over and over, which is what hovering one word does.
+clearDefinitionBodyCache();
+definitionBody(defs[0].file, defs[0].line);
+const warm = time("warm (same definition)", 20000, () => {
+  definitionBody(defs[0].file, defs[0].line);
+});
+
+// Spread: 32 distinct files round-robin, exactly the cache's capacity.
+clearDefinitionBodyCache();
+const spreadDefs = files.slice(0, 32).map((f) => defs.find((d) => d.file === f)!);
+const spread = time("spread (32 files round-robin)", 5000, (i) => {
+  const d = spreadDefs[i % spreadDefs.length];
+  definitionBody(d.file, d.line);
+});
+
+const sizes = defs.map((d) => (definitionBody(d.file, d.line) ?? "").split("\n").length).sort((a, b) => a - b);
+const pct = (p: number) => sizes[Math.min(sizes.length - 1, Math.floor((sizes.length * p) / 100))];
+console.log();
+console.log(`body lines  median=${pct(50)}  p90=${pct(90)}  max=${sizes[sizes.length - 1]}`);
+console.log();
+console.log(`cache speedup: ${(cold / warm).toFixed(0)}x warm, ${(cold / spread).toFixed(0)}x spread`);
+console.log(
+  warm < 50
+    ? "VERDICT: warm hover cost is under 50 µs, i.e. invisible next to the LSP round trip."
+    : "VERDICT: warm hover cost is NOT negligible; revisit the cache."
+);

--- a/scripts/bench-hover-body.ts
+++ b/scripts/bench-hover-body.ts
@@ -69,7 +69,9 @@ const spread = time("spread (32 files round-robin)", 5000, (i) => {
   definitionBody(d.file, d.line);
 });
 
-const sizes = defs.map((d) => (definitionBody(d.file, d.line) ?? "").split("\n").length).sort((a, b) => a - b);
+const sizes = defs
+  .map((d) => (definitionBody(d.file, d.line) ?? "").split("\n").length)
+  .sort((a, b) => a - b);
 const pct = (p: number) => sizes[Math.min(sizes.length - 1, Math.floor((sizes.length * p) / 100))];
 console.log();
 console.log(`body lines  median=${pct(50)}  p90=${pct(90)}  max=${sizes[sizes.length - 1]}`);

--- a/scripts/probe-completion.ts
+++ b/scripts/probe-completion.ts
@@ -24,7 +24,7 @@ function main(): void {
       mergeWikiTokens(
         logTokens.tokens,
         loadWikiTokens(path.join(__dirname, "..", "packages", "server", "data", "ck3", "wikidocs"))
-      )
+      ).tokens
     );
   }
   env.data.onActionScopes = parseOnActionsLog(logsPath);


### PR DESCRIPTION
Two commits. The first is the `Produced by` line reviewed earlier; the second is the redesign the [design sheet](https://claude.ai/code/artifact/fd7dd42c-9a15-4dc3-a087-28bbb069a9c8) decided, plus a user request.

## Why

The product had **four** icon vocabularies that disagreed with each other. The hover drew coloured `■` squares from one table, completion picked `CompletionItemKind` values from a second, `views.ts` painted every tree leaf `symbol-field` regardless of kind, and the datafunction and GUI hovers were in none of them.

One of those tables had a live defect. `trigger` mapped to `Function` and `effect` to `Method`, which are **one codepoint** in the codicon font and take the same colour. A condition and an action, the distinction in Paradox script that causes silent bugs when you get it wrong, were drawn identically in the suggest widget.

## What

**`@px-lsp/protocol/kinds` is the single map**: glyph, completion kind and colour family per concept, read by the hover badge, the suggest widget and the trees. It replaced the two hand-maintained tables.

**Colour drops from seven to three plus default**, using the tokens VS Code uses for its own symbol icons. 12 of the 23 script kinds are default, so most badges now emit no colour markup at all.

**Cards lose their per-card footers.** Scopes, value shape and traits merge into one muted facts line. A single-card hover puts its provenance and reference links on the scope line that has to exist anyway, worth three lines on the most common hover there is.

**Hovering a scripted trigger or effect shows its own source block**, asked for by a user. Only 11% of vanilla scripted triggers are three lines or shorter (median 10, p90 33, longest 232), so the inline part is capped and the rest opens in a `<details>` disclosure.

`<details>` and `<summary>` are on VS Code's markdown sanitizer allowlist, and I verified by hand in a live editor that the hover renders the twisty, expands **in place** and stays open. That is the shippable answer to `editorHoverVerbosityLevel` still being a proposed API. The disclosure is capped too, because a hover cannot grow past the editor viewport.

## Performance

The hover previously did no file I/O. It now reads a definition's file, so `scripts/bench-hover-body.ts` is committed alongside:

| | µs/hover |
|---|---|
| cold, cache cleared each time | 390 |
| **warm, same definition** | **25** |
| spread, 32 files round-robin | 28 |

The bench caught a real problem. The first version cached raw text and measured **66 µs warm**, because every hover re-split a multi-thousand-line vanilla file and re-ran the brace scan. Caching the file already split, plus every block extracted, took it to 25 µs, a 16x speedup over cold and invisible next to the LSP round trip.

## Compatibility

Badges render in three tiers by client capability: codicon, `■` square, or plain text. A client that does not render theme icons would otherwise print the literal text `$(symbol-method)`, which is worse than the square, so `hoverIcons` defaults to **false** and only the VS Code client declares it. The nvim gate and the published npm server are unaffected.

## Checks

- Full suite **1,609 passed, 0 failed**. `tsc --noEmit` and `eslint` clean.
- New: 22 layout tests covering the three tiers, the caps and the disclosure; 8 tests for the body reader including brace counting inside comments and strings, unclosed blocks, and mtime invalidation.
- `isShortExample()` deleted, dead since it was written.

Test vsix built and installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Standardize symbol presentation across the editor and make hovers more informative, configurable, and consistent across client capabilities.

New Features:
- Unify hover badges, completion icons, and tree icons around a shared concept-to-icon and completion-kind map.
- Show scripted definition source blocks and reverse data-type producer information in hovers.
- Add configurable hover detail levels with capped examples and expandable long bodies.
- Add client capability negotiation for theme-icon hover badges and expose the new hover settings and status information.

Bug Fixes:
- Prevent trigger and effect completions from appearing with indistinguishable icons.
- Avoid suggesting wiki-only names absent from a user's authoritative script documentation dump.
- Remove duplicate variable information from var: hovers.
- Correct status-bar progress and token-source reporting.

Enhancements:
- Redesign hover cards with consolidated facts and shared provenance and reference lines.
- Use VS Code symbol color tokens consistently across hover badges and completion items, with graceful icon fallbacks for clients without theme-icon support.
- Add cached definition-body reading and reverse data-type producer indexing for responsive, more informative hovers.
- Use shared kind styling for GUI completions and definition trees.

Documentation:
- Document the new hover icon capability, hover detail setting, and client fallback behavior.

Tests:
- Add coverage for shared kind mappings, hover rendering tiers, detail caps, expandable disclosures, definition-body extraction and caching, producer indexing, wiki merging, and variable hover deduplication.

Chores:
- Remove the obsolete isShortExample helper and update callers for the richer wiki merge result.