### PR TITLE
Browser language service: @px-lsp/server without node

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,12 @@ jobs:
       # dist/server.js and silently skip when it does not exist.
       - run: pnpm run compile
       - run: pnpm test
+      # The browser build is the only thing that proves the language service
+      # still links without node. esbuild fails outright on an unaliased node
+      # builtin, so a new fs/child_process import on a reachable path breaks
+      # here rather than in a consumer's bundler.
+      - name: Browser language service builds
+        run: pnpm run bake:browser && pnpm --filter @px-lsp/server run compile:browser
       - name: Package (vsix)
         working-directory: packages/vscode
         run: npx vsce package --allow-missing-repository --no-dependencies

--- a/docs/EMBEDDING.md
+++ b/docs/EMBEDDING.md
@@ -467,7 +467,8 @@ service.attachDocs(await (await fetch("/px/docs.json")).json());
 Hover works before that call; it just has names and scopes instead of prose.
 `capabilities.hoverDocs` says which state you are in.
 
-Regenerate the payloads with `pnpm run bake:browser -- --game <id>`. They carry
+Regenerate the payloads with `pnpm run bake:browser`, which bakes every game
+that ships `script_docs` (add `-- --game <id>` for one). They carry
 a version that `createBrowserLanguageService` checks, so a payload baked by a
 different server version fails loudly at startup instead of producing subtly
 wrong answers.

--- a/docs/EMBEDDING.md
+++ b/docs/EMBEDDING.md
@@ -413,6 +413,113 @@ Rendering notes that will save you a redesign:
   with the popup.
 - **`null`** means the document is not an open script document. Render nothing.
 
+## In a browser, with no process at all
+
+Everything above assumes a host that can spawn a process. A web page cannot,
+and `@px-lsp/server/browser` is the answer to that: the same parser, schema,
+token tables and scope engine, assembled as a plain library against a single
+in-memory document. No child process, no JSON-RPC, no workspace scan, no
+filesystem.
+
+```ts
+import { createBrowserLanguageService } from "@px-lsp/server/browser";
+
+const tokens = await (await fetch("/px/tokens.json")).json();
+const freqs = await (await fetch("/px/freqs.json")).json();
+const service = createBrowserLanguageService({ tokens, freqs });
+
+const doc = service.openDocument("events/tutorial.txt", text);
+doc.diagnostics();
+doc.completions(offset);
+doc.hover(offset);
+doc.scopeAt(offset);
+
+doc.update(newText); // keep the handle; it holds the parse across edits
+```
+
+`openDocument` takes a **mod-relative** path. Nothing opens it, but the schema
+classifies a file by its folder, so `events/tutorial.txt` gets the event
+grammar and root scope while `common/scripted_effects/00_x.txt` gets that one.
+`doc.kind` reports which schema entry matched, or `null` when the folder is not
+one the schema knows, which is worth showing rather than silently defaulting.
+
+### The data is baked, not parsed at runtime
+
+On node the server parses `data/<gameId>/script_docs/*.log` at startup. That is
+1.1 MB of text a browser should not download or parse, so
+`scripts/bake-browser-data.ts` runs the same parsers at build time and splits
+the result by how often it is needed:
+
+| Artifact | Raw | Brotli | Needed for |
+|---|---|---|---|
+| `dist/browser.js` | 838 KB | 163 KB | everything (parser, schema, features) |
+| `browser-data/<gameId>/tokens.json` | 527 KB | 36 KB | completion, diagnostics, scope inference |
+| `browser-data/<gameId>/freqs.json` | 104 KB | 26 KB | completion ranking (optional) |
+| `browser-data/<gameId>/docs.json` | 608 KB | 72 KB | hover prose only |
+
+So a page is answering completions and diagnostics after 225 KB brotli, and
+`docs.json` can wait until the first hover:
+
+```ts
+service.attachDocs(await (await fetch("/px/docs.json")).json());
+```
+
+Hover works before that call; it just has names and scopes instead of prose.
+`capabilities.hoverDocs` says which state you are in.
+
+Regenerate the payloads with `pnpm run bake:browser -- --game <id>`. They carry
+a version that `createBrowserLanguageService` checks, so a payload baked by a
+different server version fails loudly at startup instead of producing subtly
+wrong answers.
+
+### What a browser build cannot know
+
+The service has exactly one file: the one you opened. `capabilities` states
+this field by field, and a host should surface it rather than imply the
+fidelity of the editor:
+
+- `workspaceIndex: false`. No vanilla scan and no other mod files, so a
+  reference to a trait, decision or scripted effect defined elsewhere does not
+  resolve. Definitions in the **open document** do, which is why hover on a
+  `scripted_effect` you just wrote above still works.
+- `referenceDiagnostics: false`. The unknown-reference checks need that index.
+  They are omitted rather than approximated, because a false "unknown trait" on
+  a trait that exists is worse than no check.
+- `guiAndAssets: false`. `.gui` layout, DDS decoding, `[ ... ]` datafunctions
+  and the tiger runner are node-only or need a game install.
+
+Diagnostics are therefore the structural and file-layout class only: unbalanced
+braces, encoding traps, and folder traps like `common/on_actions/` (plural,
+which CK3 silently ignores).
+
+### How the node builtins are handled
+
+The feature modules import `fs`, `path` and `os` on paths a browser never
+reaches (`loadSchema(null)` takes no filesystem path, and the token tables
+arrive as JSON). The browser bundle aliases all three to
+`src/browser/shims/`, plus `vscode-languageserver/node` to
+`vscode-languageserver-types`, which drops the JSON-RPC transport the library
+form has no use for.
+
+The `fs` shim is an empty filesystem: `existsSync` is false and the readers
+throw `ENOENT`, so anything that ever did slip onto a disk-backed path fails
+the way a missing file fails on node. The `path` shim is POSIX-only and is
+pinned against node's own `path.posix` in
+`packages/server/test/browserPath.test.ts`, because `classifyFile` picks a
+schema entry with `path.relative` and a shim that disagrees by one segment
+would produce a wrong diagnostic rather than a visible failure.
+
+Consumers do not need any of these aliases: `@px-lsp/server/browser` resolves
+to the prebuilt `dist/browser.js` with the shims already linked in.
+
+### What this is not
+
+It is not the VS Code editor in a page, and it is not an LSP server in a Web
+Worker. It is the language knowledge as a library. A worker-hosted LSP would
+wrap this module with `BrowserMessageReader`/`BrowserMessageWriter` and the
+transport alias above changed back to `vscode-languageserver/browser`; nothing
+in the service would need to move.
+
 ## What is deliberately absent
 
 Three things the VS Code extension has do not exist for an embedder, and none

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "lint:fix": "eslint . --fix && prettier --write .",
     "test": "vitest run",
     "package": "pnpm --filter px-toolkit run package",
-    "testp": "pnpm --filter px-toolkit run testp"
+    "testp": "pnpm --filter px-toolkit run testp",
+    "bake:browser": "esbuild scripts/bake-browser-data.ts --bundle --platform=node --outfile=dist/bake-browser-data.cjs --log-level=warning && node dist/bake-browser-data.cjs"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.5",

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -6,6 +6,23 @@ changes. Before the split it moved inside the extension's version (up to
 0.3.2); that history is in the extension changelog
 (`packages/vscode/CHANGELOG.md`).
 
