### PR TITLE
Remove "Link existing item" from the Workshop panel (0.3.6)

### DIFF
--- a/docs/release/0.3.6.md
+++ b/docs/release/0.3.6.md
@@ -1,0 +1,37 @@
+# Paradox Modding Toolkit 0.3.6 (beta, pre-release)
+
+A safety fix for the Steam Workshop panel, shipped on its own because it
+removes a way to lose a published mod.
+
+### "Link existing item" is gone
+
+The Workshop panel showed a **Link existing item...** button for any mod that
+was not on the Workshop yet. It listed your published Workshop items and
+wrote the picked item's id into the mod, so the next upload updated that item
+instead of creating a new one.
+
+That is one careless click away from overwriting the wrong mod. The list is
+just your item titles, the button sits on whichever mod the panel happens to
+have focused, and an upload afterwards replaces that item's files, title,
+description and tags with the linked mod's. A Workshop update reaches
+subscribers within minutes and has no rollback, so the mistake is not one you
+undo.
+
+The button and the Steam call behind it (the "list my published items"
+query) are both removed. An upload from the panel now only ever:
+
+- creates a new item, private, for a mod that carries no Workshop id, or
+- updates the item whose id the mod already carries.
+
+Nothing else about publishing changed.
+
+### Adopting a launcher-published mod
+
+That is still possible, it just is not a button any more. Write the item id
+where the game's own tooling keeps it and the panel picks it up on reload:
+
+- **CK3**: `remote_file_id = "1234567890"` in `descriptor.mod`.
+- **Victoria 3, EU5**: `"publishedFileId": "1234567890"` in the mod's
+  `workshop.json`.
+
+The id is the `?id=` number in the item's Workshop URL.

--- a/docs/release/0.4.0.md
+++ b/docs/release/0.4.0.md
@@ -15,9 +15,11 @@ session authorizes the upload, and a progress bar shows what Steam is doing.
 New items are created **private**, and the Workshop id is written back where
 the game's tooling expects it (`remote_file_id` in `descriptor.mod` for CK3,
 `workshop.json` for the newer games), so the launcher and any build scripts
-agree with the toolkit about which item is yours. Mods first published
-through the launcher can be linked instead: pick the item from your published
-list and the next upload updates it.
+agree with the toolkit about which item is yours. An upload only ever creates
+a new item or updates the item the mod already carries an id for: the panel
+never points a mod at some other published item of yours, so it cannot
+overwrite the wrong mod. For a mod first published through the launcher,
+write that id into the descriptor by hand and the panel picks it up.
 
 Every upload passes one confirmation dialog first. It re-offers the three
 parts (mod files, details, translations), shows the changenote and visibility

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "px-lsp",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "private": true,
   "license": "GPL-3.0-or-later",
   "engines": {

--- a/packages/vscode/CHANGELOG.md
+++ b/packages/vscode/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.3.6 (beta, pre-release) - Workshop safety fix
+
+- **"Link existing item" is gone from the Workshop panel.** The button let a
+  mod that was not on the Workshop yet be pointed at any of your published
+  items, and the next upload then overwrote that item's files and details.
+  One wrong pick in the list, or a pick made on the wrong mod, replaced a
+  published mod with content that was never meant for it, and a Workshop
+  update reaches subscribers in minutes with no rollback. An upload from the
+  panel now only ever creates a new item or updates the item the mod is
+  already tied to. Mods first published through the launcher are still
+  adoptable by hand, by writing the item id where the game's own tooling
+  keeps it: `remote_file_id` in `descriptor.mod` for CK3, `publishedFileId`
+  in `workshop.json` for the newer games.
+
 ## 0.4.0 (beta) - the Steam Workshop release
 
 Everything below ships early in the 0.3.5 pre-release; 0.4.0 is the

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "px-toolkit",
   "displayName": "Paradox Modding Toolkit",
   "description": "Modding toolkit for Paradox games (Crusader Kings III, Victoria 3, Europa Universalis V): completion, go-to-definition, hover docs, tiger diagnostics, inline localization, event graph and a visual GUI editor.",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "publisher": "JDeffner",
   "author": {
     "name": "Joël Deffner"

--- a/packages/vscode/src/steam/bridge.ts
+++ b/packages/vscode/src/steam/bridge.ts
@@ -204,23 +204,6 @@ async function main(): Promise<void> {
       }
       break;
     }
-    case "list": {
-      try {
-        const page = await steam.workshop.getUserItems(1, steam.accountId(), { appId: job.appId });
-        done({
-          action: "list",
-          items: page.items.map((it) => ({
-            itemId: it.fileId.toString(),
-            title: it.title,
-            timeUpdated: it.timeUpdated,
-          })),
-          total: page.totalResults,
-        });
-      } catch (e) {
-        fail(`listing your Workshop items failed: ${errText(e)}`);
-      }
-      break;
-    }
     default:
       fail(`unknown action: ${(job as { action?: string }).action ?? "?"}`);
   }

