### PR TITLE
fix(steam): key Workshop error advice on Valve's per-call EResult meanings

### DIFF
--- a/packages/vscode/CHANGELOG.md
+++ b/packages/vscode/CHANGELOG.md
@@ -214,11 +214,15 @@ release these notes belong to.
   VS Code notification and a line in the output channel, so it reaches you
   even after you switch away from the Workshop tab, and errors stay
   readable instead of fading like the old in-panel toasts (which are gone).
-  Steam's bare error phrases carry advice now: "limit exceeded" says the
-  description is over Steam's 8000-character cap, "access denied" points at
-  the logged-in account not owning the item, and so on. An oversized
-  preview image is announced when the upload keeps the current one, instead
-  of being dropped in silence.
+  Steam's raw codes are rewritten as advice: `k_EResultLimitExceeded` says a
+  field is over Steam's limit (8000 characters for the description, 128 for
+  the title), `k_EResultAccessDenied` points at the logged-in account not
+  owning the item, and about thirty codes in all say what to do next. The
+  Steamworks operation and code stay in parentheses, so a support thread
+  still has the exact failure. A value Steam refuses outright is named
+  ("Steam rejected the preview image") instead of surfacing as a bare
+  "returned false". An oversized preview image is announced when the upload
+  keeps the current one, instead of being dropped in silence.
 
 - **The changenote box explains itself.** A source dropdown under it shows
   where the text came from - "From changelog: 1.2.md", "From last git

--- a/packages/vscode/CHANGELOG.md
+++ b/packages/vscode/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## Unreleased
+
+- **The Steam Workshop error advice now matches what Valve documents per
+  call.** The table was written from the generic one-line `EResult`
+  descriptions, which disagree with the per-call result lists on ISteamUGC
+  in the cases that matter. `k_EResultLimitExceeded` is the 1 MB preview-image
+  cap or a full Steam Cloud, not an over-long description;
+  `k_EResultServiceReadOnly` is the upload hold after a password or email
+  change, not a Steam outage; `k_EResultLockingFailed` is another update
+  still running on the same item; `k_EResultBanned` is a VAC or game ban on
+  the account. `k_EResultDuplicateName` was added, and the two codes Valve
+  documents nowhere for uploads (`k_EResultRevoked`, `k_EResultBlocked`) now
+  say so instead of guessing.
+
 ## 0.4.0 (beta) - the Steam Workshop release
 
 Everything below ships early in the 0.3.5 pre-release; 0.4.0 is the
@@ -214,10 +228,10 @@ release these notes belong to.
   VS Code notification and a line in the output channel, so it reaches you
   even after you switch away from the Workshop tab, and errors stay
   readable instead of fading like the old in-panel toasts (which are gone).
-  Steam's raw codes are rewritten as advice: `k_EResultLimitExceeded` says a
-  field is over Steam's limit (8000 characters for the description, 128 for
-  the title), `k_EResultAccessDenied` points at the logged-in account not
-  owning the item, and about thirty codes in all say what to do next. The
+  Steam's raw codes are rewritten as advice: `k_EResultLimitExceeded` points
+  at the preview image or the Steam Cloud quota,
+  `k_EResultAccessDenied` at the logged-in account not owning the game or
+  the item, and about thirty codes in all say what to do next. The
   Steamworks operation and code stay in parentheses, so a support thread
   still has the exact failure. A value Steam refuses outright is named
   ("Steam rejected the preview image") instead of surfacing as a bare

--- a/packages/vscode/src/steam/bridge.ts
+++ b/packages/vscode/src/steam/bridge.ts
@@ -181,7 +181,9 @@ async function main(): Promise<void> {
           needsAgreement = needsAgreement || r.needsToAcceptAgreement;
         } catch (e) {
           const lang = job.submits[i].language;
-          fail(`${lang ? `uploading the ${lang} translation` : "upload"} failed: ${errText(e)}`);
+          // No prefix for the main submit: every caller already says an
+          // upload failed, and "upload failed - upload failed:" reads badly.
+          fail(lang ? `uploading the ${lang} translation failed: ${errText(e)}` : errText(e));
         }
       }
       done({ action: "publish", itemId: job.itemId, needsToAcceptAgreement: needsAgreement });