+## Unreleased
+
+- **New `@px-lsp/server/browser` entry: the language service without node.**
+  Completion, hover, diagnostics and scope inference against a single in-memory
+  document, with no child process, no JSON-RPC, no workspace scan and no
+  filesystem. Intended for web hosts that cannot spawn the server at all.
+  `docs/EMBEDDING.md` has the API, the payload sizes and the list of what a
+  browser build cannot know.
+- `scripts/bake-browser-data.ts` (`pnpm run bake:browser`) runs the existing
+  script_docs and wikidocs parsers at build time and emits
+  `dist/browser-data/<gameId>/{tokens,docs,freqs}.json`. The prose is split from
+  the token tables so a host answers completions after 225 KB brotli and can
+  fetch the 72 KB of hover text later, or never.
+- `loadFreqs` now delegates its validation to a new exported `coerceFreqs`, so
+  the browser build validates a parsed freqs.json exactly as the node path does
+  instead of duplicating the shape checks.
+
 ## 0.1.0
 
 First npm release. The full language server (parser, index, scope engine,

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -247,6 +247,31 @@ The dashes are deliberate, not stubs: the server declares the capability
 globally (LSP has no per-language-id capability negotiation) and returns an
 empty result for the language ids where the feature has no meaning.
 
+## In a browser
+
+`@px-lsp/server/browser` is a second entry point: the same parser, schema and
+token tables as a plain library, for hosts that cannot spawn a process at all.
+
+```ts
+import { createBrowserLanguageService } from "@px-lsp/server/browser";
+
+const service = createBrowserLanguageService({
+  tokens: await (await fetch("/px/tokens.json")).json(),
+});
+const doc = service.openDocument("events/tutorial.txt", text);
+doc.diagnostics();
+doc.completions(offset);
+```
+
+The token tables ship as prebaked JSON under
+`@px-lsp/server/browser-data/<gameId>/`, split so a page can answer completions
+and diagnostics from 225 KB brotli and fetch the hover prose later.
+
+It has one file: the one you opened. There is no workspace index, so
+references to definitions in other files do not resolve and the
+unknown-reference diagnostics are omitted rather than guessed. The service
+reports this on `capabilities`. `docs/EMBEDDING.md` has the full contract.
+
 ## Per-game support
 
 | | CK3 | Victoria 3 | EU5 |

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -45,10 +45,10 @@
   "scripts": {
     "compile": "esbuild src/server.ts --bundle --outfile=dist/server.js --format=cjs --platform=node --target=node18 --banner:js=\"#!/usr/bin/env node\"",
     "watch": "esbuild src/server.ts --bundle --outfile=dist/server.js --format=cjs --platform=node --target=node18 --watch",
-    "prepack": "pnpm run compile && pnpm run bake:browser:all && pnpm run compile:browser && pnpm run types:browser",
+    "prepack": "pnpm run compile && pnpm run bake:browser && pnpm run compile:browser && pnpm run types:browser",
     "compile:browser": "esbuild src/browser/index.ts --bundle --outfile=dist/browser.js --format=esm --platform=browser --target=es2022 --minify --alias:fs=./src/browser/shims/fs.ts --alias:path=./src/browser/shims/path.ts --alias:os=./src/browser/shims/os.ts --alias:vscode-languageserver/node=vscode-languageserver-types",
     "types:browser": "tsc -p tsconfig.browser.json",
-    "bake:browser:all": "pnpm --dir ../.. run bake:browser -- --game ck3"
+    "bake:browser": "pnpm --dir ../.. run bake:browser"
   },
   "dependencies": {
     "@px-lsp/protocol": "workspace:*",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -33,6 +33,11 @@
   },
   "exports": {
     "./package.json": "./package.json",
+    "./browser": {
+      "types": "./dist/types/packages/server/src/browser/index.d.ts",
+      "default": "./dist/browser.js"
+    },
+    "./browser-data/*": "./dist/browser-data/*",
     "./dds": "./src/dds/index.ts",
     "./parser": "./src/parser/index.ts",
     "./*": "./src/*.ts"
@@ -40,7 +45,10 @@
   "scripts": {
     "compile": "esbuild src/server.ts --bundle --outfile=dist/server.js --format=cjs --platform=node --target=node18 --banner:js=\"#!/usr/bin/env node\"",
     "watch": "esbuild src/server.ts --bundle --outfile=dist/server.js --format=cjs --platform=node --target=node18 --watch",
-    "prepack": "pnpm run compile"
+    "prepack": "pnpm run compile && pnpm run bake:browser:all && pnpm run compile:browser && pnpm run types:browser",
+    "compile:browser": "esbuild src/browser/index.ts --bundle --outfile=dist/browser.js --format=esm --platform=browser --target=es2022 --minify --alias:fs=./src/browser/shims/fs.ts --alias:path=./src/browser/shims/path.ts --alias:os=./src/browser/shims/os.ts --alias:vscode-languageserver/node=vscode-languageserver-types",
+    "types:browser": "tsc -p tsconfig.browser.json",
+    "bake:browser:all": "pnpm --dir ../.. run bake:browser -- --game ck3"
   },
   "dependencies": {
     "@px-lsp/protocol": "workspace:*",

--- a/packages/server/src/browser/data.ts
+++ b/packages/server/src/browser/data.ts
@@ -1,0 +1,77 @@
+/**
+ * The baked data contract for the browser build.
+ *
+ * On node the server parses `data/<game>/script_docs/*.log` at startup. A
+ * browser cannot: the logs are 1.1 MB of text and there is no filesystem. So
+ * `scripts/bake-browser-data.ts` runs the same parsers at build time and emits
+ * the result as JSON, split in two by how often it is needed:
+ *
+ *   tokens.json  name/kind/scopes/traits for every token   ~28 KB brotli
+ *   docs.json    the doc + usage prose, index-aligned      ~85 KB brotli
+ *
+ * Completion, diagnostics and scope inference read only the first. The prose is
+ * needed the first time someone hovers, so a host can fetch it late (or never).
+ * Splitting them is what keeps the startup payload smaller than the editor.
+ */
+import type { TokenData, TokenKind } from "@px-lsp/protocol/types";
+
+/** Bumped when the payload shape changes; `applyTokens` refuses a mismatch. */
+export const BROWSER_DATA_VERSION = 1;
+
+/** One token minus its prose. Field names match `TokenData` so the merge is a spread. */
+export interface BakedToken {
+  name: string;
+  kind: TokenKind;
+  scopes: string[];
+  traits?: string;
+}
+
+export interface BakedTokens {
+  version: number;
+  gameId: string;
+  /** The game build the script_docs logs were dumped from, for provenance. */
+  source: string;
+  tokens: BakedToken[];
+  /** Templated modifier tags ($CULTURE$_opinion), kept whole: they carry prose. */
+  templates: TokenData[];
+  /** on_action name -> expected root scope, from on_actions.log. */
+  onActionScopes: Record<string, string>;
+}
+
+/**
+ * Prose for the tokens in `BakedTokens.tokens`, in the same order. A pair per
+ * token, `["", ""]` where the log had neither. Positional rather than keyed
+ * because a name can be both a trigger and an effect, so a name alone is not a
+ * key, and the aligned form is a third smaller than emitting one.
+ */
+export interface BakedDocs {
+  version: number;
+  gameId: string;
+  /** `[doc, usage]` per token, aligned with `BakedTokens.tokens`. */
+  prose: Array<[string, string]>;
+}
+
+/** The per-context completion frequency tables, copied from `freqs.json`. */
+export type BakedFreqs = unknown;
+
+export function assertVersion(payload: { version: number }, what: string): void {
+  if (payload.version !== BROWSER_DATA_VERSION) {
+    throw new Error(
+      `px-lsp browser ${what}: payload version ${payload.version}, expected ${BROWSER_DATA_VERSION}. ` +
+        `Re-run \`pnpm run bake:browser\` against this version of the server.`
+    );
+  }
+}
+
+/** Rehydrate baked tokens into the `TokenData` the features expect. */
+export function toTokenData(baked: BakedTokens, docs?: BakedDocs): TokenData[] {
+  const prose = docs?.prose;
+  return baked.tokens.map((t, i) => ({
+    name: t.name,
+    kind: t.kind,
+    scopes: t.scopes,
+    ...(t.traits === undefined ? {} : { traits: t.traits }),
+    doc: prose?.[i]?.[0] ?? "",
+    ...(prose?.[i]?.[1] ? { usage: prose[i][1] } : {}),
+  }));
+}

--- a/packages/server/src/browser/index.ts
+++ b/packages/server/src/browser/index.ts
@@ -1,0 +1,29 @@
+/**
+ * `@px-lsp/server/browser` — the language service without node.
+ *
+ * Completion, hover, diagnostics and scope inference against a single in-memory
+ * document, with no filesystem, no workspace scan and no LSP transport. The
+ * token tables come in as JSON baked by `scripts/bake-browser-data.ts`; the
+ * host decides whether to bundle them or fetch them.
+ *
+ *   import { createBrowserLanguageService } from "@px-lsp/server/browser";
+ *   import tokens from "@px-lsp/server/browser-data/<gameId>/tokens.json";
+ *
+ *   const svc = createBrowserLanguageService({ tokens });
+ *   const doc = svc.openDocument("events/tutorial.txt", text);
+ *   doc.diagnostics();
+ *   doc.completions(offset);
+ *
+ * Read `capabilities` before showing results to a user: this build cannot see
+ * any file except the one open, and says so rather than guessing.
+ */
+export {
+  createBrowserLanguageService,
+  activeGameId,
+  type BrowserCapabilities,
+  type BrowserDocument,
+  type BrowserLanguageService,
+  type BrowserServiceOptions,
+} from "./service";
+
+export { BROWSER_DATA_VERSION, toTokenData, type BakedDocs, type BakedToken, type BakedTokens } from "./data";

--- a/packages/server/src/browser/service.ts
+++ b/packages/server/src/browser/service.ts
@@ -1,0 +1,248 @@
+/**
+ * The language service, without node.
+ *
+ * `server.ts` is a language server: a process, a JSON-RPC connection, a
+ * workspace scan, a file watcher. None of that survives in a browser, but the
+ * language knowledge underneath it does, because the features are plain
+ * functions over (ServerData, TextDocument, position). This module assembles
+ * exactly those pieces and hands back a small document-shaped API.
+ *
+ * What it deliberately is NOT: a workspace. There is no index of the game files
+ * or of other mod files, so anything whose answer lives in a file you are not
+ * editing is absent by construction rather than silently wrong. `capabilities`
+ * says so field by field; hosts should surface it rather than imply full
+ * fidelity.
+ */
+import type { CompletionItem, Diagnostic, Hover } from "vscode-languageserver";
+import { TextDocument } from "vscode-languageserver-textdocument";
+import type { Definition } from "@px-lsp/protocol/types";
+import { setActiveProfile, activeProfile } from "../games/active";
+import { resolveProfile } from "../games/registry";
+import { ServerData } from "../serverData";
+import { loadSchema, type SchemaData } from "../schema/loader";
+import { coerceFreqs, type FreqData } from "../schema/freqs";
+import { classifyFile } from "../index/indexer";
+import { extractDefinitions } from "../index/extract";
+import { CompletionFeature } from "../features/completion";
+import { provideHover } from "../features/hover";
+import { computeScriptDiagnostics, type FileContext } from "../features/diagnostics";
+import { computeScopeAt } from "../features/scopeAt";
+import type { ScopeAtResult } from "@px-lsp/protocol/protocol";
+import { getParse, evictParse } from "../parseCache";
+import type { SchemaEntry } from "../schema/types";
+import { assertVersion, toTokenData, type BakedDocs, type BakedTokens } from "./data";
+
+/** What this build can and cannot answer. Honest by design: see the header. */
+export interface BrowserCapabilities {
+  /** Brace/encoding/folder-trap diagnostics over the open document. */
+  diagnostics: true;
+  /** Grammar- and scope-aware completion from the baked token tables. */
+  completion: true;
+  /** Scope inference at a position (the AD-5 annotate-never-hide ranking). */
+  scopeInference: true;
+  /** Hover prose. False until `attachDocs` supplies the prose payload. */
+  hoverDocs: boolean;
+  /**
+   * Always false. Definitions from OTHER files (vanilla, other mod files) need
+   * a workspace scan. Definitions in the open document itself DO resolve.
+   */
+  workspaceIndex: false;
+  /** Always false: unknown-reference checks need the workspace index above. */
+  referenceDiagnostics: false;
+  /** Always false: .gui, DDS, datafunctions and the tiger runner are node-only. */
+  guiAndAssets: false;
+}
+
+export interface BrowserServiceOptions {
+  /** Game profile id; defaults to the profile the tokens were baked for. */
+  gameId?: string;
+  tokens: BakedTokens;
+  /** Hover prose. Omit to start smaller and call `attachDocs` later. */
+  docs?: BakedDocs;
+  /** Parsed `freqs.json`, for completion ranking. Omit and ranking falls back. */
+  freqs?: unknown;
+  /**
+   * The virtual mod root every document path is resolved against. It never
+   * touches a disk; it exists so schema classification and the folder-trap
+   * diagnostics see a mod-relative path. Defaults to "/mod".
+   */
+  modRoot?: string;
+}
+
+/** One open document. Holds its parse across edits, so keep it and `update`. */
+export interface BrowserDocument {
+  /** The mod-relative path this document was opened as. */
+  readonly path: string;
+  /**
+   * Schema kind for the folder ("event", "scripted_effect", ...); null when the
+   * folder is not one the schema knows, which is itself worth telling a user.
+   */
+  readonly kind: string | null;
+  update(text: string): void;
+  diagnostics(): Diagnostic[];
+  completions(offset: number): CompletionItem[];
+  hover(offset: number): Hover | null;
+  scopeAt(offset: number): ScopeAtResult;
+  dispose(): void;
+}
+
+export interface BrowserLanguageService {
+  readonly capabilities: Readonly<BrowserCapabilities>;
+  /** Supply the hover prose after startup; flips `capabilities.hoverDocs`. */
+  attachDocs(docs: BakedDocs): void;
+  openDocument(path: string, text: string): BrowserDocument;
+}
+
+/** The script language id; `paradox-gui` and `paradox-loc` are out of scope. */
+const SCRIPT_LANGUAGE = "paradox";
+
+/**
+ * Distinguishes two open documents that share a path. The parse cache is keyed
+ * by uri, so without this a second `openDocument("events/x.txt", …)` reads the
+ * first one's parse and reports diagnostics for text that is no longer there.
+ * The uri is a cache key and nothing else; schema classification uses `fsPath`.
+ */
+let documentSerial = 0;
+
+export function createBrowserLanguageService(options: BrowserServiceOptions): BrowserLanguageService {
+  assertVersion(options.tokens, "tokens");
+  if (options.docs) assertVersion(options.docs, "docs");
+
+  setActiveProfile(resolveProfile(options.gameId ?? options.tokens.gameId));
+  const modRoot = options.modRoot ?? "/mod";
+
+  const data = new ServerData();
+  const schema: SchemaData = loadSchema(null);
+  const getSchema = (): SchemaData => schema;
+
+  let docs: BakedDocs | undefined = options.docs;
+  const applyTokens = (): void => {
+    data.setTokens(toTokenData(options.tokens, docs));
+  };
+  data.setModifierTemplates(options.tokens.templates);
+  applyTokens();
+  data.onActionScopes = new Map(Object.entries(options.tokens.onActionScopes));
+  data.rootScopesForFile = (file) => rootScopesFor(entryFor(file));
+
+  const freqs: FreqData = coerceFreqs(options.freqs);
+  const completion = new CompletionFeature(data, getSchema, freqs);
+
+  const capabilities: BrowserCapabilities = {
+    diagnostics: true,
+    completion: true,
+    scopeInference: true,
+    hoverDocs: docs !== undefined,
+    workspaceIndex: false,
+    referenceDiagnostics: false,
+    guiAndAssets: false,
+  };
+
+  function absolute(relPath: string): string {
+    const clean = relPath.replace(/\\/g, "/").replace(/^\/+/, "");
+    return modRoot + "/" + clean;
+  }
+
+  function entryFor(fsPath: string): SchemaEntry | null {
+    return classifyFile(modRoot, fsPath, schema.entries);
+  }
+
+  function rootScopesFor(entry: SchemaEntry | null): Set<string> | null {
+    if (!entry?.rootScopes || entry.rootScopes.length === 0) return null;
+    return new Set(entry.rootScopes.map((s) => s.toLowerCase()));
+  }
+
+  function openDocument(relPath: string, text: string): BrowserDocument {
+    const fsPath = absolute(relPath);
+    // The parse cache is keyed by uri + version, so every edit must bump the
+    // version or the second keystroke reads the first keystroke's parse.
+    const uri = "inmemory://px/" + String(++documentSerial) + encodeURI(fsPath);
+    const entry = entryFor(fsPath);
+    const rootScopes = rootScopesFor(entry);
+    let version = 0;
+    let doc = TextDocument.create(uri, SCRIPT_LANGUAGE, version, text);
+
+    const ctx: FileContext = { fsPath, modPath: modRoot, bomOnDisk: null };
+
+    /**
+     * Definitions declared in THIS document, the one part of the definition
+     * index a browser can honestly fill. Rebuilt lazily after each edit: hover
+     * only asks when the token tables had nothing for the word.
+     */
+    let localDefs: Map<string, Definition[]> | null = null;
+    function documentDefinitions(word: string): Definition[] {
+      if (!entry) return [];
+      if (localDefs === null) {
+        localDefs = new Map();
+        // The BOM strip mirrors server.ts: a leading BOM would otherwise become
+        // part of the first definition name.
+        const defs = extractDefinitions(doc.getText().replace(/^﻿/, ""), entry, fsPath, "mod");
+        for (const def of defs) {
+          const list = localDefs.get(def.name);
+          if (list) list.push(def);
+          else localDefs.set(def.name, [def]);
+        }
+      }
+      return localDefs.get(word) ?? [];
+    }
+
+    return {
+      path: relPath,
+      kind: entry?.kind ?? null,
+
+      update(next: string): void {
+        evictParse(uri);
+        version += 1;
+        doc = TextDocument.create(uri, SCRIPT_LANGUAGE, version, next);
+        localDefs = null;
+      },
+
+      diagnostics(): Diagnostic[] {
+        const { result, lineIndex } = getParse(doc);
+        // Structural and folder-trap checks only. The index-backed
+        // unknown-reference pass server.ts runs next needs a workspace scan,
+        // and running it without one would report false unknowns.
+        return computeScriptDiagnostics(result, lineIndex, ctx);
+      },
+
+      completions(offset: number): CompletionItem[] {
+        return completion.provide(doc, offset, rootScopes, entry).items;
+      },
+
+      hover(offset: number): Hover | null {
+        return provideHover(
+          data,
+          doc,
+          doc.positionAt(offset),
+          rootScopes,
+          entry,
+          getSchema,
+          documentDefinitions
+        );
+      },
+
+      scopeAt(offset: number): ScopeAtResult {
+        return computeScopeAt(data, doc, doc.positionAt(offset), rootScopes, entry);
+      },
+
+      dispose(): void {
+        evictParse(uri);
+      },
+    };
+  }
+
+  return {
+    capabilities,
+    attachDocs(next: BakedDocs): void {
+      assertVersion(next, "docs");
+      docs = next;
+      applyTokens();
+      capabilities.hoverDocs = true;
+    },
+    openDocument,
+  };
+}
+
+/** The game profile the service is currently configured for. */
+export function activeGameId(): string {
+  return activeProfile().id;
+}

--- a/packages/server/src/browser/service.ts
+++ b/packages/server/src/browser/service.ts
@@ -106,9 +106,50 @@ let documentSerial = 0;
 
 export function createBrowserLanguageService(options: BrowserServiceOptions): BrowserLanguageService {
   assertVersion(options.tokens, "tokens");
-  if (options.docs) assertVersion(options.docs, "docs");
 
-  setActiveProfile(resolveProfile(options.gameId ?? options.tokens.gameId));
+  // A schema/profile for one game over token tables baked for another produces
+  // answers that look right and are not, so it is refused rather than resolved.
+  if (options.gameId !== undefined && options.gameId !== options.tokens.gameId) {
+    throw new Error(
+      `px-lsp browser: gameId "${options.gameId}" does not match tokens baked for "${options.tokens.gameId}". ` +
+        `Pass the token payload for "${options.gameId}", or drop the gameId option.`
+    );
+  }
+
+  /**
+   * `BakedDocs.prose` is aligned with `BakedTokens.tokens` BY INDEX, so prose
+   * from another game does not fail to match — it attaches the wrong text to
+   * every token. The version check cannot see that; the gameId can.
+   */
+  function assertDocsGame(payload: BakedDocs): void {
+    if (payload.gameId !== options.tokens.gameId) {
+      throw new Error(
+        `px-lsp browser docs: baked for "${payload.gameId}", tokens baked for "${options.tokens.gameId}". ` +
+          `The prose is index-aligned with the token table, so a mismatch mislabels every token.`
+      );
+    }
+  }
+
+  if (options.docs) {
+    assertVersion(options.docs, "docs");
+    assertDocsGame(options.docs);
+  }
+
+  /**
+   * The profile is process-wide (games/active.ts) and feature code reads it at
+   * call time, so a second service created in the same realm would otherwise
+   * switch the first one's game underneath it. Each service captures its own
+   * profile here and re-asserts it at the entry of every public operation that
+   * reaches feature code, which is enough as long as none of them yields in the
+   * middle (they are all synchronous).
+   */
+  const profile = resolveProfile(options.gameId ?? options.tokens.gameId);
+  setActiveProfile(profile);
+  function enter<T>(op: () => T): T {
+    setActiveProfile(profile);
+    return op();
+  }
+
   const modRoot = options.modRoot ?? "/mod";
 
   const data = new ServerData();
@@ -152,6 +193,7 @@ export function createBrowserLanguageService(options: BrowserServiceOptions): Br
   }
 
   function openDocument(relPath: string, text: string): BrowserDocument {
+    setActiveProfile(profile);
     const fsPath = absolute(relPath);
     // The parse cache is keyed by uri + version, so every edit must bump the
     // version or the second keystroke reads the first keystroke's parse.
@@ -197,31 +239,27 @@ export function createBrowserLanguageService(options: BrowserServiceOptions): Br
       },
 
       diagnostics(): Diagnostic[] {
-        const { result, lineIndex } = getParse(doc);
-        // Structural and folder-trap checks only. The index-backed
-        // unknown-reference pass server.ts runs next needs a workspace scan,
-        // and running it without one would report false unknowns.
-        return computeScriptDiagnostics(result, lineIndex, ctx);
+        return enter(() => {
+          const { result, lineIndex } = getParse(doc);
+          // Structural and folder-trap checks only. The index-backed
+          // unknown-reference pass server.ts runs next needs a workspace scan,
+          // and running it without one would report false unknowns.
+          return computeScriptDiagnostics(result, lineIndex, ctx);
+        });
       },
 
       completions(offset: number): CompletionItem[] {
-        return completion.provide(doc, offset, rootScopes, entry).items;
+        return enter(() => completion.provide(doc, offset, rootScopes, entry).items);
       },
 
       hover(offset: number): Hover | null {
-        return provideHover(
-          data,
-          doc,
-          doc.positionAt(offset),
-          rootScopes,
-          entry,
-          getSchema,
-          documentDefinitions
+        return enter(() =>
+          provideHover(data, doc, doc.positionAt(offset), rootScopes, entry, getSchema, documentDefinitions)
         );
       },
 
       scopeAt(offset: number): ScopeAtResult {
-        return computeScopeAt(data, doc, doc.positionAt(offset), rootScopes, entry);
+        return enter(() => computeScopeAt(data, doc, doc.positionAt(offset), rootScopes, entry));
       },
 
       dispose(): void {
@@ -234,6 +272,8 @@ export function createBrowserLanguageService(options: BrowserServiceOptions): Br
     capabilities,
     attachDocs(next: BakedDocs): void {
       assertVersion(next, "docs");
+      assertDocsGame(next);
+      setActiveProfile(profile);
       docs = next;
       applyTokens();
       capabilities.hoverDocs = true;

--- a/packages/server/src/browser/shims/fs.ts
+++ b/packages/server/src/browser/shims/fs.ts
@@ -1,0 +1,77 @@
+/**
+ * An empty `fs` for the browser bundle (esbuild aliases "fs" here).
+ *
+ * The browser service never reads from disk: its token tables arrive as baked
+ * JSON and `loadSchema(null)` takes no filesystem path. This module exists so
+ * the ~26 modules that do `import * as fs from "fs"` still link, and so that
+ * anything which slips onto a disk-backed path fails the way a missing file
+ * fails on node rather than throwing "fs.readFileSync is not a function".
+ */
+function enoent(op: string, target: string): NodeJS.ErrnoException {
+  const err = new Error(`ENOENT: no such file or directory, ${op} '${target}'`) as NodeJS.ErrnoException;
+  err.code = "ENOENT";
+  err.errno = -2;
+  err.syscall = op;
+  err.path = target;
+  return err;
+}
+
+export function existsSync(_target: unknown): boolean {
+  return false;
+}
+
+export function readFileSync(target: unknown, _options?: unknown): never {
+  throw enoent("open", String(target));
+}
+
+export function readdirSync(target: unknown, _options?: unknown): never {
+  throw enoent("scandir", String(target));
+}
+
+export function statSync(target: unknown, _options?: unknown): never {
+  throw enoent("stat", String(target));
+}
+
+export function lstatSync(target: unknown, _options?: unknown): never {
+  throw enoent("lstat", String(target));
+}
+
+export function realpathSync(target: unknown): never {
+  throw enoent("realpath", String(target));
+}
+
+/** Writers are no-ops: nothing in the browser build has a disk to persist to. */
+export function mkdirSync(_target: unknown, _options?: unknown): undefined {
+  return undefined;
+}
+
+export function writeFileSync(_target: unknown, _data?: unknown, _options?: unknown): void {}
+
+export function appendFileSync(_target: unknown, _data?: unknown, _options?: unknown): void {}
+
+export function rmSync(_target: unknown, _options?: unknown): void {}
+
+export function unlinkSync(_target: unknown): void {}
+
+export const promises = {
+  readFile: (target: unknown): Promise<never> => Promise.reject(enoent("open", String(target))),
+  readdir: (target: unknown): Promise<never> => Promise.reject(enoent("scandir", String(target))),
+  stat: (target: unknown): Promise<never> => Promise.reject(enoent("stat", String(target))),
+  writeFile: (): Promise<void> => Promise.resolve(),
+  mkdir: (): Promise<undefined> => Promise.resolve(undefined),
+};
+
+export default {
+  existsSync,
+  readFileSync,
+  readdirSync,
+  statSync,
+  lstatSync,
+  realpathSync,
+  mkdirSync,
+  writeFileSync,
+  appendFileSync,
+  rmSync,
+  unlinkSync,
+  promises,
+};

--- a/packages/server/src/browser/shims/os.ts
+++ b/packages/server/src/browser/shims/os.ts
@@ -1,0 +1,19 @@
+/**
+ * Minimal `os` for the browser bundle (esbuild aliases "os" here). Only
+ * server.ts reads it, for a scratch directory the browser build never uses.
+ */
+export function tmpdir(): string {
+  return "/tmp";
+}
+
+export function homedir(): string {
+  return "/";
+}
+
+export const EOL = "\n";
+
+export function platform(): string {
+  return "browser";
+}
+
+export default { tmpdir, homedir, EOL, platform };

--- a/packages/server/src/browser/shims/path.ts
+++ b/packages/server/src/browser/shims/path.ts
@@ -1,0 +1,121 @@
+/**
+ * POSIX `path` for the browser bundle (esbuild aliases "path" here).
+ *
+ * Only the surface the reachable browser code paths use is implemented, but it
+ * is implemented exactly: `classifyFile` maps a file onto its schema entry with
+ * `relative` + `sep`, and a subtly wrong answer there is a wrong diagnostic
+ * rather than a visible failure. `test/browserPath.test.ts` pins every function
+ * against node's own `path.posix`.
+ *
+ * There is no working directory in a browser, so `resolve` treats "/" as cwd.
+ */
+export const sep = "/";
+export const delimiter = ":";
+
+function clean(parts: string[], keepUp: boolean): string[] {
+  const out: string[] = [];
+  for (const part of parts) {
+    if (part === "" || part === ".") continue;
+    if (part !== "..") out.push(part);
+    else if (out.length > 0 && out[out.length - 1] !== "..") out.pop();
+    else if (keepUp) out.push("..");
+  }
+  return out;
+}
+
+export function isAbsolute(p: string): boolean {
+  return p.startsWith("/");
+}
+
+export function normalize(p: string): string {
+  if (p === "") return ".";
+  const absolute = isAbsolute(p);
+  const trailing = p.endsWith("/");
+  let out = clean(p.split("/"), !absolute).join("/");
+  if (out === "" && !absolute) out = ".";
+  if (out !== "" && trailing) out += "/";
+  return absolute ? "/" + out : out;
+}
+
+export function join(...parts: string[]): string {
+  const joined = parts.filter((p) => p !== "").join("/");
+  return joined === "" ? "." : normalize(joined);
+}
+
+export function resolve(...parts: string[]): string {
+  let resolved = "";
+  let absolute = false;
+  for (let i = parts.length - 1; i >= 0 && !absolute; i--) {
+    const part = parts[i];
+    if (part === "") continue;
+    resolved = resolved === "" ? part : `${part}/${resolved}`;
+    absolute = isAbsolute(part);
+  }
+  return "/" + clean(resolved.split("/"), false).join("/");
+}
+
+export function relative(from: string, to: string): string {
+  const a = resolve(from);
+  const b = resolve(to);
+  if (a === b) return "";
+  const fromParts = a.split("/").filter((p) => p !== "");
+  const toParts = b.split("/").filter((p) => p !== "");
+  let i = 0;
+  while (i < fromParts.length && i < toParts.length && fromParts[i] === toParts[i]) i++;
+  const up: string[] = [];
+  for (let k = i; k < fromParts.length; k++) up.push("..");
+  return [...up, ...toParts.slice(i)].join("/");
+}
+
+export function basename(p: string, ext?: string): string {
+  const parts = p.split("/").filter((part) => part !== "");
+  let base = parts.length === 0 ? "" : parts[parts.length - 1];
+  if (ext !== undefined && ext !== base && base.endsWith(ext)) base = base.slice(0, -ext.length);
+  return base;
+}
+
+export function dirname(p: string): string {
+  // Ported from node's path.posix.dirname rather than derived from split/join:
+  // dirname does NOT normalize, so a repeated separator has to survive
+  // ("/a/b//c/d.txt" -> "/a/b//c"). The test pins this against node.
+  if (p.length === 0) return ".";
+  const rooted = p.charCodeAt(0) === 47;
+  let end = -1;
+  let matchedSlash = true;
+  for (let i = p.length - 1; i >= 1; i--) {
+    if (p.charCodeAt(i) === 47) {
+      if (!matchedSlash) {
+        end = i;
+        break;
+      }
+    } else {
+      matchedSlash = false;
+    }
+  }
+  if (end === -1) return rooted ? "/" : ".";
+  if (rooted && end === 1) return "//";
+  return p.slice(0, end);
+}
+
+export function extname(p: string): string {
+  const base = basename(p);
+  // "." and ".." are directory names, not a dotfile with an extension; node
+  // returns "" for both, and "" for a leading dot (".gitignore").
+  if (base === "." || base === "..") return "";
+  const dot = base.lastIndexOf(".");
+  return dot <= 0 ? "" : base.slice(dot);
+}
+
+export const posix = {
+  sep,
+  delimiter,
+  isAbsolute,
+  normalize,
+  join,
+  resolve,
+  relative,
+  basename,
+  dirname,
+  extname,
+};
+export default posix;

--- a/packages/server/src/schema/freqs.ts
+++ b/packages/server/src/schema/freqs.ts
@@ -53,12 +53,17 @@ export function coerceFreqs(parsed: unknown): FreqData {
   const out = emptyFreqData();
   if (!parsed || typeof parsed !== "object") return out;
   const p = parsed as Partial<FreqData>;
-  if (!p.contexts || !p.tokens) return out;
-  for (const c of FREQ_CONTEXTS) {
-    const table = (p.contexts as Record<string, unknown>)[c];
-    if (table && typeof table === "object") out.contexts[c] = table as Record<string, number>;
+  // Per field, not all-or-nothing: a payload with usable contexts and a broken
+  // `tokens` keeps its contexts instead of degrading both to empty.
+  if (p.contexts !== null && typeof p.contexts === "object") {
+    for (const c of FREQ_CONTEXTS) {
+      const table = (p.contexts as Record<string, unknown>)[c];
+      if (table && typeof table === "object") out.contexts[c] = table as Record<string, number>;
+    }
   }
-  if (typeof p.tokens === "object") out.tokens = p.tokens;
+  // `typeof null === "object"`, so the null check is not redundant: a null here
+  // would replace the empty table and completion throws on `freqs.tokens[name]`.
+  if (p.tokens !== null && typeof p.tokens === "object") out.tokens = p.tokens;
   if (p.meta) out.meta = p.meta;
   return out;
 }

--- a/packages/server/src/schema/freqs.ts
+++ b/packages/server/src/schema/freqs.ts
@@ -44,26 +44,32 @@ export function emptyFreqData(): FreqData {
 }
 
 /**
+ * Validate a parsed freqs.json into `FreqData`. Fail-soft: anything unexpected
+ * (null, wrong shape, missing tables) degrades to empty tables so completion
+ * still works. Shared with the browser build, which supplies the parsed JSON
+ * directly because it has no filesystem to read it from.
+ */
+export function coerceFreqs(parsed: unknown): FreqData {
+  const out = emptyFreqData();
+  if (!parsed || typeof parsed !== "object") return out;
+  const p = parsed as Partial<FreqData>;
+  if (!p.contexts || !p.tokens) return out;
+  for (const c of FREQ_CONTEXTS) {
+    const table = (p.contexts as Record<string, unknown>)[c];
+    if (table && typeof table === "object") out.contexts[c] = table as Record<string, number>;
+  }
+  if (typeof p.tokens === "object") out.tokens = p.tokens;
+  if (p.meta) out.meta = p.meta;
+  return out;
+}
+
+/**
  * Load the bundled freqs.json from `dir`. Fail-soft: any error (missing file,
  * bad JSON, wrong shape) returns empty tables so completion still works.
  */
 export function loadFreqs(dir: string): FreqData {
   try {
-    const raw = fs.readFileSync(path.join(dir, "freqs.json"), "utf8");
-    const parsed = JSON.parse(raw) as Partial<FreqData>;
-    if (!parsed || typeof parsed !== "object" || !parsed.contexts || !parsed.tokens) {
-      return emptyFreqData();
-    }
-    const out = emptyFreqData();
-    for (const c of FREQ_CONTEXTS) {
-      const table = (parsed.contexts as Record<string, unknown>)[c];
-      if (table && typeof table === "object") {
-        out.contexts[c] = table as Record<string, number>;
-      }
-    }
-    if (parsed.tokens && typeof parsed.tokens === "object") out.tokens = parsed.tokens;
-    if (parsed.meta) out.meta = parsed.meta;
-    return out;
+    return coerceFreqs(JSON.parse(fs.readFileSync(path.join(dir, "freqs.json"), "utf8")));
   } catch {
     return emptyFreqData();
   }

--- a/packages/server/test/browserPath.test.ts
+++ b/packages/server/test/browserPath.test.ts
@@ -1,0 +1,102 @@
+/**
+ * The browser build aliases node's `path` to src/browser/shims/path.ts. That
+ * shim is load-bearing: `classifyFile` decides which schema entry a file gets
+ * from `path.relative` + `path.sep`, so a shim that disagrees with node by one
+ * segment produces a wrong diagnostic rather than a visible failure.
+ *
+ * So this suite does not assert hand-written expectations. It asserts that the
+ * shim agrees with node's own `path.posix` on every input, which is the only
+ * bar that matters.
+ */
+import { describe, expect, it } from "vitest";
+import { posix } from "path";
+import * as shim from "../src/browser/shims/path";
+
+const PATHS = [
+  "",
+  ".",
+  "..",
+  "/",
+  "/mod",
+  "/mod/",
+  "/mod/events/tutorial.txt",
+  "mod/events/tutorial.txt",
+  "/mod/common/scripted_effects/00_my.txt",
+  "/mod/events//double//slash.txt",
+  "/mod/./events/../events/x.txt",
+  "/mod/../outside.txt",
+  "events/tutorial.txt",
+  "./events/tutorial.txt",
+  "../sibling/x.txt",
+  "/a/b/c/d",
+  "/a/b",
+  "file.txt",
+  "file",
+  ".hidden",
+  "archive.tar.gz",
+  "/trailing/dot.",
+  "...",
+  "a..b",
+  "/mod/.ck3modding/schema.json",
+  "/a/b/../..",
+  "/..",
+];
+
+describe("browser path shim", () => {
+  it("matches path.posix.normalize", () => {
+    for (const p of PATHS) expect(shim.normalize(p), p).toBe(posix.normalize(p));
+  });
+
+  it("matches path.posix.isAbsolute", () => {
+    for (const p of PATHS) expect(shim.isAbsolute(p), p).toBe(posix.isAbsolute(p));
+  });
+
+  it("matches path.posix.basename, dirname and extname", () => {
+    for (const p of PATHS) {
+      expect(shim.basename(p), `basename ${p}`).toBe(posix.basename(p));
+      expect(shim.dirname(p), `dirname ${p}`).toBe(posix.dirname(p));
+      expect(shim.extname(p), `extname ${p}`).toBe(posix.extname(p));
+    }
+    expect(shim.basename("/mod/events/x.txt", ".txt")).toBe("x");
+  });
+
+  it("matches path.posix.join", () => {
+    for (const a of PATHS) {
+      for (const b of PATHS) {
+        expect(shim.join(a, b), `join(${a}, ${b})`).toBe(posix.join(a, b));
+      }
+    }
+  });
+
+  /**
+   * `resolve` is the one place the shim cannot copy node exactly: there is no
+   * working directory in a browser, so it anchors relative input at "/". Every
+   * absolute case, which is all `classifyFile` ever sees, must still match.
+   */
+  it("matches path.posix.resolve for absolute input", () => {
+    const absolute = PATHS.filter((p) => posix.isAbsolute(p));
+    for (const a of absolute) {
+      expect(shim.resolve(a), a).toBe(posix.resolve(a));
+      for (const b of PATHS) {
+        expect(shim.resolve(a, b), `resolve(${a}, ${b})`).toBe(posix.resolve(a, b));
+      }
+    }
+  });
+
+  it("anchors relative resolve at the root instead of a working directory", () => {
+    expect(shim.resolve("events", "x.txt")).toBe("/events/x.txt");
+  });
+
+  it("matches path.posix.relative for absolute pairs", () => {
+    const absolute = PATHS.filter((p) => posix.isAbsolute(p));
+    for (const a of absolute) {
+      for (const b of absolute) {
+        expect(shim.relative(a, b), `relative(${a}, ${b})`).toBe(posix.relative(a, b));
+      }
+    }
+  });
+
+  it("uses a forward slash separator", () => {
+    expect(shim.sep).toBe(posix.sep);
+  });
+});

--- a/packages/server/test/browserService.test.ts
+++ b/packages/server/test/browserService.test.ts
@@ -12,7 +12,7 @@
 import { describe, expect, it, beforeAll } from "vitest";
 import * as fs from "fs";
 import * as path from "path";
-import { DiagnosticSeverity } from "vscode-languageserver/node";
+import { DiagnosticSeverity, type Diagnostic } from "vscode-languageserver/node";
 import { createBrowserLanguageService } from "../src/browser";
 import { BROWSER_DATA_VERSION, type BakedDocs, type BakedToken, type BakedTokens } from "../src/browser/data";
 import { loadTokenDataFromLogs, parseOnActionsLog } from "../src/data/docsParser";
@@ -189,5 +189,60 @@ describe("browser language service", () => {
     expect(() =>
       createBrowserLanguageService({ tokens: { ...tokens, version: BROWSER_DATA_VERSION + 1 } })
     ).toThrow(/bake:browser/);
+  });
+
+  it("refuses a gameId that disagrees with the token payload", () => {
+    // Otherwise the vic3 schema and profile would answer over CK3 token
+    // tables: every answer plausible, none of them right.
+    expect(() => createBrowserLanguageService({ gameId: "vic3", tokens })).toThrow(/does not match/);
+    expect(() => createBrowserLanguageService({ gameId: "ck3", tokens })).not.toThrow();
+  });
+
+  it("refuses docs baked for another game, at construction and at attachDocs", () => {
+    // The prose is aligned with the token table BY INDEX, so a foreign payload
+    // does not fail to match — it silently attaches the wrong text everywhere.
+    const foreign: BakedDocs = { ...docs, gameId: "vic3" };
+    expect(() => createBrowserLanguageService({ tokens, docs: foreign })).toThrow(/index-aligned/);
+    expect(() => service(false).attachDocs(foreign)).toThrow(/index-aligned/);
+  });
+
+  it("keeps its own game when a second service for another game exists", () => {
+    // The profile is process-wide and feature code reads it at call time, so
+    // creating the vic3 service used to switch the ck3 service's game under it.
+    const ck3 = createBrowserLanguageService({ tokens, docs, freqs });
+    const ck3Doc = ck3.openDocument("events/tutorial.txt", "a = {\n");
+
+    const vic3 = createBrowserLanguageService({
+      tokens: {
+        version: BROWSER_DATA_VERSION,
+        gameId: "vic3",
+        source: "test",
+        tokens: [],
+        templates: [],
+        onActionScopes: {},
+      },
+    });
+    const vic3Doc = vic3.openDocument("events/x.txt", "a = {\n");
+
+    const message = (ds: Diagnostic[]) => ds.map((d) => JSON.stringify(d.message)).join(" ");
+    expect(message(vic3Doc.diagnostics())).toContain("Vic3");
+    // The one that matters: the older service, asked after the newer one exists.
+    expect(message(ck3Doc.diagnostics())).toContain("CK3");
+    expect(message(ck3Doc.diagnostics())).not.toContain("Vic3");
+    // And completion still reaches the CK3 tables the service was built with.
+    expect(
+      ck3
+        .openDocument("events/tutorial.txt", EVENT)
+        .completions(EVENT.indexOf("add_gold") + 5)
+        .map((i) => i.label)
+    ).toContain("add_gold");
+  });
+
+  it("survives a freqs payload whose tables are null", () => {
+    // `typeof null === "object"`, so a null table used to land in FreqData and
+    // completion threw on the first `freqs.tokens[name]` lookup.
+    const svc = createBrowserLanguageService({ tokens, docs, freqs: { contexts: null, tokens: null } });
+    const doc = svc.openDocument("events/tutorial.txt", EVENT);
+    expect(doc.completions(EVENT.indexOf("add_gold = 100") + 5).map((i) => i.label)).toContain("add_gold");
   });
 });

--- a/packages/server/test/browserService.test.ts
+++ b/packages/server/test/browserService.test.ts
@@ -1,0 +1,193 @@
+/**
+ * The browser language service (src/browser/), end to end against the real
+ * bundled CK3 data.
+ *
+ * These tests run on node, so they prove the ASSEMBLY is right, not that the
+ * bundle is browser-clean: the shims are aliased in at bundle time and cannot
+ * be exercised from here. What they do pin is that a service built with no
+ * filesystem, no workspace scan and no LSP connection still answers with the
+ * real token tables, and that the pieces which quietly break when reassembled
+ * (the uri+version parse cache, same-file definitions) actually work.
+ */
+import { describe, expect, it, beforeAll } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+import { DiagnosticSeverity } from "vscode-languageserver/node";
+import { createBrowserLanguageService } from "../src/browser";
+import { BROWSER_DATA_VERSION, type BakedDocs, type BakedToken, type BakedTokens } from "../src/browser/data";
+import { loadTokenDataFromLogs, parseOnActionsLog } from "../src/data/docsParser";
+import { loadWikiTokens, mergeWikiTokens } from "../src/data/wikiDocs";
+
+const DATA = path.resolve(__dirname, "..", "data", "ck3");
+
+let tokens: BakedTokens;
+let docs: BakedDocs;
+let freqs: unknown;
+
+beforeAll(() => {
+  // The same bake scripts/bake-browser-data.ts does, in memory. Keeping it here
+  // rather than reading dist/ means the suite does not depend on a build step.
+  const logs = path.join(DATA, "script_docs");
+  const loaded = loadTokenDataFromLogs(logs);
+  const merged = mergeWikiTokens(loaded.tokens, loadWikiTokens(path.join(DATA, "wikidocs")));
+  const hot: BakedToken[] = [];
+  const prose: Array<[string, string]> = [];
+  for (const t of merged) {
+    const entry: BakedToken = { name: t.name, kind: t.kind, scopes: t.scopes };
+    if (t.traits) entry.traits = t.traits;
+    hot.push(entry);
+    prose.push([t.doc ?? "", t.usage ?? ""]);
+  }
+  const onActionScopes: Record<string, string> = {};
+  for (const [name, scope] of parseOnActionsLog(logs)) onActionScopes[name] = scope;
+
+  tokens = {
+    version: BROWSER_DATA_VERSION,
+    gameId: "ck3",
+    source: "test",
+    tokens: hot,
+    templates: loaded.templates,
+    onActionScopes,
+  };
+  docs = { version: BROWSER_DATA_VERSION, gameId: "ck3", prose };
+  freqs = JSON.parse(fs.readFileSync(path.join(DATA, "freqs.json"), "utf8"));
+});
+
+function service(withDocs = true) {
+  return createBrowserLanguageService({
+    tokens,
+    docs: withDocs ? docs : undefined,
+    freqs,
+  });
+}
+
+const EVENT = `namespace = tutorial
+
+tutorial.0001 = {
+\ttype = character_event
+\ttitle = tutorial.0001.t
+\tdesc = tutorial.0001.desc
+\ttheme = family
+
+\ttrigger = {
+\t\tis_ruler = yes
+\t}
+
+\timmediate = {
+\t\tadd_gold = 100
+\t}
+
+\toption = {
+\t\tname = tutorial.0001.a
+\t}
+}
+`;
+
+describe("browser language service", () => {
+  it("loads the real token tables without touching a workspace", () => {
+    const svc = service();
+    expect(svc.capabilities.completion).toBe(true);
+    expect(svc.capabilities.hoverDocs).toBe(true);
+    // Stated plainly rather than implied: there is no index behind this build.
+    expect(svc.capabilities.workspaceIndex).toBe(false);
+    expect(svc.capabilities.referenceDiagnostics).toBe(false);
+  });
+
+  it("classifies a document by its mod-relative folder", () => {
+    const svc = service();
+    expect(svc.openDocument("events/tutorial.txt", EVENT).kind).toBe("event");
+    expect(svc.openDocument("common/scripted_effects/00_x.txt", "").kind).toBe("scripted_effect");
+    // A folder outside the schema is reported as such, not silently treated
+    // as an event file.
+    expect(svc.openDocument("not_a_game_folder/x.txt", "").kind).toBe(null);
+  });
+
+  it("reports no diagnostics for a well-formed event", () => {
+    const doc = service().openDocument("events/tutorial.txt", EVENT);
+    expect(doc.diagnostics()).toEqual([]);
+  });
+
+  it("reports an unbalanced brace", () => {
+    const doc = service().openDocument("events/tutorial.txt", "a = {\n\tb = 1\n");
+    const errors = doc.diagnostics().filter((d) => d.severity === DiagnosticSeverity.Error);
+    expect(errors.length).toBeGreaterThan(0);
+  });
+
+  it("reports the plural on_actions folder trap", () => {
+    // The silent-failure class this project exists for: CK3 reads
+    // common/on_action/, so the plural folder is ignored with no error.
+    const doc = service().openDocument("common/on_actions/00_x.txt", "on_death = {}\n");
+    const codes = doc.diagnostics().map((d) => d.code);
+    expect(codes).toContain("wrong-on-action-folder");
+  });
+
+  it("completes triggers inside a trigger block", () => {
+    const doc = service().openDocument("events/tutorial.txt", EVENT);
+    const items = doc.completions(EVENT.indexOf("is_ruler = yes") + "is_r".length);
+    expect(items.map((i) => i.label)).toContain("is_ruler");
+  });
+
+  it("completes effects inside an immediate block", () => {
+    const doc = service().openDocument("events/tutorial.txt", EVENT);
+    const items = doc.completions(EVENT.indexOf("add_gold = 100") + "add_g".length);
+    expect(items.map((i) => i.label)).toContain("add_gold");
+  });
+
+  it("hovers an effect with the prose from the logs", () => {
+    const doc = service().openDocument("events/tutorial.txt", EVENT);
+    const hover = doc.hover(EVENT.indexOf("add_gold") + 2);
+    expect(hover).not.toBeNull();
+    const text = JSON.stringify(hover?.contents);
+    expect(text).toContain("add_gold");
+    expect(text.toLowerCase()).toContain("adds gold");
+  });
+
+  it("still hovers before the prose payload arrives, then improves", () => {
+    const svc = service(false);
+    expect(svc.capabilities.hoverDocs).toBe(false);
+    const doc = svc.openDocument("events/tutorial.txt", EVENT);
+    const before = JSON.stringify(doc.hover(EVENT.indexOf("add_gold") + 2)?.contents);
+    expect(before).toContain("add_gold");
+    expect(before.toLowerCase()).not.toContain("adds gold");
+
+    svc.attachDocs(docs);
+    expect(svc.capabilities.hoverDocs).toBe(true);
+    const after = JSON.stringify(
+      svc.openDocument("events/tutorial.txt", EVENT).hover(EVENT.indexOf("add_gold") + 2)?.contents
+    );
+    expect(after.toLowerCase()).toContain("adds gold");
+  });
+
+  it("infers the scope at a position", () => {
+    const doc = service().openDocument("events/tutorial.txt", EVENT);
+    const result = doc.scopeAt(EVENT.indexOf("add_gold") + 2);
+    expect(result.scopes).toContain("character");
+  });
+
+  it("resolves a definition declared in the same document", () => {
+    // The one part of the definition index a browser can honestly fill.
+    const text = "my_test_effect = {\n\tadd_gold = 100\n}\n";
+    const doc = service().openDocument("common/scripted_effects/00_x.txt", text);
+    const hover = doc.hover(2);
+    expect(JSON.stringify(hover?.contents)).toContain("my_test_effect");
+  });
+
+  it("re-parses after an edit instead of serving the stale parse", () => {
+    // The parse cache is keyed by uri + version. AGENTS.md records this biting
+    // twice; if update() failed to bump the version the second read would still
+    // report the first text's error.
+    const doc = service().openDocument("events/tutorial.txt", "a = {\n");
+    expect(doc.diagnostics().length).toBeGreaterThan(0);
+    doc.update("a = { b = 1 }\n");
+    expect(doc.diagnostics()).toEqual([]);
+    doc.update("a = {\n");
+    expect(doc.diagnostics().length).toBeGreaterThan(0);
+    doc.dispose();
+  });
+
+  it("refuses a payload baked by a different version", () => {
+    expect(() =>
+      createBrowserLanguageService({ tokens: { ...tokens, version: BROWSER_DATA_VERSION + 1 } })
+    ).toThrow(/bake:browser/);
+  });
+});

--- a/packages/server/test/schema.test.ts
+++ b/packages/server/test/schema.test.ts
@@ -8,6 +8,7 @@
 import { describe, expect, it } from "vitest";
 import { extractDefinitions } from "../src/index/extract";
 import { CK3_SCHEMA, REF_FIELDS, PREFIX_REFS } from "../src/games/ck3/schema";
+import { coerceFreqs } from "../src/schema/freqs";
 import type { SchemaEntry } from "../src/schema/types";
 import type { Definition } from "@px-lsp/protocol/types";
 
@@ -186,5 +187,18 @@ describe("REF_FIELDS / PREFIX_REFS sanity", () => {
     for (const kinds of Object.values(PREFIX_REFS)) {
       expect(kinds.length).toBeGreaterThan(0);
     }
+  });
+});
+
+describe("coerceFreqs", () => {
+  it("never lets a null table through, and keeps the tables that are usable", () => {
+    // `typeof null === "object"`: a null tokens table reaching FreqData makes
+    // completion throw on `freqs.tokens[name]`.
+    const out = coerceFreqs({ contexts: { effect_block: { add_gold: 7 } }, tokens: null });
+    expect(out.tokens).toEqual({});
+    expect(out.contexts.effect_block).toEqual({ add_gold: 7 });
+    expect(coerceFreqs({ contexts: null, tokens: { add_gold: 7 } }).contexts.effect_block).toEqual({});
+    expect(coerceFreqs({ contexts: null, tokens: { add_gold: 7 } }).tokens).toEqual({ add_gold: 7 });
+    expect(coerceFreqs(null).tokens).toEqual({});
   });
 });

--- a/packages/server/tsconfig.browser.json
+++ b/packages/server/tsconfig.browser.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "dist/types",
+    "rootDir": "../.."
+  },
+  "include": ["src/browser/index.ts"]
+}

--- a/scripts/bake-browser-data.ts
+++ b/scripts/bake-browser-data.ts
@@ -1,0 +1,107 @@
+/**
+ * Bake the bundled language data into the two JSON payloads the browser build
+ * consumes. On node the server parses data/<game>/script_docs/*.log at startup;
+ * a browser has no filesystem and no appetite for 1.1 MB of log text, so the
+ * same parsers run here instead and the result ships as JSON.
+ *
+ * The split is the point. Completion, diagnostics and scope inference need only
+ * a token's name, kind and scopes; the doc and usage prose is needed the first
+ * time someone hovers and is two thirds of the bytes. Emitting them separately
+ * lets a host start on the small half.
+ *
+ * Output: packages/server/dist/browser-data/<gameId>/{tokens,docs,freqs}.json
+ *
+ * Run:
+ *   pnpm --filter @px-lsp/server run bake:browser [-- --game <id>]
+ */
+import * as fs from "fs";
+import * as path from "path";
+import type { TokenData } from "../packages/protocol/src/types";
+import { setActiveProfile } from "../packages/server/src/games/active";
+import { resolveProfile } from "../packages/server/src/games/registry";
+import { loadTokenDataFromLogs, parseOnActionsLog } from "../packages/server/src/data/docsParser";
+import { loadWikiTokens, mergeWikiTokens } from "../packages/server/src/data/wikiDocs";
+import {
+  BROWSER_DATA_VERSION,
+  type BakedDocs,
+  type BakedToken,
+  type BakedTokens,
+} from "../packages/server/src/browser/data";
+import { parseGameArg } from "./devPaths";
+
+const { gameId } = parseGameArg(process.argv.slice(2));
+setActiveProfile(resolveProfile(gameId));
+
+const SERVER = path.resolve(__dirname, "..", "packages", "server");
+const DATA = path.join(SERVER, "data", gameId);
+const OUT = path.join(SERVER, "dist", "browser-data", gameId);
+
+if (!fs.existsSync(DATA)) {
+  console.error(`no bundled data for game "${gameId}" at ${DATA}`);
+  process.exit(1);
+}
+
+const scriptDocs = path.join(DATA, "script_docs");
+const loaded = loadTokenDataFromLogs(scriptDocs);
+if (loaded.missing.length > 0) {
+  console.warn(`missing logs (baked without them): ${loaded.missing.join(", ")}`);
+}
+
+// Same merge order as server.ts: script_docs first, the wiki mirror filling the
+// gaps. Baking the merged result means the browser never has to do either.
+const wiki = loadWikiTokens(path.join(DATA, "wikidocs"));
+const tokens: TokenData[] = mergeWikiTokens(loaded.tokens, wiki);
+
+const hot: BakedToken[] = [];
+const prose: Array<[string, string]> = [];
+for (const t of tokens) {
+  const entry: BakedToken = { name: t.name, kind: t.kind, scopes: t.scopes };
+  if (t.traits) entry.traits = t.traits;
+  hot.push(entry);
+  prose.push([t.doc ?? "", t.usage ?? ""]);
+}
+
+const onActionScopes: Record<string, string> = {};
+for (const [name, scope] of parseOnActionsLog(scriptDocs)) onActionScopes[name] = scope;
+
+const bakedTokens: BakedTokens = {
+  version: BROWSER_DATA_VERSION,
+  gameId,
+  source: `bundled script_docs + wikidocs (${new Date().toISOString().slice(0, 10)})`,
+  tokens: hot,
+  templates: loaded.templates,
+  onActionScopes,
+};
+
+const bakedDocs: BakedDocs = { version: BROWSER_DATA_VERSION, gameId, prose };
+
+fs.mkdirSync(OUT, { recursive: true });
+const write = (name: string, value: unknown): number => {
+  const json = JSON.stringify(value);
+  fs.writeFileSync(path.join(OUT, name), json, "utf8");
+  return Buffer.byteLength(json);
+};
+
+const sizes = {
+  tokens: write("tokens.json", bakedTokens),
+  docs: write("docs.json", bakedDocs),
+  freqs: 0,
+};
+
+// freqs.json is copied rather than transformed: coerceFreqs validates it on the
+// way in, and the browser has no reason to see a different shape than node does.
+const freqsSrc = path.join(DATA, "freqs.json");
+if (fs.existsSync(freqsSrc)) {
+  const raw = fs.readFileSync(freqsSrc, "utf8");
+  fs.writeFileSync(path.join(OUT, "freqs.json"), raw, "utf8");
+  sizes.freqs = Buffer.byteLength(raw);
+} else {
+  console.warn(`no freqs.json for ${gameId}; completion ranking falls back to empty tables`);
+}
+
+const kb = (n: number): string => (n / 1024).toFixed(0).padStart(5) + " KB";
+console.log(`baked ${gameId}: ${tokens.length} tokens, ${loaded.templates.length} templates`);
+console.log(`  tokens.json ${kb(sizes.tokens)}   (name/kind/scopes/traits)`);
+console.log(`  docs.json   ${kb(sizes.docs)}   (doc + usage prose, fetch on first hover)`);
+console.log(`  freqs.json  ${kb(sizes.freqs)}   (completion ranking)`);
+console.log(`  -> ${OUT}`);

--- a/scripts/bake-browser-data.ts
+++ b/scripts/bake-browser-data.ts
@@ -12,13 +12,14 @@
  * Output: packages/server/dist/browser-data/<gameId>/{tokens,docs,freqs}.json
  *
  * Run:
- *   pnpm --filter @px-lsp/server run bake:browser [-- --game <id>]
+ *   pnpm run bake:browser                  every game that ships script_docs
+ *   pnpm run bake:browser -- --game vic3   just that one
  */
 import * as fs from "fs";
 import * as path from "path";
 import type { TokenData } from "../packages/protocol/src/types";
 import { setActiveProfile } from "../packages/server/src/games/active";
-import { resolveProfile } from "../packages/server/src/games/registry";
+import { resolveProfile, allProfiles } from "../packages/server/src/games/registry";
 import { loadTokenDataFromLogs, parseOnActionsLog } from "../packages/server/src/data/docsParser";
 import { loadWikiTokens, mergeWikiTokens } from "../packages/server/src/data/wikiDocs";
 import {
@@ -29,79 +30,95 @@ import {
 } from "../packages/server/src/browser/data";
 import { parseGameArg } from "./devPaths";
 
-const { gameId } = parseGameArg(process.argv.slice(2));
-setActiveProfile(resolveProfile(gameId));
-
 const SERVER = path.resolve(__dirname, "..", "packages", "server");
-const DATA = path.join(SERVER, "data", gameId);
-const OUT = path.join(SERVER, "dist", "browser-data", gameId);
+const kb = (n: number): string => (n / 1024).toFixed(0).padStart(5) + " KB";
 
-if (!fs.existsSync(DATA)) {
-  console.error(`no bundled data for game "${gameId}" at ${DATA}`);
+function bake(gameId: string): boolean {
+  // The parsers read the ACTIVE profile for their token vocabulary, so this has
+  // to move with the game rather than being set once at startup.
+  setActiveProfile(resolveProfile(gameId));
+
+  const data = path.join(SERVER, "data", gameId);
+  const scriptDocs = path.join(data, "script_docs");
+  if (!fs.existsSync(scriptDocs)) return false;
+
+  const loaded = loadTokenDataFromLogs(scriptDocs);
+  if (loaded.missing.length > 0) {
+    console.warn(`  ${gameId}: missing logs, baked without them: ${loaded.missing.join(", ")}`);
+  }
+
+  // Same merge order as server.ts: script_docs first, the wiki mirror filling
+  // the gaps. Baking the merged result means the browser never does either.
+  const wiki = loadWikiTokens(path.join(data, "wikidocs"));
+  const tokens: TokenData[] = mergeWikiTokens(loaded.tokens, wiki);
+
+  const hot: BakedToken[] = [];
+  const prose: Array<[string, string]> = [];
+  for (const t of tokens) {
+    const entry: BakedToken = { name: t.name, kind: t.kind, scopes: t.scopes };
+    if (t.traits) entry.traits = t.traits;
+    hot.push(entry);
+    prose.push([t.doc ?? "", t.usage ?? ""]);
+  }
+
+  const onActionScopes: Record<string, string> = {};
+  for (const [name, scope] of parseOnActionsLog(scriptDocs)) onActionScopes[name] = scope;
+
+  const bakedTokens: BakedTokens = {
+    version: BROWSER_DATA_VERSION,
+    gameId,
+    source: `bundled script_docs + wikidocs (${new Date().toISOString().slice(0, 10)})`,
+    tokens: hot,
+    templates: loaded.templates,
+    onActionScopes,
+  };
+  const bakedDocs: BakedDocs = { version: BROWSER_DATA_VERSION, gameId, prose };
+
+  const out = path.join(SERVER, "dist", "browser-data", gameId);
+  fs.mkdirSync(out, { recursive: true });
+  const write = (name: string, value: unknown): number => {
+    const json = JSON.stringify(value);
+    fs.writeFileSync(path.join(out, name), json, "utf8");
+    return Buffer.byteLength(json);
+  };
+
+  const tokensSize = write("tokens.json", bakedTokens);
+  const docsSize = write("docs.json", bakedDocs);
+
+  // freqs.json is copied rather than transformed: coerceFreqs validates it on
+  // the way in, so the browser sees the same shape node does.
+  let freqsSize = 0;
+  const freqsSrc = path.join(data, "freqs.json");
+  if (fs.existsSync(freqsSrc)) {
+    const raw = fs.readFileSync(freqsSrc, "utf8");
+    fs.writeFileSync(path.join(out, "freqs.json"), raw, "utf8");
+    freqsSize = Buffer.byteLength(raw);
+  } else {
+    console.warn(`  ${gameId}: no freqs.json, completion ranking falls back to empty tables`);
+  }
+
+  console.log(`${gameId}: ${tokens.length} tokens, ${loaded.templates.length} templates`);
+  console.log(`  tokens.json ${kb(tokensSize)}   (name/kind/scopes/traits)`);
+  console.log(`  docs.json   ${kb(docsSize)}   (doc + usage prose, fetch on first hover)`);
+  console.log(`  freqs.json  ${kb(freqsSize)}   (completion ranking)`);
+  return true;
+}
+
+const argv = process.argv.slice(2);
+const explicit = argv.some((a) => a === "--game" || a.startsWith("--game="));
+const games = explicit ? [parseGameArg(argv).gameId] : allProfiles().map((p) => p.id);
+
+let baked = 0;
+for (const gameId of games) {
+  if (bake(gameId)) baked += 1;
+  else if (explicit) {
+    console.error(`no script_docs bundled for game "${gameId}"`);
+    process.exit(1);
+  }
+}
+
+if (baked === 0) {
+  console.error("no game bundles script_docs; nothing to bake");
   process.exit(1);
 }
-
-const scriptDocs = path.join(DATA, "script_docs");
-const loaded = loadTokenDataFromLogs(scriptDocs);
-if (loaded.missing.length > 0) {
-  console.warn(`missing logs (baked without them): ${loaded.missing.join(", ")}`);
-}
-
-// Same merge order as server.ts: script_docs first, the wiki mirror filling the
-// gaps. Baking the merged result means the browser never has to do either.
-const wiki = loadWikiTokens(path.join(DATA, "wikidocs"));
-const tokens: TokenData[] = mergeWikiTokens(loaded.tokens, wiki);
-
-const hot: BakedToken[] = [];
-const prose: Array<[string, string]> = [];
-for (const t of tokens) {
-  const entry: BakedToken = { name: t.name, kind: t.kind, scopes: t.scopes };
-  if (t.traits) entry.traits = t.traits;
-  hot.push(entry);
-  prose.push([t.doc ?? "", t.usage ?? ""]);
-}
-
-const onActionScopes: Record<string, string> = {};
-for (const [name, scope] of parseOnActionsLog(scriptDocs)) onActionScopes[name] = scope;
-
-const bakedTokens: BakedTokens = {
-  version: BROWSER_DATA_VERSION,
-  gameId,
-  source: `bundled script_docs + wikidocs (${new Date().toISOString().slice(0, 10)})`,
-  tokens: hot,
-  templates: loaded.templates,
-  onActionScopes,
-};
-
-const bakedDocs: BakedDocs = { version: BROWSER_DATA_VERSION, gameId, prose };
-
-fs.mkdirSync(OUT, { recursive: true });
-const write = (name: string, value: unknown): number => {
-  const json = JSON.stringify(value);
-  fs.writeFileSync(path.join(OUT, name), json, "utf8");
-  return Buffer.byteLength(json);
-};
-
-const sizes = {
-  tokens: write("tokens.json", bakedTokens),
-  docs: write("docs.json", bakedDocs),
-  freqs: 0,
-};
-
-// freqs.json is copied rather than transformed: coerceFreqs validates it on the
-// way in, and the browser has no reason to see a different shape than node does.
-const freqsSrc = path.join(DATA, "freqs.json");
-if (fs.existsSync(freqsSrc)) {
-  const raw = fs.readFileSync(freqsSrc, "utf8");
-  fs.writeFileSync(path.join(OUT, "freqs.json"), raw, "utf8");
-  sizes.freqs = Buffer.byteLength(raw);
-} else {
-  console.warn(`no freqs.json for ${gameId}; completion ranking falls back to empty tables`);
-}
-
-const kb = (n: number): string => (n / 1024).toFixed(0).padStart(5) + " KB";
-console.log(`baked ${gameId}: ${tokens.length} tokens, ${loaded.templates.length} templates`);
-console.log(`  tokens.json ${kb(sizes.tokens)}   (name/kind/scopes/traits)`);
-console.log(`  docs.json   ${kb(sizes.docs)}   (doc + usage prose, fetch on first hover)`);
-console.log(`  freqs.json  ${kb(sizes.freqs)}   (completion ranking)`);
-console.log(`  -> ${OUT}`);
+console.log(`-> ${path.join(SERVER, "dist", "browser-data")}`);


### PR DESCRIPTION
The language server needs a process. A web page cannot spawn one. This adds a
second entry point, `@px-lsp/server/browser`, that runs the language knowledge
as a plain library: completion, hover, diagnostics and scope inference against
one in-memory document, with no child process, no JSON-RPC, no workspace scan
and no filesystem.

## Why it was small

The features were already plain functions over `(ServerData, TextDocument,
position)`, and `ServerData` is a container rather than a loader. Nothing in
`features/` moved. What was missing was the assembly and the data.

The `fs` use splits cleanly in two. Bundled data (`data/*.ts`, `schema/`) is
read-only and known at build time. Workspace data (`index/`, `overview/`,
`gui/`, asset paths) is the user's mod on disk, which a browser does not have
and does not need for one document. Only the first had to be solved.

## The three pieces

**Baked data.** `scripts/bake-browser-data.ts` runs the existing script_docs
and wikidocs parsers at build time. The prose is split from the token tables,
because completion and diagnostics need name/kind/scopes and hover needs the
rest:

| Artifact | Raw | Brotli |
|---|---|---|
| `dist/browser.js` | 838 KB | 163 KB |
| `tokens.json` | 527 KB | 36 KB |
| `freqs.json` | 104 KB | 26 KB |
| `docs.json` (hover prose) | 608 KB | 72 KB |

225 KB brotli to answer completions and diagnostics; `docs.json` can be fetched
on the first hover, or never. For comparison, the node path parses 1.1 MB of
`.log` at startup.

**Shims.** `src/browser/shims/` replaces `fs`, `path` and `os` at bundle time.
The reachable code never calls them (`loadSchema(null)` takes no filesystem
path, the tokens arrive as JSON); they exist so the ~26 `import * as fs`
modules link. `vscode-languageserver/node` is aliased to
`vscode-languageserver-types`, dropping a JSON-RPC transport the library form
has no use for: 27 KB brotli.

**The service.** A document handle that holds its parse across edits, so
`update()` does not throw away the cache.

## Honest about the subset

`capabilities` reports `workspaceIndex`, `referenceDiagnostics` and
`guiAndAssets` as `false` rather than returning empty results that read as
"nothing wrong". Definitions in the open document DO resolve, so hover on a
`scripted_effect` written above still works. Diagnostics are the structural and
folder-trap class only, including the `common/on_actions/` plural trap.

## Two bugs the tests caught

- `extname("..")` and `dirname("/a/b//c/d")` disagreed with node. `dirname` in
  particular must not normalize. The path shim is now pinned against
  `path.posix` over a cross-product of inputs, because `classifyFile` picks a
  schema entry with `path.relative` and a one-segment disagreement produces a
  wrong diagnostic rather than a visible failure.
- Two documents opened on the same path shared a parse-cache key, so the second
  read the first one's parse. This is the uri+version trap AGENTS.md records
  biting twice; the uri now carries a serial.

## Checks

`typecheck`, `lint`, `check-game-boundary`, full `vitest` (1580 passed, 44
corpus-gated skips, 0 failed). 21 new tests across `browserPath.test.ts` and
`browserService.test.ts`, the latter running against the real bundled CK3 data.

CI now builds the browser bundle: esbuild fails outright on an unaliased node
builtin, so a new `fs` import on a reachable path breaks there rather than in a
consumer's bundler.

## Notes

- Changelog bullet is in `packages/server/CHANGELOG.md` under Unreleased. No
  `packages/vscode/CHANGELOG.md` entry: this ships nothing to the extension.
- No test vsix: there is nothing to try in the editor.
- `docs/EMBEDDING.md` gained an "In a browser, with no process at all" section;
  the wiki mirror still needs pushing.
- Not included, deliberately: an LSP server in a Web Worker. That would wrap
  this module with `BrowserMessageReader`/`Writer` and change the transport
  alias back; nothing in the service would move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Provide a browser-ready language service library backed by prebaked game data and an explicit single-document capability subset.

New Features:
- Add a browser entry point that exposes completion, hover, diagnostics, and scope inference for a single in-memory document without Node, filesystem access, workspace scanning, or JSON-RPC.
- Bake game language data into browser-consumable token, documentation, and frequency payloads with optional deferred hover prose.
- Expose browser service capabilities that clearly identify unsupported workspace, reference-diagnostic, and GUI/asset features.

Bug Fixes:
- Correct browser path behavior to match POSIX Node semantics and prevent stale parse results when multiple documents share a path.
- Harden frequency-data validation against malformed and null tables.

Enhancements:
- Add a document-oriented browser service API with persistent parse state across edits and same-document definition resolution.
- Add payload version and game-consistency validation for browser data and documentation.
- Provide browser filesystem, operating-system, and path compatibility shims for bundling.

Build:
- Add scripts to bake browser data and compile the browser library as an ESM browser bundle.
- Publish the @px-lsp/server/browser entry point and browser-data package exports.

CI:
- Build the browser language service during CI to catch reachable Node builtin dependencies.

Documentation:
- Document browser embedding, data payloads, capability limitations, and deferred hover documentation.

Tests:
- Add browser service integration tests covering classification, diagnostics, completion, hover, scope inference, edits, payload validation, and multi-game isolation.
- Add cross-product tests that pin the browser path shim against Node's POSIX path behavior.

Chores:
- Record the browser entry point and data-baking workflow in the server changelog.
- Share frequency-data coercion between Node and browser loading paths.