### PR TITLE
Workshop panel: two-column layout, step progress, selectable download, sortable previews, links, translations/ folder

### DIFF
--- a/packages/vscode/CHANGELOG.md
+++ b/packages/vscode/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## Unreleased
 
+- **The Workshop panel uses the width it has.** Two columns of cards: Item and
+  Publish first, then Previews and Requirements, then Links; the description
+  and the translations follow at full width. A step strip under the toolbar
+  names each stage of an upload or download and shows the percent of the one
+  in flight.
+- **Download picks its parts.** The toolbar's download button now asks which
+  parts to write, the same list as Publish plus the preview image: details
+  into item.json (title, tags, visibility), the description, translations,
+  the gallery images and videos, the requirements, the main preview image.
+- **Previews reorder by drag and drop.** The order is saved to
+  `previews/order.txt`; files not listed follow by name.
+- **Links.** Steam has no link field, so the panel keeps `links.json` next to
+  the listing and appends a Links block at the end of the description on
+  upload; a download takes the block back apart.
+- **Translations moved into `translations/`.** The listing folder keeps
+  `description.bbcode`, `item.json`, `links.json` and `dependencies.json` at
+  its root; each language lives in `translations/<language>/`. Old root
+  language folders are still read and move on the next save.
 - **Required DLC and required items in the Workshop panel.** A Requirements
   section lists the game's DLC as Steam reports it (unowned ones marked) and
   the required Workshop items, with installed mods and declared dependencies

--- a/packages/vscode/src/steam/workshopFiles.ts
+++ b/packages/vscode/src/steam/workshopFiles.ts
@@ -6,9 +6,15 @@
  *   <workshopDir>/
  *     item.json                    {"title": "...", "publishedfileid": "..."}
  *     description.bbcode           default-language description
- *     <steamlang>/title.txt        localized title (optional)
- *     <steamlang>/description.bbcode
+ *     links.json                   links rendered as a block at the end of the description
+ *     translations/<steamlang>/title.txt        localized title (optional)
+ *     translations/<steamlang>/description.bbcode
+ *     previews/                    extra preview images, videos.txt, order.txt
+ *     dependencies.json            required DLC and items
  *     changelog/                   changenote sources (see resolveChangeNote)
+ *
+ * Listings written before 0.4.0 keep `<steamlang>/` at the root; reads fall
+ * back to it and the next write moves the language into `translations/`.
  *
  * The folder's location is `px.workshop.dir`, resolved against the mod root.
  * Empty (the default) means `<configDir>/workshop` inside the mod, which a
@@ -25,6 +31,12 @@ import { STEAM_LANGUAGES, type WorkshopTranslation } from "@px-lsp/protocol/work
 
 export const SIBLING_WORKSHOP_DIR = "../workshop";
 export const DEFAULT_CHANGELOG = "changelog";
+export const TRANSLATIONS_DIR = "translations";
+
+/** Where one language's files live: `translations/<lang>/`. */
+export function langDir(workshopDir: string, api: string): string {
+  return path.join(workshopDir, TRANSLATIONS_DIR, api);
+}
 
 /**
  * The workshop folder of `root`: the `px.workshop.dir` setting when set, else
@@ -65,10 +77,16 @@ const read = (file: string): string | null => {
 export function readListingFiles(workshopDir: string): ListingFiles {
   const translations: Record<string, WorkshopTranslation> = {};
   for (const { api } of STEAM_LANGUAGES) {
-    const dir = path.join(workshopDir, api);
-    const title = read(path.join(dir, "title.txt"));
-    const description = read(path.join(dir, "description.bbcode"));
-    if (title === null && description === null) continue;
+    let dir = langDir(workshopDir, api);
+    let title = read(path.join(dir, "title.txt"));
+    let description = read(path.join(dir, "description.bbcode"));
+    if (title === null && description === null) {
+      // Pre-0.4.0 layout: the language folder sits at the root.
+      dir = path.join(workshopDir, api);
+      title = read(path.join(dir, "title.txt"));
+      description = read(path.join(dir, "description.bbcode"));
+      if (title === null && description === null) continue;
+    }
     translations[api] = {
       ...(title !== null ? { title: title.trim() } : {}),
       ...(description !== null ? { description } : {}),
@@ -90,28 +108,34 @@ export function writeListingFiles(
   fs.writeFileSync(path.join(workshopDir, "description.bbcode"), listing.description, "utf8");
   for (const { api } of STEAM_LANGUAGES) {
     const t = listing.translations[api];
-    const dir = path.join(workshopDir, api);
+    const dir = langDir(workshopDir, api);
+    // The pre-0.4.0 root folder is always cleared: its text now lives under translations/.
+    removeLangFiles(path.join(workshopDir, api));
     const title = (t?.title ?? "").trim();
     const description = t?.description ?? "";
     if (title === "" && description.trim() === "") {
-      // Nothing drafted: remove only the two files this store manages.
-      for (const f of ["title.txt", "description.bbcode"]) {
-        try {
-          fs.rmSync(path.join(dir, f));
-        } catch {
-          /* absent */
-        }
-      }
-      try {
-        if (fs.existsSync(dir) && fs.readdirSync(dir).length === 0) fs.rmdirSync(dir);
-      } catch {
-        /* leave a non-empty or locked folder alone */
-      }
+      removeLangFiles(dir);
       continue;
     }
     fs.mkdirSync(dir, { recursive: true });
     writeOrRemove(path.join(dir, "title.txt"), title === "" ? null : title + "\n");
     writeOrRemove(path.join(dir, "description.bbcode"), description.trim() === "" ? null : description);
+  }
+}
+
+/** Remove only the two files this store manages, and the folder once it is empty. */
+function removeLangFiles(dir: string): void {
+  for (const f of ["title.txt", "description.bbcode"]) {
+    try {
+      fs.rmSync(path.join(dir, f));
+    } catch {
+      /* absent */
+    }
+  }
+  try {
+    if (fs.existsSync(dir) && fs.readdirSync(dir).length === 0) fs.rmdirSync(dir);
+  } catch {
+    /* leave a non-empty or locked folder alone */
   }
 }
 