--- a/packages/vscode/src/steam/jobs.ts
+++ b/packages/vscode/src/steam/jobs.ts
@@ -35,9 +35,7 @@ export type BridgeJob =
   /** Sequential SubmitItemUpdate calls in one Steam session (details, then translations). */
   | { action: "publish"; appId: number; itemId: string; submits: SubmitSpec[] }
   /** The item's live details, plus its title/description per requested language. */
-  | { action: "query"; appId: number; itemId: string; languages?: string[] }
-  /** The user's own published items of this app (to link an existing item). */
-  | { action: "list"; appId: number };
+  | { action: "query"; appId: number; itemId: string; languages?: string[] };
 
 /** The live item details the toolkit shows (bigints already stringified). */
 export interface ItemDetails {
@@ -79,8 +77,7 @@ export type BridgeDone =
       item: ItemDetails | null;
       /** Title/description as Steam serves each requested language (its default-language fallback included). */
       translations: Record<string, { title: string; description: string }>;
-    }
-  | { action: "list"; items: { itemId: string; title: string; timeUpdated: number }[]; total: number };
+    };
 
 /** Dotted-number version compare: `a` >= `b`. Non-numeric parts compare as 0. */
 export function versionAtLeast(a: string, b: string): boolean {

--- a/packages/vscode/src/webviews/workshop/app/main.ts
+++ b/packages/vscode/src/webviews/workshop/app/main.ts
@@ -176,14 +176,7 @@ function renderItem(): void {
     const s = document.createElement("span");
     s.className = "px-muted px-xs";
     s.textContent = "not on the Workshop yet";
-    const link = document.createElement("button");
-    link.className = "px-btn";
-    link.dataset.variant = "outline";
-    link.dataset.size = "sm";
-    link.append(iconEl("link"), document.createTextNode(" Link existing item…"));
-    link.setAttribute("data-tip", "Connect this mod to one of your published Workshop items.");
-    link.addEventListener("click", () => send({ type: "linkExisting" }));
-    idBox.append(s, link);
+    idBox.append(s);
   }
 
   const meta = $("itemMeta");
@@ -1011,10 +1004,6 @@ $("helpBtn").addEventListener("click", () =>
           {
             lead: "Visibility",
             text: "is sent with the details on the next upload. A brand new item is always created private.",
-          },
-          {
-            lead: "Not published yet?",
-            text: "Link existing item connects this mod to one of your own Workshop items instead of creating a second one.",
           },
           {
             lead: "Statistics",

--- a/packages/vscode/src/webviews/workshop/messages.ts
+++ b/packages/vscode/src/webviews/workshop/messages.ts
@@ -104,7 +104,6 @@ export type AppToHost =
       visibility: WorkshopVisibility | null;
     }
   | { type: "openPage" }
-  | { type: "linkExisting" }
   | { type: "createDescriptor" }
   /** Write a descriptor/metadata scalar (title = name, versions). */
   | { type: "setField"; field: "title" | "version" | "supportedVersion"; value: string }

--- a/packages/vscode/src/webviews/workshop/panel.ts
+++ b/packages/vscode/src/webviews/workshop/panel.ts
@@ -274,9 +274,6 @@ export class WorkshopPanel {
         if (id) void vscode.env.openExternal(vscode.Uri.parse(workshopUrl(id)));
         return;
       }
-      case "linkExisting":
-        await this.linkExisting();
-        return;
       case "createDescriptor":
         await vscode.commands.executeCommand("px.createDescriptor");
         await this.postInfo();
@@ -521,38 +518,6 @@ export class WorkshopPanel {
     } catch (e) {
       log(`workshop: live query failed: ${e instanceof Error ? e.message : String(e)}`);
       this.post({ type: "live", item: null, translations: {}, error: friendlyError(e, meta) });
-    }
-  }
-
-  private async linkExisting(): Promise<void> {
-    const { meta, log } = this.options;
-    const root = this.active;
-    if (!root) return;
-    try {
-      const done = await runBridge(this.context, { action: "list", appId: meta.steamAppId }, log);
-      if (done.action !== "list") throw new Error("unexpected bridge reply");
-      if (!done.items.length) {
-        this.notify(`You have no published ${meta.name} Workshop items to link.`);
-        return;
-      }
-      const picked = await vscode.window.showQuickPick(
-        done.items.map((it) => ({
-          label: it.title || `(untitled item)`,
-          description: `#${it.itemId}`,
-          detail: `last update ${new Date(it.timeUpdated * 1000).toLocaleDateString()}`,
-          itemId: it.itemId,
-        })),
-        {
-          title: `Link "${path.basename(root)}" to one of your Workshop items`,
-          placeHolder: "The next upload updates the linked item instead of creating a new one",
-        }
-      );
-      if (!picked) return;
-      persistPublishedId(root, meta, picked.itemId);
-      this.options.log(`workshop: linked ${root} to existing item ${picked.itemId}`);
-      await this.postInfo();
-    } catch (e) {
-      this.notifyError(`Listing your Workshop items failed - ${friendlyError(e, meta)}`, e);
     }
   }
 


### PR DESCRIPTION
## Why

The Workshop panel showed a **Link existing item...** button on the Item row of every mod that was not on the Workshop yet. It ran a Steam `getUserItems` query, put all of your published items in a quick pick, and wrote the picked id into the mod (`remote_file_id` / `workshop.json`). The next upload then updated that item instead of creating a new one.

That is one careless pick away from destroying a published mod. The quick pick is just a list of your own item titles, the button acts on whichever mod the panel currently has focused, and the upload afterwards replaces that item's files, title, description, tags and visibility with the linked mod's content. A Workshop update reaches subscribers within minutes and has no rollback, so the mistake is not recoverable.

Publishing keeps only the two paths that cannot target the wrong item:

- a mod with no Workshop id gets a **new, private** item created for it;
- a mod that already carries an id updates that item.

## What changed

- `webviews/workshop/app/main.ts`: the button is gone from the Item row (the row now just reads "not on the Workshop yet"), and so is the "Not published yet?" entry in the panel's help dialog.
- `webviews/workshop/messages.ts`: `linkExisting` removed from the app to host message union.
- `webviews/workshop/panel.ts`: the `linkExisting` case and its handler removed.
- `steam/jobs.ts` + `steam/bridge.ts`: the bridge's `list` job removed with them, the only caller. That drops the `getUserItems` / `accountId` Steam calls from the bridge entirely, so the capability is not just hidden behind a missing button.

Adopting a mod first published through the launcher is still possible, by hand: `remote_file_id = "..."` in `descriptor.mod` (CK3) or `"publishedFileId": "..."` in `workshop.json` (Victoria 3, EU5). `docs/release/0.3.6.md` spells that out.

## Version

Bumped `packages/vscode/package.json` and the root manifest 0.3.5 -> 0.3.6, with a changelog section and `docs/release/0.3.6.md` for the release body, since this is meant to ship on its own rather than wait for 0.4.0.

Two notes on the change notes, both worth a look before merging:

- `docs/release/0.4.0.md` is unreleased and promised the linking flow ("pick the item from your published list"), so that paragraph is rewritten. The 0.4.0 **changelog** section is left untouched, because it is the record of what 0.3.5 actually shipped.
- The changelog now has 0.3.6 above the 0.4.0 heading, which is the existing quirk of 0.3.5 shipping under 0.4.0 notes. Newest is still on top; say the word if you want it arranged differently.

## Verification

`npx tsc --noEmit`, `pnpm run lint`, `pnpm run compile` and `npx vitest run packages/vscode/test` (43 files, 509 passed) all clean. No test covered the removed path. Not installed via `package:test` here, since this session has no VS Code to reload; the panel change is a removed button plus a removed help row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LEyqNbJuACW4taZLSkAMzX

---
_Generated by [Claude Code](https://claude.ai/code/session_01LEyqNbJuACW4taZLSkAMzX)_

## Summary by Sourcery

Remove arbitrary Workshop item linking to ensure uploads can only create a new item or update the item already associated with a mod.

Bug Fixes:
- Prevent accidental overwriting of published Steam Workshop mods by removing the ability to link an unpublished mod to an arbitrary existing item.

Enhancements:
- Remove the Workshop panel's linking UI, message handling, and Steam published-item listing capability while preserving creation of new private items and updates to already-associated items.
- Document manual adoption of launcher-published Workshop items and revise the upcoming release notes to reflect the safer publishing workflow.

Build:
- Bump the project and VS Code extension versions from 0.3.5 to 0.3.6.

Documentation:
- Add 0.3.6 release documentation and changelog entries describing the Workshop safety change and manual item adoption.