--- a/packages/vscode/src/steam/steamErrors.ts
+++ b/packages/vscode/src/steam/steamErrors.ts
@@ -1,71 +1,105 @@
 /**
- * One-line advice for the Steam error phrases the native layer produces
- * (steamworks-rs maps EResult codes to short strings like "limit exceeded" -
- * accurate, but bare). The hint says what the phrase usually means for a
- * Workshop upload, so a failure is actionable without a Steamworks manual.
+ * Turns the Steam bridge's raw failures into a sentence a modder can act on.
+ *
+ * steamwand throws two message shapes. Both are exact, and both are
+ * Steamworks jargon:
+ *   "SubmitItemUpdate failed: k_EResultAccessDenied"   (a non-OK EResult)
+ *   "steamwand: SetItemTags returned false (invalid handle or argument?)"
+ * We put the plain-language cause in front and keep the operation and the
+ * code in parentheses, because a support thread needs the exact code.
+ *
+ * The table is keyed on the EResult NAME on purpose. It used to be keyed on
+ * prose ("access denied", "limit exceeded"), which is what steamworks-rs
+ * emitted; moving the bridge to steamwand changed every message to an enum
+ * name, no key matched any more, and all advice went silently missing.
  *
  * No vscode imports: unit-tested in plain Node.
  */
 