@@ -130,6 +154,8 @@ function writeOrRemove(file: string, content: string | null): void {
 export interface ItemJson {
   title?: string;
   publishedfileid?: string;
+  tags?: string[];
+  visibility?: number;
 }
 
 /** `<workshopDir>/item.json`, or null when absent/unreadable. */
@@ -184,6 +210,8 @@ export function moveListing(
 
 export const PREVIEWS_DIR = "previews";
 export const VIDEOS_FILE = "videos.txt";
+/** One file name per line: the gallery order. Files not listed follow, by name. */
+export const ORDER_FILE = "order.txt";
 export const DEPENDENCIES_FILE = "dependencies.json";
 const PREVIEW_EXTS = new Set([".png", ".jpg", ".jpeg", ".gif"]);
 
@@ -207,21 +235,31 @@ export function readPreviews(workshopDir: string): Previews | null {
   } catch {
     return null;
   }
-  const images = names
+  const byName = names
     .filter((n) => PREVIEW_EXTS.has(path.extname(n).toLowerCase()))
-    .sort((a, b) => a.localeCompare(b, undefined, { numeric: true }))
-    .map((n) => path.join(dir, n));
-  let videos: string[] = [];
+    .sort((a, b) => a.localeCompare(b, undefined, { numeric: true }));
+  const order = readLines(path.join(dir, ORDER_FILE)).filter((n) => byName.includes(n));
+  const images = [...order, ...byName.filter((n) => !order.includes(n))].map((n) => path.join(dir, n));
+  return { images, videos: readLines(path.join(dir, VIDEOS_FILE)) };
+}
+
+/** Non-empty, non-comment lines of a text file; none when it is absent. */
+function readLines(file: string): string[] {
   try {
-    videos = fs
-      .readFileSync(path.join(dir, VIDEOS_FILE), "utf8")
+    return fs
+      .readFileSync(file, "utf8")
       .split(/\r?\n/)
       .map((l) => l.trim())
       .filter((l) => l !== "" && !l.startsWith("#"));
   } catch {
-    /* no videos file */
+    return [];
   }
-  return { images, videos };
+}
+
+export function writePreviewOrder(workshopDir: string, names: string[]): void {
+  const dir = path.join(workshopDir, PREVIEWS_DIR);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, ORDER_FILE), names.join("\n") + "\n", "utf8");
 }
 
 export function writeVideos(workshopDir: string, ids: string[]): void {
@@ -233,6 +271,76 @@ export function writeVideos(workshopDir: string, ids: string[]): void {
     return;
   }
   fs.writeFileSync(file, ids.join("\n") + "\n", "utf8");
+}
+
+// ---------------------------------------------------------------------------
+// Links: Steam has no link field, so they render as a block at the end of the
+// description. The block is recognizable, so an upload replaces it and a pull
+// takes it back apart.
+// ---------------------------------------------------------------------------
+
+export const LINKS_FILE = "links.json";
+const LINKS_HEAD = "[h2]Links[/h2]";
+
+export interface Link {
+  label: string;
+  url: string;
+}
+
+const isHttp = (u: string): boolean => /^https?:\/\/\S+$/i.test(u);
+
+/** `<workshopDir>/links.json`, or none. */
+export function readLinks(workshopDir: string): Link[] {
+  try {
+    const raw = JSON.parse(fs.readFileSync(path.join(workshopDir, LINKS_FILE), "utf8")) as unknown;
+    if (!Array.isArray(raw)) return [];
+    return raw
+      .filter((l): l is Link => typeof l?.url === "string" && isHttp(l.url))
+      .map((l) => ({ label: typeof l.label === "string" ? l.label : "", url: l.url }));
+  } catch {
+    return [];
+  }
+}
+
+export function writeLinks(workshopDir: string, links: Link[]): void {
+  const file = path.join(workshopDir, LINKS_FILE);
+  const kept = links.filter((l) => isHttp(l.url));
+  if (kept.length === 0) {
+    fs.rmSync(file, { force: true });
+    return;
+  }
+  fs.mkdirSync(workshopDir, { recursive: true });
+  fs.writeFileSync(file, JSON.stringify(kept, null, 2) + "\n", "utf8");
+}
+
+/** The description without its trailing links block. */
+export function stripLinksBlock(description: string): string {
+  const at = description.lastIndexOf(LINKS_HEAD);
+  if (at < 0) return description;
+  // Only a block that runs to the end is ours; a heading mid-text is the author's.
+  const tail = description.slice(at + LINKS_HEAD.length);
+  if (!/^\s*\[list\][\s\S]*\[\/list\]\s*$/.test(tail)) return description;
+  return description.slice(0, at).replace(/\s+$/, "");
+}
+
+/** The description with `links` rendered as its trailing block (or none). */
+export function withLinksBlock(description: string, links: Link[]): string {
+  const base = stripLinksBlock(description);
+  const kept = links.filter((l) => isHttp(l.url));
+  if (kept.length === 0) return base;
+  const items = kept.map((l) => `[*] [url=${l.url}]${l.label.trim() || l.url}[/url]`).join("\n");
+  return `${base}${base.trim() === "" ? "" : "\n\n"}${LINKS_HEAD}\n[list]\n${items}\n[/list]`;
+}
+
+/** The links a trailing block carries, so a pulled description round-trips into links.json. */
+export function parseLinksBlock(description: string): Link[] {
+  const at = description.lastIndexOf(LINKS_HEAD);
+  if (at < 0 || stripLinksBlock(description) === description) return [];
+  const out: Link[] = [];
+  for (const m of description.slice(at).matchAll(/\[url=([^\]]+)\]([^[]*)\[\/url\]/g)) {
+    if (isHttp(m[1])) out.push({ label: m[2].trim(), url: m[1] });
+  }
+  return out;
 }
 
 export interface Dependencies {

--- a/packages/vscode/src/webviews/workshop/app/main.ts
+++ b/packages/vscode/src/webviews/workshop/app/main.ts
@@ -20,6 +20,7 @@ import type {
   HostToApp,
   LiveTranslation,
   ModChoice,
+  PullParts,
   TranslationDraft,
   WorkshopModInfo,
 } from "../messages";
@@ -49,6 +50,7 @@ let busy = false;
 let dlc: DlcEntry[] | null = null;
 let dlcError: string | null = null;
 let dlcLoading = false;
+let linksTimer: ReturnType<typeof setTimeout> | undefined;
 
 /** The visibility the user picked, or null = whatever the item has. */
 let pickedVisibility: WorkshopVisibility | null = null;
@@ -117,8 +119,48 @@ function renderAll(): void {
   renderTranslations();
   renderPreviews();
   renderRequirements();
+  renderLinks();
   renderChecks();
   renderPublish();
+}
+
+/** The step strip: every step of the running job, the one in flight, and its bar. */
+function renderProgress(m: {
+  busy: boolean;
+  message?: string;
+  steps?: string[];
+  step?: number;
+  percent?: number | null;
+}): void {
+  const strip = $("progress");
+  strip.classList.toggle("on", m.busy);
+  if (!m.busy) return;
+  const steps = $("steps");
+  steps.replaceChildren();
+  (m.steps ?? []).forEach((name, i) => {
+    if (i > 0) {
+      const sep = document.createElement("span");
+      sep.className = "sep";
+      sep.append(iconEl("chevronRight"));
+      steps.append(sep);
+    }
+    const el = document.createElement("span");
+    el.className = "st";
+    const state = m.step === undefined ? "todo" : i < m.step ? "done" : i === m.step ? "on" : "todo";
+    el.dataset.state = state;
+    if (state === "done") el.append(iconEl("check"));
+    el.append(document.createTextNode(name));
+    steps.append(el);
+  });
+  const msg = document.createElement("span");
+  msg.className = "msg";
+  msg.textContent =
+    (m.message ?? "") + (m.percent !== null && m.percent !== undefined ? ` ${m.percent}%` : "");
+  steps.append(msg);
+  const bar = $("bar");
+  const known = m.percent !== null && m.percent !== undefined;
+  bar.classList.toggle("indeterminate", !known);
+  (bar.firstElementChild as HTMLElement).style.width = known ? `${m.percent}%` : "";
 }
 
 const hasErrors = (): boolean => !!info?.checks.some((c) => c.level === "error");
@@ -140,7 +182,7 @@ function renderToolbar(): void {
   $<HTMLButtonElement>("upload").disabled = busy || !info || info.descriptorMissing || hasErrors();
   $<HTMLButtonElement>("refresh").disabled = fetching || !info?.publishedId;
   $<HTMLButtonElement>("pull").disabled = busy || fetching || !info?.publishedId;
-  $("busy").classList.toggle("on", busy || fetching);
+  $("busy").classList.toggle("on", fetching && !busy);
 }
 
 function renderItem(): void {
@@ -576,10 +618,110 @@ function renderPreviews(): void {
     rm.append(iconEl("x"));
     rm.addEventListener("click", () => send({ type: "removePreview", name: img.name }));
     tile.append(el, cap, rm);
+    tile.draggable = true;
+    tile.dataset.name = img.name;
+    tile.setAttribute("data-tip", "Drag to reorder; the order is saved to previews/order.txt");
     gallery.append(tile);
   }
+  wireGalleryDrag(gallery);
   for (const id of info.previews.videos) gallery.append(liveTile(1, id, ""));
   if (document.activeElement !== videos) videos.value = info.previews.videos.join(", ");
+}
+
+/** HTML5 drag and drop between image tiles; the new order goes to the host as file names. */
+function wireGalleryDrag(gallery: HTMLElement): void {
+  let dragged: HTMLElement | null = null;
+  const tiles = () => [...gallery.querySelectorAll<HTMLElement>(".tile[draggable]")];
+  const clearMarks = () => tiles().forEach((t) => t.classList.remove("drop-before", "drop-after"));
+  for (const tile of tiles()) {
+    tile.addEventListener("dragstart", (e) => {
+      dragged = tile;
+      tile.classList.add("dragging");
+      e.dataTransfer?.setData("text/plain", tile.dataset.name ?? "");
+      if (e.dataTransfer) e.dataTransfer.effectAllowed = "move";
+    });
+    tile.addEventListener("dragend", () => {
+      dragged = null;
+      tile.classList.remove("dragging");
+      clearMarks();
+    });
+    tile.addEventListener("dragover", (e) => {
+      if (!dragged || dragged === tile) return;
+      e.preventDefault();
+      clearMarks();
+      const r = tile.getBoundingClientRect();
+      tile.classList.add(e.clientX < r.left + r.width / 2 ? "drop-before" : "drop-after");
+    });
+    tile.addEventListener("drop", (e) => {
+      if (!dragged || dragged === tile) return;
+      e.preventDefault();
+      const r = tile.getBoundingClientRect();
+      const before = e.clientX < r.left + r.width / 2;
+      gallery.insertBefore(dragged, before ? tile : tile.nextSibling);
+      clearMarks();
+      const names = tiles()
+        .map((t) => t.dataset.name ?? "")
+        .filter(Boolean);
+      send({ type: "reorderPreviews", names });
+    });
+  }
+}
+
+/** The links rows: label + url, saved to links.json a moment after the last edit. */
+function renderLinks(): void {
+  $("linksSection").style.display = info && !info.descriptorMissing ? "" : "none";
+  if (!info || info.descriptorMissing) return;
+  const box = $("linksBox");
+  if (box.contains(document.activeElement)) return; // typing: leave the rows alone
+  box.replaceChildren();
+  const rows = info.links.map((l) => ({ ...l }));
+  const commit = () => {
+    clearTimeout(linksTimer);
+    linksTimer = setTimeout(
+      () => send({ type: "setLinks", links: rows.filter((l) => l.url.trim() !== "") }),
+      500
+    );
+  };
+  rows.forEach((link, i) => {
+    const row = document.createElement("div");
+    row.className = "link-row";
+    const label = document.createElement("input");
+    label.className = "px-input";
+    label.placeholder = "Label (Discord, GitHub, …)";
+    label.value = link.label;
+    label.addEventListener("input", () => {
+      rows[i].label = label.value;
+      commit();
+    });
+    const url = document.createElement("input");
+    url.className = "px-input";
+    url.placeholder = "https://…";
+    url.value = link.url;
+    url.spellcheck = false;
+    url.addEventListener("input", () => {
+      rows[i].url = url.value;
+      commit();
+    });
+    const rm = document.createElement("button");
+    rm.className = "px-btn";
+    rm.dataset.variant = "ghost";
+    rm.dataset.size = "icon-xs";
+    rm.setAttribute("aria-label", "Remove link");
+    rm.append(iconEl("x"));
+    rm.addEventListener("click", () => {
+      rows.splice(i, 1);
+      clearTimeout(linksTimer);
+      send({ type: "setLinks", links: rows.filter((l) => l.url.trim() !== "") });
+    });
+    row.append(label, url, rm);
+    box.append(row);
+  });
+  if (rows.length === 0) {
+    const none = document.createElement("span");
+    none.className = "px-muted px-xs";
+    none.textContent = "None yet.";
+    box.append(none);
+  }
 }
 
 function liveTile(type: number, urlOrId: string, name: string): HTMLElement {
@@ -782,7 +924,8 @@ window.addEventListener("message", (e: MessageEvent<HostToApp>) => {
     case "uploadState":
       busy = m.busy;
       renderToolbar();
-      $("liveState").textContent = m.message ?? (busy ? "uploading…" : "");
+      renderProgress(m);
+      $("liveState").textContent = busy ? "" : "";
       return;
     case "dlc":
       dlcLoading = false;
@@ -1115,23 +1258,54 @@ $("pull").addEventListener(
   () =>
     void (async () => {
       if (!info?.publishedId || busy || fetching) return;
+      const wrap = document.createElement("div");
+      wrap.className = "modal-rows";
+      const part = (id: keyof PullParts, label: string, sub: string) => {
+        const r = document.createElement("div");
+        r.className = "pub-row";
+        const sw = document.createElement("label");
+        sw.className = "px-switch";
+        const input = document.createElement("input");
+        input.type = "checkbox";
+        input.checked = true;
+        sw.append(input, document.createElement("span"));
+        const text = document.createElement("span");
+        text.className = "lbl";
+        text.append(document.createTextNode(label));
+        const subEl = document.createElement("span");
+        subEl.className = "sub";
+        subEl.textContent = ` - ${sub}`;
+        text.append(subEl);
+        r.append(sw, text);
+        wrap.append(r);
+        return [id, input] as const;
+      };
+      const inputs = [
+        part("details", "Details", "title, tags and visibility into item.json"),
+        part("description", "Description", "description.bbcode, links.json from its Links block"),
+        part("translations", "Translations", "translations/<language>/ for every translated language"),
+        part("previews", "Previews", "the gallery images, videos.txt and order.txt into previews/"),
+        part("requirements", "Requirements", "dependencies.json"),
+        part("thumbnail", "Preview image", "the main image into the mod folder"),
+      ];
+      const warn = document.createElement("div");
+      warn.className = "modal-note";
+      warn.textContent =
+        `Overwrites the matching files in ${info.workshopDir} and replaces the local drafts. ` +
+        "Local text never uploaded to Steam is lost - commit or copy it first if it matters.";
+      wrap.append(warn);
       const go = await confirmDialog({
-        title: "Download the listing from Steam into files?",
-        description:
-          "The live description and every translated language are written into the workshop folder, which becomes the canonical store for the listing:",
-        details: [
-          `Folder: ${info.workshopDir} (px.workshop.dir)`,
-          "description.bbcode - the default-language description",
-          "<language>/title.txt and <language>/description.bbcode per translated language",
-          "item.json - title and publishedfileid",
-          "THIS OVERWRITES those files and replaces the local drafts. Local text that was never uploaded to Steam is lost - commit or copy it first if it matters.",
-        ],
+        title: "Download from Steam into files?",
+        content: wrap,
         confirmLabel: "Download & overwrite",
         destructive: true,
         wide: true,
       });
       if (!go) return;
-      send({ type: "pullListing" });
+      const parts = Object.fromEntries(
+        inputs.map(([id, input]) => [id, input.checked])
+      ) as unknown as PullParts;
+      send({ type: "pullListing", parts });
     })()
 );
 
@@ -1178,6 +1352,19 @@ commitField("supported", "supportedVersion");
 
 $("changePreview").addEventListener("click", () => send({ type: "pickPreview" }));
 $("addPreviews").addEventListener("click", () => send({ type: "addPreviews" }));
+$("addLink").addEventListener("click", () => {
+  if (!info) return;
+  // Keep what is typed but not yet saved, then add the empty row and focus it.
+  const current = [...$("linksBox").querySelectorAll<HTMLElement>(".link-row")].map((r) => {
+    const [label, url] = r.querySelectorAll("input");
+    return { label: label.value, url: url.value };
+  });
+  info.links = [...current, { label: "", url: "" }];
+  (document.activeElement as HTMLElement | null)?.blur();
+  renderLinks();
+  const inputs = $("linksBox").querySelectorAll<HTMLInputElement>("input");
+  inputs[inputs.length - 2]?.focus();
+});
 $("openPreviews").addEventListener("click", () => send({ type: "openPreviewsFolder" }));
 {
   const videos = $<HTMLInputElement>("videos");
@@ -1272,16 +1459,16 @@ $("helpBtn").addEventListener("click", () =>
         intro: "Two stores, and the panel says at the Files row which one this mod uses.",
         items: [
           {
-            lead: "A workshop folder",
-            text: "keeps the listing as files: description.bbcode, one folder per language with title.txt and description.bbcode, and item.json. They diff and version like the rest of your code. The folder is px.workshop.dir, resolved against the mod folder.",
-          },
-          {
-            lead: "Without that folder,",
-            text: "drafts save to workshop.json inside the mod instead.",
+            lead: "The workshop folder",
+            text: "keeps the listing as files: description.bbcode, links.json, translations/<language>/ with title.txt and description.bbcode, previews/, dependencies.json and item.json. They diff and version like the rest of your code. The folder is .px-toolkit/workshop inside the mod unless px.workshop.dir says otherwise.",
           },
           {
             lead: "The download button",
-            text: "in the toolbar writes the folder from what is on Steam. It overwrites those files and your local drafts, so anything never uploaded is lost. It asks first.",
+            text: "in the toolbar writes the folder from what is on Steam. You pick the parts: details, description, translations, previews, requirements, the preview image. It overwrites those files and your local drafts, so anything never uploaded is lost.",
+          },
+          {
+            lead: "Links",
+            text: "have no field on Steam. The panel keeps them in links.json and appends them as a Links block at the end of the description on upload; a download takes the block back apart.",
           },
           {
             lead: "Reload",

--- a/packages/vscode/src/webviews/workshop/html.ts
+++ b/packages/vscode/src/webviews/workshop/html.ts
@@ -40,10 +40,31 @@ ${uiCss}
     0% { transform: translateX(-110%); }
     100% { transform: translateX(440%); }
   }
+  /* Step strip under the toolbar while a job runs: names, the one in flight, its percent. */
+  #progress { display: none; flex: 0 0 auto; padding: 4px 12px 6px; border-bottom: 1px solid var(--px-border); gap: 4px; flex-direction: column; }
+  #progress.on { display: flex; }
+  #steps { display: flex; align-items: center; gap: 6px; font-size: var(--px-text-xs); color: var(--px-muted-fg); flex-wrap: wrap; }
+  #steps .st { display: inline-flex; align-items: center; gap: 4px; }
+  #steps .st .px-icon { width: 12px; height: 12px; }
+  #steps .st[data-state="done"] { color: var(--px-fg); }
+  #steps .st[data-state="on"] { color: var(--px-primary); font-weight: 600; }
+  #steps .sep { opacity: 0.5; }
+  #steps .msg { margin-left: auto; color: var(--px-fg); }
+  #bar { height: 3px; border-radius: 2px; background: var(--px-muted); overflow: hidden; }
+  #bar > div { height: 100%; width: 0; background: var(--px-primary); transition: width 200ms linear; }
+  #bar.indeterminate > div { width: 30%; animation: busy-slide 1.2s ease-in-out infinite; }
   #main { flex: 1 1 auto; overflow-y: auto; min-height: 0; }
-  #page { max-width: 760px; margin: 0 auto; padding: 12px 16px 40px; display: flex; flex-direction: column; gap: 10px; }
-  .section { display: flex; flex-direction: column; gap: 8px; padding: 10px 0; }
-  .section + .section { border-top: 1px solid var(--px-border); }
+  #page {
+    max-width: 1480px; margin: 0 auto; padding: 12px 16px 40px;
+    display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 12px; align-items: start;
+  }
+  @media (max-width: 880px) { #page { grid-template-columns: minmax(0, 1fr); } }
+  .section {
+    display: flex; flex-direction: column; gap: 8px; padding: 10px 12px; min-width: 0;
+    border: 1px solid var(--px-border); border-radius: var(--px-radius-md); background: var(--px-card, transparent);
+  }
+  .section.wide, #noDescriptor { grid-column: 1 / -1; }
+  .section[hidden] { display: none; }
   #noDescriptor { display: none; flex-direction: row; align-items: center; gap: 10px; padding: 12px;
     border: 1px solid var(--px-border); border-radius: var(--px-radius-md); }
   #noDescriptor.on { display: flex; }
@@ -133,6 +154,12 @@ ${BBPREV_CSS}
   .gallery .tile .cap { position: absolute; left: 0; right: 0; bottom: 0; padding: 2px 4px; font-size: var(--px-text-xs); background: color-mix(in srgb, var(--px-bg) 80%, transparent); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
   .gallery .tile .rm { position: absolute; top: 2px; right: 2px; }
   .gallery .tile.video { display: flex; align-items: center; justify-content: center; color: var(--px-muted-fg); font-size: var(--px-text-xs); }
+  .gallery .tile[draggable="true"] { cursor: grab; }
+  .gallery .tile.dragging { opacity: 0.4; }
+  .gallery .tile.drop-before { box-shadow: -3px 0 0 var(--px-primary); }
+  .gallery .tile.drop-after { box-shadow: 3px 0 0 var(--px-primary); }
+  .link-row { display: grid; grid-template-columns: minmax(0, 2fr) minmax(0, 3fr) auto; gap: 6px; align-items: center; }
+  .link-row .px-input { width: 100%; }
   .check-row { display: flex; align-items: flex-start; gap: 6px; font-size: var(--px-text-xs); padding: 2px 0; }
   .check-row[data-level="error"] { color: var(--px-destructive); }
   .check-row[data-level="warn"] { color: var(--px-muted-fg); }
@@ -154,6 +181,10 @@ ${BBPREV_CSS}
     <button id="helpBtn" class="px-btn" data-variant="ghost" data-size="icon" data-tip="How this panel works" data-tip-side="left" aria-label="How this panel works">${icon("circleHelp")}</button>
   </div>
   <div id="busy"><div></div></div>
+  <div id="progress">
+    <div id="steps"></div>
+    <div id="bar"><div></div></div>
+  </div>
   <div id="main"><div id="page">
 
     <div id="noDescriptor">
@@ -208,67 +239,8 @@ ${BBPREV_CSS}
           </div>
         </div>
       </div>
+      <div id="statsSection" hidden><div id="stats"></div></div>
     </div>
-
-    <div class="section" id="statsSection" hidden>
-      <div class="px-panel-title">Statistics</div>
-      <div id="stats"></div>
-    </div>
-
-    <div class="section">
-      <div class="px-panel-title">Description
-        <span class="px-grow"></span>
-        <div class="seg" id="descMode" data-tip="Preview renders the BBCode roughly as the Workshop page will.">
-          <button data-mode="edit" class="on">Edit</button>
-          <button data-mode="preview">Preview</button>
-        </div>
-      </div>
-      <textarea id="desc" class="px-textarea" spellcheck="false" placeholder="The item's description, in Steam's BBCode ([h1], [b], [list], [url=…])."></textarea>
-      <div id="descPreview" class="bbprev" hidden></div>
-      <div class="hintline">
-        <span>Saved locally to the mod's workshop.json as you type; goes to Steam on Upload.</span>
-        <span class="px-grow"></span>
-        <button id="openDescFile" class="px-btn" data-variant="ghost" data-size="sm" data-tip="Open the workshop folder's description.bbcode in the editor">${icon("pencil")} Open file</button>
-        <button id="reloadLocal" class="px-btn" data-variant="ghost" data-size="sm" data-tip="Re-read the description and translations from the local files" data-tip-wrap>${icon("rotate")} Reload</button>
-        <button id="pullDesc" class="px-btn" data-variant="ghost" data-size="sm" data-tip="Replace the draft with the description currently on Steam" disabled>${icon("arrowDown")} Fetch from Steam</button>
-      </div>
-    </div>
-
-    <div class="section">
-      <div class="px-panel-title">${icon("globe")} Translations
-        <span class="px-grow"></span>
-        <button id="addLang" class="px-btn" data-variant="outline" data-size="sm">${icon("plus")} Add language</button>
-      </div>
-      <div class="hintline"><span>Title and description shown to Workshop visitors browsing Steam in that language. The default text above is what everyone else sees.</span></div>
-      <div id="translations"></div>
-    </div>
-
-    <div class="section" id="previewsSection">
-      <div class="px-panel-title">Previews</div>
-      <div id="previewsHint" class="px-muted px-xs" style="margin-bottom:6px"></div>
-      <div id="gallery" class="gallery"></div>
-      <div class="hintline" style="margin-top:6px">
-        <button id="addPreviews" class="px-btn" data-variant="outline" data-size="sm" data-tip="Copy images into the previews folder of the listing. Under 1 MB each; Steam shows them in file-name order." data-tip-wrap>${icon("plus")} Add images</button>
-        <button id="openPreviews" class="px-btn" data-variant="ghost" data-size="sm" data-tip="Open the previews folder. Reorder by renaming, remove by deleting." data-tip-wrap>${icon("folderOpen")} Folder</button>
-      </div>
-      <div class="field-row" style="margin-top:8px">
-        <span class="px-label">Videos</span>
-        <input id="videos" class="px-input" spellcheck="false" placeholder="YouTube links or ids, comma separated" data-tip="Saved to previews/videos.txt. Enter or leaving the field writes it." data-tip-wrap />
-      </div>
-    </div>
-
-    <div class="section" id="requirementsSection">
-      <div class="px-panel-title">Requirements</div>
-      <div class="px-label" style="margin-bottom:4px">Required DLC</div>
-      <div id="dlcBox"></div>
-      <div class="px-label" style="margin:10px 0 4px">Required items</div>
-      <div id="itemsBox"></div>
-      <div class="hintline" style="margin-top:4px">
-        <button id="addItem" class="px-btn px-dropdown" data-variant="outline" data-size="sm" style="width:auto">${icon("plus")} Add item${icon("chevronDown")}</button>
-        <input id="itemIdInput" class="px-input" spellcheck="false" placeholder="Workshop id or link" style="width:220px" />
-      </div>
-    </div>
-
     <div class="section">
       <div class="px-panel-title">Publish</div>
       <div id="checks" style="margin-bottom:6px"></div>
@@ -298,6 +270,71 @@ ${BBPREV_CSS}
         </div>
       </div>
     </div>
+    <div class="section" id="previewsSection">
+      <div class="px-panel-title">Previews</div>
+      <div id="previewsHint" class="px-muted px-xs" style="margin-bottom:6px"></div>
+      <div id="gallery" class="gallery"></div>
+      <div class="hintline" style="margin-top:6px">
+        <button id="addPreviews" class="px-btn" data-variant="outline" data-size="sm" data-tip="Copy images into the previews folder of the listing. Under 1 MB each; Steam shows them in file-name order." data-tip-wrap>${icon("plus")} Add images</button>
+        <button id="openPreviews" class="px-btn" data-variant="ghost" data-size="sm" data-tip="Open the previews folder. Reorder by renaming, remove by deleting." data-tip-wrap>${icon("folderOpen")} Folder</button>
+      </div>
+      <div class="field-row" style="margin-top:8px">
+        <span class="px-label">Videos</span>
+        <input id="videos" class="px-input" spellcheck="false" placeholder="YouTube links or ids, comma separated" data-tip="Saved to previews/videos.txt. Enter or leaving the field writes it." data-tip-wrap />
+      </div>
+    </div>
+    <div class="section" id="requirementsSection">
+      <div class="px-panel-title">Requirements</div>
+      <div class="px-label" style="margin-bottom:4px">Required DLC</div>
+      <div id="dlcBox"></div>
+      <div class="px-label" style="margin:10px 0 4px">Required items</div>
+      <div id="itemsBox"></div>
+      <div class="hintline" style="margin-top:4px">
+        <button id="addItem" class="px-btn px-dropdown" data-variant="outline" data-size="sm" style="width:auto">${icon("plus")} Add item${icon("chevronDown")}</button>
+        <input id="itemIdInput" class="px-input" spellcheck="false" placeholder="Workshop id or link" style="width:220px" />
+      </div>
+    </div>
+    <div class="section" id="linksSection">
+      <div class="px-panel-title">Links
+        <span class="px-grow"></span>
+        <button id="addLink" class="px-btn" data-variant="outline" data-size="sm">${icon("plus")} Add link</button>
+      </div>
+      <div id="linksHint" class="px-muted px-xs">Steam has no link field: these render as a "Links" block at the end of the description on upload, and a download takes them back apart.</div>
+      <div id="linksBox" style="display:flex;flex-direction:column;gap:6px"></div>
+    </div>
+    <div class="section wide">
+      <div class="px-panel-title">Description
+        <span class="px-grow"></span>
+        <div class="seg" id="descMode" data-tip="Preview renders the BBCode roughly as the Workshop page will.">
+          <button data-mode="edit" class="on">Edit</button>
+          <button data-mode="preview">Preview</button>
+        </div>
+      </div>
+      <textarea id="desc" class="px-textarea" spellcheck="false" placeholder="The item's description, in Steam's BBCode ([h1], [b], [list], [url=…])."></textarea>
+      <div id="descPreview" class="bbprev" hidden></div>
+      <div class="hintline">
+        <span>Saved to description.bbcode as you type; goes to Steam on Upload, with the links below appended as a block.</span>
+        <span class="px-grow"></span>
+        <button id="openDescFile" class="px-btn" data-variant="ghost" data-size="sm" data-tip="Open the workshop folder's description.bbcode in the editor">${icon("pencil")} Open file</button>
+        <button id="reloadLocal" class="px-btn" data-variant="ghost" data-size="sm" data-tip="Re-read the description and translations from the local files" data-tip-wrap>${icon("rotate")} Reload</button>
+        <button id="pullDesc" class="px-btn" data-variant="ghost" data-size="sm" data-tip="Replace the draft with the description currently on Steam" disabled>${icon("arrowDown")} Fetch from Steam</button>
+      </div>
+    </div>
+    <div class="section wide">
+      <div class="px-panel-title">${icon("globe")} Translations
+        <span class="px-grow"></span>
+        <button id="addLang" class="px-btn" data-variant="outline" data-size="sm">${icon("plus")} Add language</button>
+      </div>
+      <div class="hintline"><span>Title and description shown to Workshop visitors browsing Steam in that language. The default text above is what everyone else sees.</span></div>
+      <div id="translations"></div>
+    </div>
+
+
+
+
+
+
+
 
   </div></div>
 </div>

--- a/packages/vscode/src/webviews/workshop/messages.ts
+++ b/packages/vscode/src/webviews/workshop/messages.ts
@@ -72,6 +72,24 @@ export interface WorkshopModInfo {
   dependencies: { apps: number[]; items: string[] } | null;
   /** Installed Workshop mods the required-items picker offers first. */
   dependencyCandidates: { itemId: string; label: string; declared: boolean }[];
+  /** `<workshopDir>/links.json`: rendered as a block at the end of the description on upload. */
+  links: { label: string; url: string }[];
+}
+
+/** What a download from Steam writes into the listing folder; mirrors the publish parts. */
+export interface PullParts {
+  /** item.json: title, tags, visibility, id. */
+  details: boolean;
+  /** description.bbcode (and links.json from its trailing links block). */
+  description: boolean;
+  /** translations/<lang>/ for every language whose text differs from the default. */
+  translations: boolean;
+  /** previews/: the gallery images downloaded, videos.txt, order.txt. */
+  previews: boolean;
+  /** dependencies.json. */
+  requirements: boolean;
+  /** The main preview image, into the mod folder. */
+  thumbnail: boolean;
 }
 
 /** Title/description as Steam serves one language (its fallback included). */
@@ -91,7 +109,16 @@ export type HostToApp =
       /** Steam unreachable or the query failed; disk data stays usable. */
       error: string | null;
     }
-  | { type: "uploadState"; busy: boolean; message?: string }
+  | {
+      type: "uploadState";
+      busy: boolean;
+      message?: string;
+      /** The named steps of the running job, and which one is on (0-based). */
+      steps?: string[];
+      step?: number;
+      /** 0..100 for the running step, null while Steam has no size yet. */
+      percent?: number | null;
+    }
   /** The game's DLC list, or why it could not be read. */
   | { type: "dlc"; list: DlcEntry[]; error: string | null };
 
@@ -129,8 +156,12 @@ export type AppToHost =
   | { type: "openWorkshopSettings" }
   /** Surface a message as a VS Code notification (the app has no UI for it). */
   | { type: "notify"; message: string; warn?: boolean }
-  /** Download the live listing from Steam into the workshop folder (confirmed app-side). */
-  | { type: "pullListing" }
+  /** Download the chosen parts of the live listing into the workshop folder (confirmed app-side). */
+  | { type: "pullListing"; parts: PullParts }
+  /** Write previews/order.txt (bare file names, gallery order). */
+  | { type: "reorderPreviews"; names: string[] }
+  /** Write links.json. */
+  | { type: "setLinks"; links: { label: string; url: string }[] }
   /** Ask the Steam client for the game's DLC list. */
   | { type: "loadDlc" }
   /** Write dependencies.json (required DLC app ids, required Workshop item ids). */

--- a/packages/vscode/src/webviews/workshop/panel.ts
+++ b/packages/vscode/src/webviews/workshop/panel.ts
@@ -23,13 +23,20 @@ import { METADATA_REL_PATH } from "@px-lsp/protocol/descriptorMetadata";
 import { type ItemDetails, type SubmitSpec } from "../../steam/jobs";
 import {
   hasListingFiles,
+  langDir,
+  parseLinksBlock,
   PREVIEWS_DIR,
   readDependencies,
   readItemJson,
+  readLinks,
   readPreviews,
+  stripLinksBlock,
   upsertItemJson,
+  withLinksBlock,
   writeDependencies,
+  writeLinks,
   writeListingFiles,
+  writePreviewOrder,
   writeVideos,
 } from "../../steam/workshopFiles";
 import { preflight } from "../../steam/preflight";
@@ -58,7 +65,7 @@ import { gameDocsSubdir } from "../../config";
 import { tabIcon } from "../tabIcons";
 import { bundleUri, watchBundle, webviewSource } from "../devReload";
 import { workshopHtml } from "./html";
-import type { AppToHost, HostToApp, ModChoice, WorkshopModInfo } from "./messages";
+import type { AppToHost, HostToApp, ModChoice, PullParts, WorkshopModInfo } from "./messages";
 
 export interface WorkshopPanelOptions {
   meta: GameMeta;
@@ -281,7 +288,13 @@ export class WorkshopPanel {
       previews: this.previewsInfo(workshopDir),
       dependencies: readDependencies(workshopDir),
       dependencyCandidates: this.dependencyCandidates(root),
+      links: readLinks(workshopDir),
     };
+  }
+
+  /** One line of the progress strip: the step list, the current one, and its percent. */
+  private progress(steps: string[], step: number, message: string, percent: number | null = null): void {
+    this.post({ type: "uploadState", busy: true, message, steps, step, percent });
   }
 
   private previewsInfo(workshopDir: string): WorkshopModInfo["previews"] {
@@ -383,8 +396,26 @@ export class WorkshopPanel {
         await this.pickPreview();
         return;
       case "pullListing":
-        await this.pullListing();
+        await this.pullListing(message.parts);
         return;
+      case "reorderPreviews": {
+        if (!root) return;
+        writePreviewOrder(
+          workshopDirFor(root, meta),
+          message.names.filter((n) => path.basename(n) === n)
+        );
+        await this.postInfo();
+        return;
+      }
+      case "setLinks": {
+        if (!root) return;
+        writeLinks(
+          workshopDirFor(root, meta),
+          message.links.map((l) => ({ label: String(l.label ?? ""), url: String(l.url ?? "") }))
+        );
+        await this.postInfo();
+        return;
+      }
       case "openListingFile":
         await this.openListingFile(message.lang);
         return;
@@ -499,7 +530,9 @@ export class WorkshopPanel {
       );
       return;
     }
-    const file = lang ? path.join(dir, lang, "description.bbcode") : path.join(dir, "description.bbcode");
+    const file = lang
+      ? path.join(langDir(dir, lang), "description.bbcode")
+      : path.join(dir, "description.bbcode");
     if (!fs.existsSync(file)) {
       // Seed a missing file with the draft the store holds, so nothing is lost.
       const info = readPublishInfo(root, meta, dir);
@@ -603,25 +636,30 @@ export class WorkshopPanel {
   }
 
   /**
-   * Download the live listing into the workshop folder: description.bbcode,
-   * one `<lang>/` folder per language whose text differs from the default
-   * (Steam serves the default as fallback for everything else), and item.json.
-   * The app confirms first - this REPLACES the folder's listing files.
+   * Download the chosen parts of the live listing into the workshop folder.
+   * Translations are written for every language whose text differs from the
+   * default (Steam serves the default as fallback for everything else). The
+   * app confirms first - this REPLACES the matching local files.
    */
-  private async pullListing(): Promise<void> {
+  private async pullListing(parts: PullParts): Promise<void> {
     const { meta, log } = this.options;
     const root = this.active;
     if (!root) return;
-    const itemId = readPublishInfo(root, meta)?.publishedId;
+    const info = readPublishInfo(root, meta);
+    const itemId = info?.publishedId;
     if (!itemId) {
       this.notify("The mod has no Workshop item to pull from.", "warn");
       return;
     }
     const dir = workshopDirFor(root, meta);
     if (!hasListingFiles(dir) && !(await this.confirmWorkshopDirPlacement(dir))) return;
-    this.post({ type: "uploadState", busy: true, message: "downloading the listing…" });
+    const steps = ["Ask Steam"];
+    if (parts.details || parts.description || parts.translations) steps.push("Text");
+    if (parts.previews || parts.thumbnail) steps.push("Images");
+    if (parts.requirements) steps.push("Requirements");
+    this.progress(steps, 0, "asking Steam…");
     try {
-      const languages = STEAM_LANGUAGES.map((l) => l.api);
+      const languages = parts.translations ? STEAM_LANGUAGES.map((l) => l.api) : [];
       const done = await runBridge(
         this.context,
         { action: "query", appId: meta.steamAppId, itemId, languages },
@@ -629,24 +667,90 @@ export class WorkshopPanel {
       );
       if (done.action !== "query" || !done.item) throw new Error("Steam returned no item details");
       const item = done.item;
-      const translations: Record<string, WorkshopTranslation> = {};
-      for (const [lang, t] of Object.entries(done.translations)) {
-        const title = t.title !== item.title ? t.title : "";
-        const description = t.description !== item.description ? t.description : "";
-        if (title === "" && description === "") continue;
-        translations[lang] = {
-          ...(title !== "" ? { title } : {}),
-          ...(description !== "" ? { description } : {}),
-        };
+      const wrote: string[] = [];
+
+      if (parts.details || parts.description || parts.translations) {
+        this.progress(steps, steps.indexOf("Text"), "writing text…");
       }
-      writeListingFiles(dir, { description: item.description, translations });
-      upsertItemJson(dir, { title: item.title, publishedfileid: item.itemId });
-      writeDependencies(dir, { apps: item.appDependencies, items: item.children });
-      // Type 1 = YouTube video. Images stay on Steam: pulling would download them.
-      const videos = item.additionalPreviews.filter((p) => p.type === 1).map((p) => p.urlOrVideoId);
-      if (videos.length) writeVideos(dir, videos);
-      const n = Object.keys(translations).length;
-      this.notify(`Wrote the description${n ? ` and ${n} translation(s)` : ""} to ${dir}.`);
+      if (parts.details) {
+        upsertItemJson(dir, {
+          title: item.title,
+          publishedfileid: item.itemId,
+          tags: item.tags,
+          visibility: item.visibility,
+        });
+        wrote.push("item.json");
+      }
+      if (parts.description || parts.translations) {
+        const current = readPublishInfo(root, meta, dir);
+        const translations: Record<string, WorkshopTranslation> = parts.translations
+          ? {}
+          : { ...(current?.translations ?? {}) };
+        if (parts.translations) {
+          for (const [lang, t] of Object.entries(done.translations)) {
+            const title = t.title !== item.title ? t.title : "";
+            const description = t.description !== item.description ? t.description : "";
+            if (title === "" && description === "") continue;
+            translations[lang] = {
+              ...(title !== "" ? { title } : {}),
+              ...(description !== "" ? { description } : {}),
+            };
+          }
+          wrote.push(`${Object.keys(translations).length} translation(s)`);
+        }
+        let description = current?.description ?? "";
+        if (parts.description) {
+          description = stripLinksBlock(item.description);
+          const links = parseLinksBlock(item.description);
+          if (links.length) writeLinks(dir, links);
+          wrote.push("description.bbcode");
+        }
+        writeListingFiles(dir, { description, translations });
+      }
+
+      if (parts.previews || parts.thumbnail)
+        this.progress(steps, steps.indexOf("Images"), "downloading images…");
+      if (parts.previews) {
+        const previewsDir = path.join(dir, PREVIEWS_DIR);
+        fs.mkdirSync(previewsDir, { recursive: true });
+        const images = item.additionalPreviews.filter((p) => p.type === 0);
+        const names: string[] = [];
+        for (let i = 0; i < images.length; i++) {
+          const p = images[i];
+          const ext = path.extname(p.originalFileName || new URL(p.urlOrVideoId).pathname) || ".png";
+          const base =
+            path.basename(p.originalFileName || "", ext) || `steam-${String(i + 1).padStart(2, "0")}`;
+          const name = `${base}${ext}`;
+          this.progress(
+            steps,
+            steps.indexOf("Images"),
+            `downloading ${name}…`,
+            Math.round((i / images.length) * 100)
+          );
+          fs.writeFileSync(path.join(previewsDir, name), await download(p.urlOrVideoId));
+          names.push(name);
+        }
+        if (names.length) writePreviewOrder(dir, names);
+        writeVideos(
+          dir,
+          item.additionalPreviews.filter((p) => p.type === 1).map((p) => p.urlOrVideoId)
+        );
+        wrote.push(`${names.length} preview image(s)`);
+      }
+      if (parts.thumbnail && item.previewUrl) {
+        const target = info?.previewPath ?? path.join(root, "thumbnail.png");
+        fs.writeFileSync(target, await download(item.previewUrl));
+        wrote.push(path.basename(target));
+      }
+
+      if (parts.requirements) {
+        this.progress(steps, steps.indexOf("Requirements"), "writing requirements…");
+        writeDependencies(dir, { apps: item.appDependencies, items: item.children });
+        wrote.push("dependencies.json");
+      }
+      this.notify(
+        wrote.length ? `Wrote ${wrote.join(", ")} to ${dir}.` : "Nothing was selected to download."
+      );
     } catch (e) {
       this.notifyError(`Pulling the listing failed - ${friendlyError(e, meta)}`, e);
     } finally {
@@ -695,13 +799,19 @@ export class WorkshopPanel {
     // The app's upload modal already confirmed (incl. the new-item case).
     let itemId = info.publishedId;
     this.uploading = true;
-    this.post({ type: "uploadState", busy: true, message: "starting…" });
+    const steps: string[] = [];
+    if (!itemId) steps.push("Create item");
+    if (message.content) steps.push("Mod files");
+    if (message.details) steps.push("Details");
+    if (message.languages.length) steps.push("Translations");
+    const stepOf = (name: string): number => Math.max(0, steps.indexOf(name));
+    this.progress(steps, 0, "starting…");
     let staging: string | null = null;
     try {
       let needsAgreement = false;
       const createdNow = !itemId;
       if (!itemId) {
-        this.post({ type: "uploadState", busy: true, message: "creating the Workshop item…" });
+        this.progress(steps, stepOf("Create item"), "creating the Workshop item…");
         const created = await runBridge(this.context, { action: "create", appId: meta.steamAppId }, log);
         if (created.action !== "create") throw new Error("unexpected bridge reply");
         itemId = created.itemId;
@@ -717,6 +827,7 @@ export class WorkshopPanel {
       const wsDir = workshopDirFor(root, meta);
       const previews = message.details ? readPreviews(wsDir) : null;
       const deps = message.details ? readDependencies(wsDir) : null;
+      if (deps) steps.push("Requirements");
       const liveItem = !createdNow && (previews || deps) ? await this.queryItem(itemId) : null;
 
       const submits: SubmitSpec[] = [];
@@ -750,7 +861,7 @@ export class WorkshopPanel {
             main.removePreviewIndexes = Array.from({ length: count }, (_, i) => i);
           }
           main.title = info.name ?? undefined;
-          main.description = info.description ?? undefined;
+          main.description = withLinksBlock(info.description ?? "", readLinks(wsDir));
           if (info.tags.length) main.tags = info.tags;
           if (message.visibility !== null) main.visibility = message.visibility;
           const preview = info.previewPath;
@@ -765,7 +876,7 @@ export class WorkshopPanel {
           }
         }
         if (message.content) {
-          this.post({ type: "uploadState", busy: true, message: "preparing files…" });
+          this.progress(steps, stepOf("Mod files"), "preparing files…");
           if (ensurePxIgnore(root)) this.explainPxIgnore(root);
           staging = makeStagingDir();
           stageContent(root, staging, [workshopDirFor(root, meta)]);
@@ -789,9 +900,13 @@ export class WorkshopPanel {
         { action: "publish", appId: meta.steamAppId, itemId, submits },
         log,
         (status, uploaded, total, submit, count) => {
-          const pct = total > 0 ? ` (${Math.round((uploaded / total) * 100)}%)` : "";
-          const step = count > 1 ? ` - step ${submit}/${count}` : "";
-          this.post({ type: "uploadState", busy: true, message: `${status.toLowerCase()}${pct}${step}` });
+          // Submit 1 carries files and details; the rest are one language each.
+          const onFiles = submit === 1 && message.content && /content/i.test(status);
+          const name =
+            submit > 1 ? "Translations" : onFiles ? "Mod files" : message.details ? "Details" : "Mod files";
+          const pct = total > 0 ? Math.round((uploaded / total) * 100) : null;
+          const step = count > 1 && submit > 1 ? ` (${submit - 1}/${count - 1})` : "";
+          this.progress(steps, stepOf(name), `${status.toLowerCase()}${step}`, pct);
         }
       );
       if (done.action !== "publish") throw new Error("unexpected bridge reply");
@@ -816,7 +931,7 @@ export class WorkshopPanel {
           removeItems: liveItems.filter((i) => !deps.items.includes(i)),
         };
         if (job.addApps.length || job.removeApps.length || job.addItems.length || job.removeItems.length) {
-          this.post({ type: "uploadState", busy: true, message: "updating requirements…" });
+          this.progress(steps, stepOf("Requirements"), "updating requirements…");
           await runBridge(this.context, job, log);
           log(`workshop: requirements of ${itemId} updated`);
         }
@@ -843,6 +958,13 @@ export class WorkshopPanel {
       this.post({ type: "uploadState", busy: false });
     }
   }
+}
+
+/** One http(s) resource as bytes; Steam serves preview images from its CDN. */
+async function download(url: string): Promise<Buffer> {
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`download of ${url} failed: HTTP ${res.status}`);
+  return Buffer.from(await res.arrayBuffer());
 }
 
 /**

--- a/packages/vscode/test/workshopFiles.test.ts
+++ b/packages/vscode/test/workshopFiles.test.ts
@@ -13,6 +13,12 @@ import {
   mdToBBCode,
   readItemJson,
   moveListing,
+  parseLinksBlock,
+  readLinks,
+  stripLinksBlock,
+  withLinksBlock,
+  writeLinks,
+  writePreviewOrder,
   readDependencies,
   readListingFiles,
   readPreviews,
@@ -71,8 +77,8 @@ describe("listing files", () => {
       },
     });
     expect(fs.readFileSync(path.join(dir, "description.bbcode"), "utf8")).toBe("[h1]Hello[/h1]");
-    expect(fs.readFileSync(path.join(dir, "german", "title.txt"), "utf8")).toBe("Hallo\n");
-    expect(fs.existsSync(path.join(dir, "french", "title.txt"))).toBe(false);
+    expect(fs.readFileSync(path.join(dir, "translations", "german", "title.txt"), "utf8")).toBe("Hallo\n");
+    expect(fs.existsSync(path.join(dir, "translations", "french", "title.txt"))).toBe(false);
 
     const back = readListingFiles(dir);
     expect(back.description).toBe("[h1]Hello[/h1]");
@@ -87,7 +93,7 @@ describe("listing files", () => {
       translations: { german: { title: "Hallo", description: "x" } },
     });
     writeListingFiles(dir, { description: "d", translations: {} });
-    expect(fs.existsSync(path.join(dir, "german"))).toBe(false);
+    expect(fs.existsSync(path.join(dir, "translations", "german"))).toBe(false);
     expect(hasListingFiles(dir)).toBe(true);
   });
 
@@ -96,6 +102,63 @@ describe("listing files", () => {
     fs.writeFileSync(path.join(dir, "item.json"), JSON.stringify({ custom: 1, title: "Old" }), "utf8");
     upsertItemJson(dir, { title: "New", publishedfileid: "42" });
     expect(readItemJson(dir)).toEqual({ custom: 1, title: "New", publishedfileid: "42" });
+  });
+});
+
+describe("translations folder", () => {
+  it("writes languages under translations/ and clears the pre-0.4.0 root folder", () => {
+    const dir = tmp();
+    fs.mkdirSync(path.join(dir, "german"));
+    fs.writeFileSync(path.join(dir, "german", "title.txt"), "Alt\n");
+    expect(readListingFiles(dir).translations.german).toEqual({ title: "Alt" });
+    writeListingFiles(dir, { description: "d", translations: { german: { title: "Neu" } } });
+    expect(fs.existsSync(path.join(dir, "german"))).toBe(false);
+    expect(fs.readFileSync(path.join(dir, "translations", "german", "title.txt"), "utf8")).toBe("Neu\n");
+    expect(readListingFiles(dir).translations.german).toEqual({ title: "Neu" });
+  });
+});
+
+describe("preview order and links", () => {
+  it("orders previews by order.txt, then by name", () => {
+    const dir = tmp();
+    const previews = path.join(dir, "previews");
+    fs.mkdirSync(previews);
+    for (const f of ["a.png", "b.png", "c.png"]) fs.writeFileSync(path.join(previews, f), "");
+    writePreviewOrder(dir, ["c.png", "a.png", "gone.png"]);
+    expect(readPreviews(dir)!.images.map((p) => path.basename(p))).toEqual(["c.png", "a.png", "b.png"]);
+  });
+
+  it("renders links as a trailing block and takes it apart again", () => {
+    const links = [
+      { label: "Discord", url: "https://discord.gg/x" },
+      { label: "", url: "https://example.com" },
+      { label: "bad", url: "javascript:alert(1)" },
+    ];
+    const text = withLinksBlock("Hello [b]there[/b]", links);
+    expect(text).toBe(
+      "Hello [b]there[/b]\n\n[h2]Links[/h2]\n[list]\n[*] [url=https://discord.gg/x]Discord[/url]\n[*] [url=https://example.com]https://example.com[/url]\n[/list]"
+    );
+    expect(stripLinksBlock(text)).toBe("Hello [b]there[/b]");
+    expect(parseLinksBlock(text)).toEqual([
+      { label: "Discord", url: "https://discord.gg/x" },
+      { label: "https://example.com", url: "https://example.com" },
+    ]);
+    // Replacing keeps one block, and an author's own [h2]Links[/h2] mid-text is left alone.
+    expect(withLinksBlock(text, [links[0]]).match(/\[h2\]Links\[\/h2\]/g)).toHaveLength(1);
+    expect(stripLinksBlock("[h2]Links[/h2]\nsee below\n[b]x[/b]")).toBe(
+      "[h2]Links[/h2]\nsee below\n[b]x[/b]"
+    );
+  });
+
+  it("round-trips links.json and drops non-http urls", () => {
+    const dir = tmp();
+    writeLinks(dir, [
+      { label: "a", url: "https://a" },
+      { label: "b", url: "ftp://b" },
+    ]);
+    expect(readLinks(dir)).toEqual([{ label: "a", url: "https://a" }]);
+    writeLinks(dir, []);
+    expect(fs.existsSync(path.join(dir, "links.json"))).toBe(false);
   });
 });
 


### PR DESCRIPTION
Stacked on #41 (base: feat/in-mod-layout).

- **Layout**: two columns of cards. Item + Publish, then Previews + Requirements, then Links; Description and Translations full width below. Statistics fold into the Item card.
- **Progress**: a step strip under the toolbar names every stage of an upload or download (Create item, Mod files, Details, Translations, Requirements / Ask Steam, Text, Images, Requirements) with a percent bar for the one in flight.
- **Download picks its parts**: details (item.json now carries tags and visibility), description, translations, previews (gallery images downloaded, videos.txt, order.txt), requirements, the main preview image. Default all on.
- **Previews** reorder by drag and drop, saved to previews/order.txt.
- **Links**: Steam has no link field. links.json renders as a trailing `[h2]Links[/h2]` block on upload and is parsed back out on download; an author's own mid-text heading is left alone.
- **translations/<lang>/** replaces root language folders; old ones are read as fallback and cleared on the next save.

Checks: tsc, lint, boundary, workshopFiles/pxignore/preflight suites (43 tests).
Needs a live pass: upload with links, download with previews.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Improve the Workshop panel with a responsive layout, clearer operation progress, richer listing file management, and more selective synchronization with Steam.

New Features:
- Add a responsive two-column Workshop panel with organized cards, full-width description and translations, and integrated statistics.
- Show named upload and download progress steps with status and percentage feedback.
- Allow downloads to selectively retrieve listing details, text, translations, previews, requirements, and the main preview image.
- Support drag-and-drop preview ordering persisted in the workshop files.
- Add editable links stored locally and synchronized with a trailing Links block in uploaded descriptions.

Bug Fixes:
- Preserve compatibility with legacy root-level translation folders while migrating them to the new layout on save.
- Prevent author-authored mid-description Links headings from being mistaken for generated link blocks.

Enhancements:
- Store item tags and visibility in item.json and download gallery images alongside video metadata.
- Move translations into translations/<language>/ and add order metadata for previews.

Documentation:
- Update Workshop panel changelog and help content for the new layout, selectable downloads, links, previews, and translation storage.

Tests:
- Add coverage for translation migration, preview ordering, links round-tripping, and URL filtering.