-const HINTS: { match: RegExp; hint: string }[] = [
-  {
-    match: /limit exceeded/i,
-    hint: "usually the description: Steam caps it at 8000 characters (and titles at 128)",
-  },
-  {
-    match: /file was not found/i,
-    hint: "a path Steam was given does not exist - re-check the preview image and the mod's content",
-  },
-  {
-    match: /access denied|insufficient privilege/i,
-    hint:
-      "the logged-in Steam account cannot edit this item - a linked remote_file_id must belong " +
-      "to the account Steam is logged in as",
-  },
-  {
-    match: /user not logged on/i,
-    hint: "log into Steam first",
-  },
-  {
-    match: /isn't a network connection|connect failed|no connection/i,
-    hint: "Steam appears to be offline - check the client's connection and retry",
-  },
-  {
-    match: /operation timed out/i,
-    hint: "Steam did not answer in time - usually transient, retry the upload",
-  },
-  {
-    match: /parameter is invalid/i,
-    hint: "often a malformed tag or visibility value - check the descriptor's tags block",
-  },
-  {
-    match: /request is a duplicate/i,
-    hint: "Steam already processed an identical update - refresh the panel before retrying",
-  },
-  {
-    match: /banned|account disabled|access revoked/i,
-    hint: "Steam has restricted the item or the account - check the item's Workshop page",
-  },
-  {
-    match: /service is read only|requested service is unavailable/i,
-    hint: "a Steam-side outage - wait and retry",
-  },
-  {
-    match: /disk being full/i,
-    hint: "Steam ran out of disk space while preparing the upload",
-  },
-  {
-    match: /generic failure/i,
-    hint:
-      "Steam's catch-all - often transient, sometimes a tag or image it refuses. Retry once, " +
-      "then check the item on its Workshop page",
-  },
-];
+/**
+ * EResult name without its `k_EResult` prefix -> what the code means for a
+ * Workshop upload. Only the codes an upload can realistically hit; the full
+ * enum is 131 entries, and listing one we have nothing to say about is worse
+ * than the fallback sentence.
+ *
+ * Exported so the test can check every key against the enum steamwand ships:
+ * a typo here fires no hint and nothing else would notice.
+ */
+export const RESULT_HINTS: Record<string, string> = {
+  Fail: "Steam's catch-all failure, often transient. Retry once, then check the item on its Workshop page",
+  NoConnection: "Steam has no connection. Check the Steam client and retry",
+  ConnectFailed: "Steam could not reach its servers. Check the Steam client and retry",
+  RemoteDisconnect: "Steam dropped the connection during the call. Retry the upload",
+  IOFailure: "Steam could not read or write the files for this upload. Retry, and check the disk",
+  Busy: "Steam is busy with another task. Wait a moment and retry",
+  Timeout: "Steam did not answer in time. This is usually transient, so retry the upload",
+  InvalidParam:
+    "Steam rejected one of the values. Check the tags, the visibility and the title in the descriptor",
+  FileNotFound: "a path Steam was given does not exist. Check the preview image and the mod's content folder",
+  AccessDenied:
+    "the Steam account you are logged in as may not edit this item. The Workshop ID in the " +
+    "descriptor must belong to that account",
+  InsufficientPrivilege:
+    "the Steam account may not publish right now. A community ban or another restriction on the " +
+    "account blocks Workshop uploads",
+  NotLoggedOn: "Steam is not logged in. Log in and retry",
+  LimitExceeded:
+    "a field is over Steam's limit. The description caps at 8000 characters and the title at 128",
+  RateLimitExceeded: "too many Workshop updates in a short time. Wait a few minutes and retry",
+  DuplicateRequest: "Steam already has an identical update in flight. Refresh the panel before retrying",
+  Banned: "Steam has banned this item or this account. Check the item's Workshop page",
+  Revoked: "Steam has withdrawn access to this item. Check the item's Workshop page",
+  Blocked: "Steam blocked the request for this account. Check the account's status on Steam",
+  AccountDisabled: "the Steam account is disabled, so it cannot publish",
+  Suspended: "the Steam account is suspended, so it cannot publish",
+  ServiceUnavailable: "Steam's Workshop service is down. Wait and retry",
+  ServiceReadOnly: "Steam is in read-only mode, so it accepts no updates right now. Wait and retry",
+  DiskFull: "the disk ran out of space while Steam prepared the upload",
+  ItemDeleted: "this Workshop item no longer exists. It was deleted on Steam, so link or create another item",
+  InvalidItemType: "Steam refuses this item type here. Check the item was created for this game",
+  MustAgreeToSSA: "the account has not accepted the Steam Subscriber Agreement. Accept it on Steam and retry",
+  Cancelled: "the upload was cancelled",
+  NotModified: "nothing in this update differs from what Steam already has",
+  LockingFailed: "Steam could not save the change on its side. Retry the upload",
+  PersistFailed: "Steam could not save the change on its side. Retry the upload",
+  ValueOutOfRange: "one value is outside the range Steam accepts. Check the visibility and the tags",
+};
 
-/** Advice for a Steam error message, or null when no phrase is recognized. */
+/** Flat setter -> the value Steam refused, for the "returned false" shape. */
+const REJECTED_VALUE: Record<string, string> = {
+  StartItemUpdate: "the item handle",
+  SetItemTitle: "the title",
+  SetItemDescription: "the description",
+  SetItemTags: "the tags",
+  SetItemVisibility: "the visibility",
+  SetItemContent: "the content folder",
+  SetItemPreview: "the preview image",
+  SetItemUpdateLanguage: "the language code",
+};
+
+/** `<Op> failed: k_EResultAccessDenied`, or the `EResult(<n>)` fallback name. */
+const RESULT_FAILURE = /(\w+) failed: (k_EResult(\w+)|EResult\(\d+\))/i;
+/** `steamwand: <Op> returned false (invalid handle or argument?)`. */
+const SETTER_FAILURE = /steamwand: (\w+) returned false(?: \([^)]*\))?/i;
+
+/**
+ * The message with its Steam failure rewritten in plain language, or null
+ * when it carries no Steam failure (a bridge or staging error passes through
+ * unchanged). Surrounding text is kept, so the step that failed still reads
+ * first.
+ */
 export function explainSteamError(message: string): string | null {
-  for (const { match, hint } of HINTS) {
-    if (match.test(message)) return hint;
+  const result = RESULT_FAILURE.exec(message);
+  if (result) {
+    const [segment, operation, code, name] = result;
+    const hint = (name && RESULT_HINTS[name]) || "Steam refused the request";
+    return message.replace(segment, () => `${hint} (${operation}: ${code})`);
+  }
+  const setter = SETTER_FAILURE.exec(message);
+  if (setter) {
+    const [segment, operation] = setter;
+    const value = REJECTED_VALUE[operation] ?? "one of the values it was given";
+    return message.replace(segment, () => `Steam rejected ${value} (${operation})`);
   }
   return null;
 }

--- a/packages/vscode/src/steam/steamErrors.ts
+++ b/packages/vscode/src/steam/steamErrors.ts
@@ -24,6 +24,13 @@
  *
  * Exported so the test can check every key against the enum steamwand ships:
  * a typo here fires no hint and nothing else would notice.
+ *
+ * Meanings come from the per-call result lists Valve documents on ISteamUGC
+ * (CreateItem, SubmitItemUpdate), not from the generic one-line enum text.
+ * The two disagree often, and the per-call one is what a Workshop upload
+ * gets: LimitExceeded is the preview image or the Cloud quota, not a text
+ * field; ServiceReadOnly is the account's post-password-change hold, not a
+ * Steam outage. Codes Valve documents nowhere for uploads say so.
  */
 export const RESULT_HINTS: Record<string, string> = {
   Fail: "Steam's catch-all failure, often transient. Retry once, then check the item on its Workshop page",
@@ -34,33 +41,44 @@ export const RESULT_HINTS: Record<string, string> = {
   Busy: "Steam is busy with another task. Wait a moment and retry",
   Timeout: "Steam did not answer in time. This is usually transient, so retry the upload",
   InvalidParam:
-    "Steam rejected one of the values. Check the tags, the visibility and the title in the descriptor",
-  FileNotFound: "a path Steam was given does not exist. Check the preview image and the mod's content folder",
+    "Steam rejected the item ID or one of the fields. The Workshop ID in the descriptor must " +
+    "belong to this game",
+  FileNotFound:
+    "Steam could not read the preview image, or the item's Workshop entry is gone. Check the " +
+    "preview image path, then the item's Workshop page",
   AccessDenied:
-    "the Steam account you are logged in as may not edit this item. The Workshop ID in the " +
-    "descriptor must belong to that account",
+    "the Steam account you are logged in as does not own the game, or does not own this item. " +
+    "Log in as the account that created the Workshop item",
   InsufficientPrivilege:
-    "the Steam account may not publish right now. A community ban or another restriction on the " +
-    "account blocks Workshop uploads",
+    "the Steam account is banned from this game's community, so it cannot publish. Check the " +
+    "account's status on the game's Steam hub",
   NotLoggedOn: "Steam is not logged in. Log in and retry",
   LimitExceeded:
-    "a field is over Steam's limit. The description caps at 8000 characters and the title at 128",
+    "the preview image is over 1 MB, or this account's Steam Cloud is full. Use a smaller preview " +
+    "image, then free up Steam Cloud space",
   RateLimitExceeded: "too many Workshop updates in a short time. Wait a few minutes and retry",
-  DuplicateRequest: "Steam already has an identical update in flight. Refresh the panel before retrying",
-  Banned: "Steam has banned this item or this account. Check the item's Workshop page",
-  Revoked: "Steam has withdrawn access to this item. Check the item's Workshop page",
-  Blocked: "Steam blocked the request for this account. Check the account's status on Steam",
+  DuplicateRequest: "Steam already has this upload. Refresh the panel before uploading again",
+  DuplicateName: "this account already has a Workshop item with that name. Rename the mod and retry",
+  Banned:
+    "the Steam account has a VAC or game ban, so it cannot upload for this game. Check the " +
+    "account's bans on its Steam profile",
+  Revoked:
+    "Steam gives no Workshop detail for this code. Check the account still owns the game, then " +
+    "check the item's Workshop page",
+  Blocked: "Steam gives no Workshop detail for this code. Retry, then check the account's status on Steam",
   AccountDisabled: "the Steam account is disabled, so it cannot publish",
   Suspended: "the Steam account is suspended, so it cannot publish",
-  ServiceUnavailable: "Steam's Workshop service is down. Wait and retry",
-  ServiceReadOnly: "Steam is in read-only mode, so it accepts no updates right now. Wait and retry",
+  ServiceUnavailable: "Steam's Workshop servers are having trouble. Wait a few minutes and retry",
+  ServiceReadOnly:
+    "a recent password or email change blocks new uploads from this account. The block usually " +
+    "clears after 5 days, and can last 30",
   DiskFull: "the disk ran out of space while Steam prepared the upload",
   ItemDeleted: "this Workshop item no longer exists. It was deleted on Steam, so link or create another item",
   InvalidItemType: "Steam refuses this item type here. Check the item was created for this game",
   MustAgreeToSSA: "the account has not accepted the Steam Subscriber Agreement. Accept it on Steam and retry",
   Cancelled: "the upload was cancelled",
   NotModified: "nothing in this update differs from what Steam already has",
-  LockingFailed: "Steam could not save the change on its side. Retry the upload",
+  LockingFailed: "another update to this item is still running on Steam. Wait a moment and retry",
   PersistFailed: "Steam could not save the change on its side. Retry the upload",
   ValueOutOfRange: "one value is outside the range Steam accepts. Check the visibility and the tags",
 };

--- a/packages/vscode/src/steam/workshop.ts
+++ b/packages/vscode/src/steam/workshop.ts
@@ -312,10 +312,9 @@ export function friendlyError(e: unknown, meta: GameMeta): string {
       `Steam must be running and logged in to an account that owns ${meta.name}.`
     );
   }
-  // Steam's EResult phrases are accurate but bare ("limit exceeded"); say
-  // what the phrase usually means for a Workshop upload.
-  const hint = explainSteamError(msg);
-  return hint ? `${msg} (${hint})` : msg;
+  // steamwand names the raw code ("SubmitItemUpdate failed:
+  // k_EResultAccessDenied"); say what it means, code kept for support.
+  return explainSteamError(msg) ?? msg;
 }
 
 export function registerWorkshop(

--- a/packages/vscode/test/steamErrors.test.ts
+++ b/packages/vscode/test/steamErrors.test.ts
@@ -14,10 +14,13 @@ const submitFailed = (name: string) => `SubmitItemUpdate failed: ${name}`;
 describe("explainSteamError", () => {
   it("explains the codes an upload actually hits", () => {
     expect(explainSteamError(submitFailed("k_EResultAccessDenied"))).toBe(
-      "the Steam account you are logged in as may not edit this item. The Workshop ID in the " +
-        "descriptor must belong to that account (SubmitItemUpdate: k_EResultAccessDenied)"
+      "the Steam account you are logged in as does not own the game, or does not own this item. " +
+        "Log in as the account that created the Workshop item (SubmitItemUpdate: k_EResultAccessDenied)"
     );
-    expect(explainSteamError(submitFailed("k_EResultLimitExceeded"))).toContain("8000 characters");
+    // Valve documents LimitExceeded on SubmitItemUpdate as the 1 MB preview cap
+    // or a full Steam Cloud, NOT a text-length limit (which is what this used
+    // to claim).
+    expect(explainSteamError(submitFailed("k_EResultLimitExceeded"))).toContain("over 1 MB");
     expect(explainSteamError(submitFailed("k_EResultNotLoggedOn"))).toContain("Log in and retry");
     expect(explainSteamError("CreateItem failed: k_EResultFileNotFound")).toContain("preview image");
     expect(explainSteamError(submitFailed("k_EResultTimeout"))).toContain("retry the upload");
@@ -27,8 +30,9 @@ describe("explainSteamError", () => {
     expect(
       explainSteamError(`uploading the german translation failed: ${submitFailed("k_EResultBanned")}`)
     ).toBe(
-      "uploading the german translation failed: Steam has banned this item or this account. " +
-        "Check the item's Workshop page (SubmitItemUpdate: k_EResultBanned)"
+      "uploading the german translation failed: the Steam account has a VAC or game ban, so it " +
+        "cannot upload for this game. Check the account's bans on its Steam profile " +
+        "(SubmitItemUpdate: k_EResultBanned)"
     );
   });
 

--- a/packages/vscode/test/steamErrors.test.ts
+++ b/packages/vscode/test/steamErrors.test.ts
@@ -1,29 +1,69 @@
 /**
- * The Steam-error advice table (steam/steamErrors.ts): the phrases the
- * native layer's EResult mapping produces get a one-line hint, everything
- * unrecognized passes through unchanged.
+ * The Steam-error rewriter (steam/steamErrors.ts). The fixtures are the exact
+ * message shapes steamwand throws, because the previous table was keyed on
+ * the phrases of the OLD native layer and silently matched nothing after the
+ * bridge moved to steamwand.
  */
 import { describe, expect, it } from "vitest";
-import { explainSteamError } from "../src/steam/steamErrors";
+import { EResult } from "steamwand.js/dist/generated/enums";
+import { RESULT_HINTS, explainSteamError } from "../src/steam/steamErrors";
+
+/** What bridge.ts hands friendlyError for a failed main submit. */
+const submitFailed = (name: string) => `SubmitItemUpdate failed: ${name}`;
 
 describe("explainSteamError", () => {
-  it("explains the phrases uploads actually hit", () => {
-    expect(explainSteamError("upload failed: limit exceeded")).toContain("8000 characters");
-    expect(explainSteamError("a file was not found")).toContain("preview image");
-    expect(explainSteamError("access denied")).toContain("logged-in Steam account");
-    expect(explainSteamError("insufficient privilege")).toContain("logged-in Steam account");
-    expect(explainSteamError("user not logged on")).toContain("log into Steam");
-    expect(explainSteamError("there isn't a network connection to steam or it failed to connect")).toContain(
-      "offline"
+  it("explains the codes an upload actually hits", () => {
+    expect(explainSteamError(submitFailed("k_EResultAccessDenied"))).toBe(
+      "the Steam account you are logged in as may not edit this item. The Workshop ID in the " +
+        "descriptor must belong to that account (SubmitItemUpdate: k_EResultAccessDenied)"
     );
-    expect(explainSteamError("operation timed out")).toContain("retry");
-    expect(explainSteamError("a parameter is invalid")).toContain("tag");
-    expect(explainSteamError("a generic failure from the steamworks API")).toContain("catch-all");
+    expect(explainSteamError(submitFailed("k_EResultLimitExceeded"))).toContain("8000 characters");
+    expect(explainSteamError(submitFailed("k_EResultNotLoggedOn"))).toContain("Log in and retry");
+    expect(explainSteamError("CreateItem failed: k_EResultFileNotFound")).toContain("preview image");
+    expect(explainSteamError(submitFailed("k_EResultTimeout"))).toContain("retry the upload");
   });
 
-  it("returns null for anything it does not recognize", () => {
+  it("keeps the text around the failure", () => {
+    expect(
+      explainSteamError(`uploading the german translation failed: ${submitFailed("k_EResultBanned")}`)
+    ).toBe(
+      "uploading the german translation failed: Steam has banned this item or this account. " +
+        "Check the item's Workshop page (SubmitItemUpdate: k_EResultBanned)"
+    );
+  });
+
+  it("still names an unmapped or unknown code", () => {
+    expect(explainSteamError(submitFailed("k_EResultInvalidSteamID"))).toBe(
+      "Steam refused the request (SubmitItemUpdate: k_EResultInvalidSteamID)"
+    );
+    // eResultName's fallback for a value not in the shipped enum.
+    expect(explainSteamError(submitFailed("EResult(9999)"))).toBe(
+      "Steam refused the request (SubmitItemUpdate: EResult(9999))"
+    );
+  });
+
+  it("names the field a rejected setter was given", () => {
+    expect(explainSteamError("steamwand: SetItemTags returned false (invalid handle or argument?)")).toBe(
+      "Steam rejected the tags (SetItemTags)"
+    );
+    expect(explainSteamError("steamwand: SetLanguage returned false (invalid handle or argument?)")).toBe(
+      "Steam rejected one of the values it was given (SetLanguage)"
+    );
+  });
+
+  it("returns null for anything that is not a Steam failure", () => {
     expect(explainSteamError("unexpected bridge reply")).toBeNull();
     expect(explainSteamError("Steam bridge exited with code 127")).toBeNull();
+    expect(explainSteamError("content folder does not exist: F:/mods/x")).toBeNull();
     expect(explainSteamError("")).toBeNull();
+  });
+
+  it("keys only on EResult names steamwand can emit", () => {
+    const names = new Set(Object.keys(EResult));
+    for (const key of Object.keys(RESULT_HINTS)) {
+      // steamwand spells one entry K_EResult..., so accept either prefix.
+      expect(names.has(`k_EResult${key}`) || names.has(`K_EResult${key}`)).toBe(true);
+      expect(explainSteamError(`Op failed: k_EResult${key}`)).toContain(RESULT_HINTS[key]);
+    }
   });
 });


### PR DESCRIPTION
The Workshop panel's error advice was written from the generic EResult enum text. Valve documents a different meaning per ISteamUGC call (CreateItem, SubmitItemUpdate), and that is what an upload gets. Six entries were wrong as a result:

- LimitExceeded: preview image over 1 MB or a full Steam Cloud, not the description length.
- ServiceReadOnly: the 5 to 30 day upload hold after a password or email change, not a Steam outage.
- LockingFailed: another update on the same item holds the UGC lock.
- Banned: VAC or game ban on the account.
- DuplicateRequest: the upload already succeeded; refresh.
- AccessDenied, InvalidParam, FileNotFound: retargeted to the documented causes (license and item ownership, app ID mismatch, unreadable preview or missing item).

Revoked and Blocked are documented nowhere for uploads and now say so instead of guessing. DuplicateName (CreateItem) added. The wiki page Steam-Workshop-Error-Codes was updated to match, byte for byte modulo case.

Checks: steamErrors test 6/6, tsc, lint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Align Steam Workshop upload error reporting with Valve's documented per-call meanings and make failures actionable while retaining diagnostic details.

New Features:
- Add actionable, per-operation Steam Workshop guidance for documented EResult codes, including DuplicateName and rejected setter values.

Bug Fixes:
- Correct Workshop error advice to reflect Valve's ISteamUGC meanings for upload failures instead of generic EResult descriptions.
- Restore error explanations for steamwand's enum-based failure messages and preserve the original operation and code for support.
- Avoid duplicating the main upload-failure prefix in error messages.

Enhancements:
- Handle unmapped and undocumented Steam result codes with explicit fallback guidance rather than misleading guesses.

Documentation:
- Update the VS Code changelog and Steam Workshop error-code documentation to match Valve's per-call meanings.

Tests:
- Expand Steam error coverage for exact steamwand message shapes, mapped and unknown codes, rejected setters, and enum-key validity.