### PR TITLE
Event graph: connected-only pruning, on by default

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,152 +1,120 @@
-# AGENTS.md — the one guide for AI agents working in this repo
+# AGENTS.md
 
-This is the single source of agent-facing truth. `CLAUDE.md` is just
-`@AGENTS.md`, so every agent tool loads the same file. Long procedures live
-in the documents this file links; everything else agent-relevant is here.
+Agent-facing guide for this repo. `CLAUDE.md` is `@AGENTS.md`.
 
 ## What this project is
 
 The **Paradox Modding Toolkit** (`JDeffner.px-toolkit`): a VS Code extension
-plus a standalone LSP server (`@px-lsp/server`) that give Paradox/Jomini
-script modders a full language workbench across Crusader Kings III,
-Victoria 3 and Europa Universalis V. Hand-written tolerant parser,
-scope-aware completion, hover docs, diagnostics for the silent-failure class
-of bugs, ck3-tiger integration, event graph, GUI editor with a
-pixel-calibrated layout engine, DDS tooling, localization workflow. The
-server also serves bare LSP clients (neovim) and an external WPF IDE
-(Sage's Clausewitz Studio).
+plus a standalone LSP server (`@px-lsp/server`) for Paradox/Jomini script
+modding across Crusader Kings III, Victoria 3 and Europa Universalis V.
+Tolerant parser, scope-aware completion, hover docs, structural diagnostics,
+ck3-tiger integration, event graph, GUI editor with a pixel-calibrated layout
+engine, DDS tooling, localization workflow. The server also serves bare LSP
+clients (neovim) and an external WPF IDE (Sage's Clausewitz Studio, owned by
+lennart99v).
 
-**The one design idea that explains most decisions:** all language knowledge
-is *derived from the game itself* — the user's `script_docs` logs, the
-vanilla files, harvested `_*.info` schema docs, real-corpus usage counts —
-never hand-maintained rule files (that is what killed CWTools' CK3 support).
+**Core design idea:** all language knowledge is *derived from the game
+itself* (the user's `script_docs` logs, vanilla files, harvested `_*.info`
+docs, real-corpus usage counts), never hand-maintained rule files.
 
-## How these rules bind
+Terms: **mod** = user content package; **vanilla** = shipped game files,
+indexed read-only, never diagnosed; **`gameId`** = `ck3`/`vic3`/`eu5`, one
+per workspace; **GameProfile** = the boundary behind which ALL game-specific
+knowledge lives (`packages/server/src/games/<id>/`); **schema** = per-game
+folder-to-definition-kind table; **harvest** = build-time script output in
+`data/<id>/*.json`; **tiger** = ck3-tiger/vic3-tiger; **loc** = Paradox
+localization (`*_l_<lang>.yml`, UTF-8 with BOM).
 
-Most of this file is good defaults, and Joel's stated preference in the
-session overrides them. Two sections are hard rules with no override:
-"The ways to hurt yourself" and the invariants list. If a rule here fights
-the task in front of you, say so loudly and get Joel's sign-off instead of
-quietly breaking it.
+## Hard rules (no override; if a task fights one, stop and ask Joel)
 
-## Glossary
+1. **Never commit or push to `main`.** `main` = one squash commit per PR,
+   created only by Joel. Check your branch before the first edit; never use
+   a worktree with `main` checked out. Old release recipes that push `main`
+   directly are superseded.
+2. **Never hand-code game knowledge from memory.** Find it in the game
+   install, the `_*.info` docs, a `script_docs` dump or a harvest, or don't
+   add it.
+3. **No Studio-origin content in a commit.** `docs/reference/studio/`
+   (gitignored) is C# for human consultation only. Nothing from it may be
+   translated, ported or committed into this GPL repo; GUI parity is a
+   spec-driven rebuild from `docs/gui-designer/parity-checklist.md` with a
+   design-credit header (see `gui/sourceEdit*`).
+4. **No machine paths in tracked files.** They live in `dev-paths.json`
+   (gitignored) or env vars.
 
-- **mod**: a user's content package for a Paradox game; what our users edit.
-- **vanilla**: the shipped game files; indexed read-only, never diagnosed.
-- **game / `gameId`**: `ck3`, `vic3` or `eu5`; one active game per workspace.
-- **GameProfile**: the boundary behind which ALL game-specific knowledge
-  lives (`packages/server/src/games/<id>/`).
-- **definition / reference**: an indexed name's declaration site / use site.
-- **schema**: the per-game folder-to-definition-kind table driving indexing.
-- **harvest**: a build-time script output bundled as `data/<id>/*.json`.
-- **tiger**: ck3-tiger/vic3-tiger, the external deep validator we integrate.
-- **loc**: Paradox localization (`*_l_<lang>.yml`, UTF-8 with BOM).
-- **the Studio**: Sage's Clausewitz Studio, an external C# consumer of the
-  server over stdio; owned by lennart99v, not by Joel.
-
-## The ways to hurt yourself (hard rules, each learned the expensive way)
-
-1. **Committing or pushing to `main`.** `main` is the public face: one
-   squash commit per landed change, created ONLY by Joel squash-merging a
-   PR. The whole 0.3.1 cycle was once committed straight onto `main` (11
-   commits, 103 files) and recovering it needed a public-history rewrite.
-   Check your branch before the first edit; never work in a worktree with
-   `main` checked out; never push to `main` in any form. Old release
-   recipes that push `main` directly (the `read-tree` cut in older docs)
-   are superseded — do not run them.
-2. **Hand-coding game knowledge from memory.** A trigger name, folder
-   layout or loc rule written from recall is how rule files rot. Find it
-   in the game install, the `_*.info` docs, a `script_docs` dump or a
-   harvest — or don't add it.
-3. **Letting Studio-origin content into a commit.** `docs/reference/studio/`
-   (gitignored) holds C# from the Studio repo for HUMAN consultation only.
-   Nothing from it may be translated, ported or committed into this GPL
-   repo; the accepted route is a spec-driven rebuild from checklists and
-   fixtures (see `docs/gui-designer/parity-checklist.md`), with a
-   design-credit header, which is what `gui/sourceEdit*` already carries.
-4. **Machine paths in tracked files.** Personal paths live in
-   `dev-paths.json` (gitignored) or env vars, nowhere else.
-
-## Non-negotiable invariants
+## Invariants
 
 - **AD-5 "annotate, never hide":** scope inference ranks and labels
   completion items but emits zero diagnostics and never removes an item for
-  scope reasons. (Server-side word-filtering/capping is fine — it mirrors
-  what the client drops anyway.)
-- **PX names the product, `ck3` names the game.** Everything we invent is
-  `px`: extension id `px-toolkit`, `px.*` settings and commands, `@px-lsp/*`
-  packages, `# px:ignore`. Everything belonging to the game stays `ck3`:
+  scope reasons. (Server-side word-filtering/capping is fine.)
+- **`px` names the product, `ck3` names the game.** Ours: `px-toolkit`,
+  `px.*` settings/commands, `@px-lsp/*`, `# px:ignore`. The game's:
   `gameId`, `games/ck3/`, `data/ck3/`, `ck3-tiger`, `ck3-script`,
   `.ck3modding/`, `zzz_ck3_modding_edits_*.yml`. The `paradox*` language ids
-  and `paradox/*` wire methods mean "the engine family" — do NOT rename
-  them to `px`.
-- **Deep validation belongs to ck3-tiger,** not us. Our own diagnostics stay
-  structural and certain (braces, encodings, folder traps).
-- **The games fail silently.** Every writer must produce files correct by
+  and `paradox/*` wire methods mean "the engine family"; do NOT rename them.
+- **Deep validation belongs to ck3-tiger.** Our diagnostics stay structural
+  and certain (braces, encodings, folder traps).
+- **The games fail silently**, so every writer produces files correct by
   construction: loc yml = UTF-8 **with BOM** + `l_<lang>:` header +
   `_l_<lang>.yml` filename; script `.txt` = UTF-8 with BOM; event files
   START with their `namespace =` line.
-- **`localization/replace/` is only for overriding vanilla keys.** New keys
-  go to the mod loc file holding their siblings (`writeLocSmart` /
+- **`localization/replace/` only overrides vanilla keys.** New keys go to
+  the mod loc file holding their siblings (`writeLocSmart` /
   `upsertNewModLoc` in `packages/vscode/src/locCommands.ts`).
-- **Override rules:** script databases are last-in-wins (LIOS), `gui/` and
-  `localization/replace` are first-in-wins (FIOS).
+- **Override rules:** script databases are last-in-wins, `gui/` and
+  `localization/replace` are first-in-wins.
 - **No `vscode` imports** in `packages/server` or `packages/protocol`
-  modules that carry logic — they must be unit-testable in plain Node.
+  modules that carry logic; they must be unit-testable in plain Node.
 - The parse cache (`packages/server/src/parseCache.ts`) is keyed by
-  **uri + version**. In tests and scripts, use a fresh URI per document text
-  or you get a stale parse (this has bitten twice).
+  **uri + version**. In tests and scripts, use a fresh URI per document
+  text or you get a stale parse.
 
-## The hit-every-surface checklist
+## Hit-every-surface checklist
 
-The most common defect class here is a change that works on the path you
-tested and is missing everywhere else. Before calling work done, walk these
-axes and say which applied:
+The most common defect: a change that works on the path you tested and is
+missing everywhere else. Before calling work done, walk these and say which
+applied:
 
 | Axis | Question |
 |---|---|
-| Games | One decision per GameProfile (`ck3`, `vic3`, `eu5`), even if the decision is "not supported here" (gate on profile data, not on `if (gameId === ...)` — the boundary check enforces it). |
-| Clients | VS Code is the rich client; bare LSP clients (neovim) and the Studio get degraded-but-honest behavior via capability gates (`clientCommands`, `snippetSupport`, `fileLinks`), never broken markup or dead links. |
-| Entry points | A feature reachable from one place usually also needs: command palette entry, Project-panel row, keybinding (`when`-scoped), walkthrough mention. |
-| Contracts | Anything crossing the wire is typed in `packages/protocol` and documented in `docs/PROTOCOL.md`; embedder-visible behavior also in `docs/EMBEDDING.md`. Changing either doc means porting it to its wiki mirror in the same session. |
-| Data | Per-game bundled data lives in `data/<id>/`; a new harvest needs its regen script row below and a `--game` flag. |
-| Change notes | The changelog bullet ships in the same PR (see "Landing work"). |
+| Games | One decision per GameProfile (`ck3`, `vic3`, `eu5`), even "not supported". Gate on profile data, not `if (gameId === ...)`; the boundary check enforces it. |
+| Clients | VS Code is the rich client; bare LSP clients and the Studio get degraded-but-honest behavior via capability gates (`clientCommands`, `snippetSupport`, `fileLinks`), never broken markup or dead links. |
+| Entry points | A feature usually also needs: command palette entry, Project-panel row, `when`-scoped keybinding, walkthrough mention. |
+| Contracts | Anything on the wire is typed in `packages/protocol` and documented in `docs/PROTOCOL.md`; embedder-visible behavior also in `docs/EMBEDDING.md`. Changing either doc means porting it to its wiki mirror in the same session. |
+| Data | Per-game bundled data lives in `data/<id>/`; a new harvest needs a regen script row below and a `--game` flag. |
+| Change notes | The changelog bullet ships in the same PR. |
 
 ## Repo map
 
 | Path | What lives there |
 |---|---|
 | `packages/vscode/src/` | Extension host: language-mode switching, tiger runner + download, views, webview panels (`webviews/`), DDS editor/converter, loc commands, scaffolds, setup |
-| `packages/server/src/` | The LSP server (`@px-lsp/server`). `parser/` (tolerant CST, encoding), `index/`, `features/`, `scopes/`, `overview/`, `gui/` (layout engine + source writer), `schema/`, `games/<id>/` (the GameProfile boundary) |
-| `packages/protocol/src/` | `@px-lsp/protocol`: wire protocol, shared types/constants, translation core, suppression, tiger report parser, descriptorMod, fsWalk. One subpath export per module; no barrel |
-| `packages/server/data/<id>/` | Bundled harvested data per game (`freqs.json`, `structures.json`, `guiSchema.json`, `wikidocs/` with its ATTRIBUTION.md). JSON-imported, inlined into the server bundle |
-| `packages/*/test/` | Vitest suites, package-local. The bulk in `packages/server/test`: `vscodeFuzzy.ts` = faithful port of VS Code's suggest scoring; `rankEvalCore.ts` = ranking eval; `lspSmoke.test.ts` forks the real bundle over node IPC |
+| `packages/server/src/` | The LSP server. `parser/` (tolerant CST, encoding), `index/`, `features/`, `scopes/`, `overview/`, `gui/` (layout engine + source writer), `schema/`, `games/<id>/` |
+| `packages/protocol/src/` | Wire protocol, shared types/constants, translation core, suppression, tiger report parser, descriptorMod, fsWalk. One subpath export per module; no barrel |
+| `packages/server/data/<id>/` | Bundled harvested data per game (`freqs.json`, `structures.json`, `guiSchema.json`, `wikidocs/` + ATTRIBUTION.md). Inlined into the server bundle |
+| `packages/*/test/` | Vitest suites. `vscodeFuzzy.ts` = port of VS Code's suggest scoring; `rankEvalCore.ts` = ranking eval; `lspSmoke.test.ts` forks the real bundle over node IPC |
 | `scripts/` | Build-time harvests, evals, packaging (`package-test.mjs`), brand generation |
-| `packages/vscode/media/` | Icon, walkthrough pages, banner, `image-guidelines.md`. `media/` SHIPS in the vsix; `docs/` does NOT |
-| `packages/vscode/skills/ck3-modding/` | An agent skill for CK3 modding itself (not the extension). Machine-agnostic placeholders; excluded from the vsix |
-| `packages/vscode/syntaxes/` | TextMate grammars (`paradox`, per-game wrappers, `paradox-loc`, `paradox-info`, `paradox-mod`, `paradox-gui`) |
-| `docs/` | Tracked: `diagnostics/` (per-code explanations), `gui-designer/` (calibration evidence + editor ledgers, see its README), `release/` (per-release notes, read by release.yml), `PROTOCOL.md`, `EMBEDDING.md`, `PERFORMANCE.md`, `deferred-features.md`, `RELEASING.md` (the release runbook), `file-icons.md`, `webviews.md` (the webview-panel pattern; CONTRIBUTING.md points contributors at it). Everything else under `docs/` is gitignored — and should not exist: working notes do not belong in the repo (see "Work artifacts") |
+| `packages/vscode/media/` | Icon, walkthrough pages, banner, `image-guidelines.md`. `media/` ships in the vsix; `docs/` does not |
+| `packages/vscode/skills/ck3-modding/` | Agent skill for CK3 modding itself. Machine-agnostic; excluded from the vsix |
+| `packages/vscode/syntaxes/` | TextMate grammars |
+| `docs/` | Tracked: `diagnostics/`, `gui-designer/`, `release/` (read by release.yml), `PROTOCOL.md`, `EMBEDDING.md`, `PERFORMANCE.md`, `deferred-features.md`, `RELEASING.md`, `file-icons.md`, `webviews.md`. Everything else under `docs/` is gitignored and should not exist |
 
-Feature routing (most-touched files): completion ranking →
-`packages/server/src/features/completion.ts`; context detection →
-`packages/server/src/context.ts` + `contextKeywords.ts`; gui language →
+Feature routing: completion ranking → `packages/server/src/features/completion.ts`;
+context detection → `context.ts` + `contextKeywords.ts`; gui language →
 `features/guiLanguage.ts`; `[ ... ]` datafunctions → `features/datafunction.ts`
 + `data/dataTypes.ts` + `data/dataFnUsage.ts` + `data/dataFnDocs.ts`;
-gui layout engine → `packages/server/src/gui/layoutEngine.ts` + `guiDefs.ts`
-(rules measured in `docs/gui-designer/spec.md`, fixtures in
-`packages/server/test/guiLayout.test.ts`); gui source writer →
-`gui/sourceEdit*.ts` (contract: `docs/gui-designer/parity-checklist.md`);
-descriptor.mod → `packages/vscode/src/descriptorMod.ts` +
-`packages/protocol/src/descriptorMod.ts`; event graph →
-`packages/server/src/overview/eventGraph.ts` + `eventDetail.ts` +
+gui layout engine → `gui/layoutEngine.ts` + `guiDefs.ts` (rules in
+`docs/gui-designer/spec.md`, fixtures in `test/guiLayout.test.ts`); gui
+source writer → `gui/sourceEdit*.ts` (contract:
+`docs/gui-designer/parity-checklist.md`); descriptor.mod →
+`packages/vscode/src/descriptorMod.ts` + `packages/protocol/src/descriptorMod.ts`;
+event graph → `overview/eventGraph.ts` + `eventDetail.ts` +
 `packages/vscode/src/webviews/eventGraph/panel.ts`; DDS →
 `packages/server/src/dds/` + `packages/vscode/src/ddsEditor.ts`.
 
 ## Local machine paths (dev-paths.json)
 
-Machine-specific paths (game folder, logs, your mod, eval corpus, tiger
-binary) live in ONE place: `dev-paths.json` at the repo root, gitignored —
-copy `dev-paths.example.json`. Slots are per game:
+`dev-paths.json` at the repo root (gitignored; copy `dev-paths.example.json`):
 
 ```json
 { "games": { "ck3": { "gamePath": "…", "logsPath": "…", "modPath": "…",
@@ -154,15 +122,12 @@ copy `dev-paths.example.json`. Slots are per game:
              "vic3": { "gamePath": "…" } } }
 ```
 
-Env vars override per game and key: `PX_<GAMEID>_GAME_PATH`,
-`PX_<GAMEID>_LOGS_PATH`, `PX_<GAMEID>_MOD_PATH`, `PX_<GAMEID>_MOD_CORPUS`,
-`PX_<GAMEID>_TIGER_PATH`. Loader: `scripts/devPaths.ts`; accessors default
-to `ck3`; the old flat shape and `CK3_*` names keep working for ck3.
-Corpus-gated tests skip when a path is unset. (The shipped extension reads
-none of this; runtime paths come from VS Code settings with auto-inference.)
+Env overrides: `PX_<GAMEID>_GAME_PATH`, `_LOGS_PATH`, `_MOD_PATH`,
+`_MOD_CORPUS`, `_TIGER_PATH`. Loader: `scripts/devPaths.ts`. Corpus-gated
+tests skip when a path is unset. The shipped extension reads none of this.
 
-The base game files are THE source of truth for script syntax. Never guess
-names; grep the game folder or the `_*.info` docs.
+The base game files are THE source of truth for script syntax. Grep the game
+folder or the `_*.info` docs; never guess names.
 
 ## Build, test, verify
 
@@ -172,118 +137,95 @@ pnpm run compile        # server bundle + extension bundle + data copy
 npx tsc --noEmit        # typecheck (esbuild does not check types)
 pnpm run lint           # eslint + prettier --check (both gate CI)
 npx vitest run          # suite (corpus-gated tests skip without dev-paths)
+node scripts/check-game-boundary.mjs   # run whenever you touch packages/server/src
 ```
 
-- Scope verification to what you changed: the tests you touched plus
-  typecheck and lint. The full corpus-gated suite (needs `gamePath` +
-  `modCorpus`) is for cross-cutting changes; rank-eval alone takes ~4 min.
-- Two corpus **timing** tests can fail under full-suite load and pass in
-  isolation; re-run them alone before believing a red full run.
+- Verify what you changed: touched tests + typecheck + lint. The full
+  corpus-gated suite is for cross-cutting changes (rank-eval alone ~4 min).
+- Two corpus timing tests can fail under full-suite load; re-run them alone
+  before believing a red run.
 - Completion changes MUST be justified with `fuzzy-diag`/`rank-eval`
-  numbers, not vibes; run them BEFORE and AFTER.
-- Cross-cutting refactors are gated on CK3 rank-eval staying
-  byte-identical and CK3 `freqs.json` regenerating byte-identical.
-- Protocol additions extend `lspSmoke.test.ts` (the headless stand-in for a
-  live VS Code pass). Scaffold/writer changes get validated against real
-  ck3-tiger on a scratch mod.
-- `node scripts/check-game-boundary.mjs` guards the GameProfile boundary;
-  run it whenever you touch `packages/server/src`.
+  numbers, run BEFORE and AFTER.
+- Cross-cutting refactors are gated on CK3 rank-eval staying byte-identical
+  and CK3 `freqs.json` regenerating byte-identical.
+- Protocol additions extend `lspSmoke.test.ts`. Scaffold/writer changes get
+  validated against real ck3-tiger on a scratch mod.
 
-**Test builds are part of finishing extension work.** When a change alters
-what the editor does, end with:
+**Test builds finish extension work.** When a change alters what the editor
+does, end with:
 
 ```bash
 pnpm run package:test   # compile, vsce package, code --install-extension --force
 ```
 
-then tell Joel it is installed and VS Code needs a reload
-(`Developer: Reload Window`). Skip only for changes with nothing to try in
-the editor (docs, CI, tests alone), and say so. Never commit a vsix.
+then tell Joel it is installed and VS Code needs `Developer: Reload Window`.
+Skip only for changes with nothing to try in the editor, and say so. Never
+commit a vsix.
 
-## Landing work: branches, PRs, and change notes
+## Landing work
 
 1. **Branch first** (`feat/`, `fix/`, `docs/`, `chore/`), never from a
-   `main` checkout. Granular commits belong on the branch; commit messages
-   explain the WHY, with measured numbers where they exist.
-2. **A feature or fix PR writes changelog bullets, and nothing else.** One
-   bullet under "Unreleased" at the top of `packages/vscode/CHANGELOG.md`;
-   server or protocol changes also get a bullet in that package's own
-   `CHANGELOG.md` (they version independently — see below). Do NOT touch
+   `main` checkout. Commit messages explain the WHY, with measured numbers.
+2. **A feature or fix PR writes changelog bullets, nothing else.** One bullet
+   under "Unreleased" in `packages/vscode/CHANGELOG.md`; server or protocol
+   changes also get one in that package's own `CHANGELOG.md`. Do NOT touch
    release notes, README feature lists or the wiki from a feature PR.
-3. Push the branch and open the PR:
+3. Push and open the PR:
    ```bash
    git push -u origin <branch>
    gh pr create --base main --title "<title>" --body "<why, with numbers>"
    ```
-   Multi-PR effort for one release may target an `integration/<version>`
-   branch instead; that branch then PRs into `main`.
-4. **Stop there and hand Joel the PR link.** The squash merge into `main`
-   is Joel's call, and his alone.
-5. Sourcery reviews every PR next to CI (`gh pr checks <n>` shows both). A
-   finding is a pointer to a site, not a verdict: verify against source,
-   fix what is real, dismiss false positives with a written reason. With
-   stacked PRs, fix a finding on the branch the file belongs to, then merge
-   upward.
+   Multi-PR efforts may target an `integration/<version>` branch.
+4. **Stop and hand Joel the PR link.** The squash merge is his call.
+5. Sourcery reviews every PR (`gh pr checks <n>`). A finding is a pointer,
+   not a verdict: verify, fix what is real, dismiss false positives with a
+   written reason. With stacked PRs, fix on the branch the file belongs to.
 
-**The release PR writes everything else.** Cutting version `<v>`:
+**The release PR writes everything else.** Cutting `<v>`:
 
-- Roll the "Unreleased" sections into `<v>` headings; check
-  `git log v<prev>..HEAD` against the changelog for anything missed.
-- Write `docs/release/<v>.md` — mostly a curated paste of the Unreleased
-  bullets. release.yml uses it as the GitHub Release body and the Discord
-  announcement; a missing file falls back to a generated commit list
-  (0.3.2 shipped that way; do not repeat it).
-- Sweep the user-facing story ONLY if user-visible features changed:
-  `packages/vscode/README.md` (the Marketplace listing) Highlights and the
-  root README's short list.
-- Versioning is NOT lockstep: `packages/vscode` + root `package.json` carry
-  the release version and bump every release; `packages/server` and
-  `packages/protocol` bump only when they changed. The tag must match
-  `packages/vscode/package.json` (v0.1.3 was once tagged on a 0.1.2
-  manifest). Never pass `--pre-release` to vsce.
-- The full runbook (artifacts, tarball/zip smokes, Marketplace, npm) is
-  `docs/RELEASING.md`.
+- Roll "Unreleased" into `<v>` headings; check `git log v<prev>..HEAD`
+  against the changelog.
+- Write `docs/release/<v>.md` (curated Unreleased bullets). release.yml uses
+  it as the GitHub Release body and Discord announcement; a missing file
+  falls back to a generated commit list.
+- Sweep `packages/vscode/README.md` Highlights and the root README only if
+  user-visible features changed.
+- Versioning is NOT lockstep: `packages/vscode` + root `package.json` bump
+  every release; `packages/server` and `packages/protocol` bump only when
+  changed. The tag must match `packages/vscode/package.json`. Never pass
+  `--pre-release` to vsce.
+- Full runbook: `docs/RELEASING.md`.
 
-**Wiki mirrors:** `docs/EMBEDDING.md` → wiki "Embedding" and
-`docs/PROTOCOL.md` → wiki "Protocol Reference" (repo copies canonical).
-Whenever you change either repo doc, port the change to the wiki page in
-the same session (clone `paradox-modding-toolkit.wiki.git`, edit, push).
+**Wiki mirrors:** `docs/EMBEDDING.md` → wiki "Embedding", `docs/PROTOCOL.md`
+→ wiki "Protocol Reference" (repo copies canonical). Port changes to the
+wiki in the same session (clone `paradox-modding-toolkit.wiki.git`).
 
-## Work artifacts
-
-Plans, research notes and scratch files stay OUT of the repo: a code search
-must return the product as it exists, not abandoned intentions. Plans live
-in PR descriptions; durable decisions live in the tracked docs, written in
-present tense; the merged PR is the implementation record. `docs/` is
-gitignored by default precisely so a stray note cannot land in git, but the
-goal is to not create the note there at all.
+**Work artifacts stay out of the repo.** Plans live in PR descriptions;
+durable decisions in the tracked docs, present tense; the merged PR is the
+record. Do not create notes under `docs/`.
 
 ## Regenerating bundled data (per game patch)
 
-All are esbuild-bundled scripts: `npx esbuild scripts/<name>.ts --bundle
---platform=node --outfile=dist/<name>.cjs && node dist/<name>.cjs` (then
-delete the .cjs). Per-game scripts take `--game <id>`, default `ck3`.
+`npx esbuild scripts/<name>.ts --bundle --platform=node --outfile=dist/<name>.cjs && node dist/<name>.cjs`
+(then delete the .cjs). Per-game scripts take `--game <id>`, default `ck3`.
 
 | Script | Output | What it does |
 |---|---|---|
-| `build-structures-json.ts` | `data/ck3/structures.json` | Harvests every `_*.info` schema doc (CK3-only: no other game ships them) |
-| `build-gui-schema.ts [--game]` | `data/<id>/guiSchema.json` | Widget types + property counts from the vanilla `gui/` tree |
-| `build-freqs.ts [--game]` | `data/<id>/freqs.json` | Per-context usage counts. CK3 regen must stay byte-identical modulo the `meta.generated` stamp unless the game patched |
-| `import-cwt-types.ts <clone>` | `games/eu5/schema.generated.ts` | By-hand importer from a pinned cwtools-eu5-config clone; update the pinned commit in the file header AND `THIRD-PARTY-NOTICES.md` |
-| `audit-schema-coverage.ts [--game]` | stdout | Schema vs game folders; gaps should be 0 or documented |
-| `gen-brand.ts` / `gen-icons.ts` | `media/` brand + file icons | Geometry in `brandGeometry.ts`; regeneration guide in `docs/file-icons.md` |
-| `gen-codicon-glyphs.ts` | `webviews/exampleWiki/codiconGlyphs.ts` | Inlines the codicons `protocol/kinds.ts` names, so a webview draws the same picture as the hover badge without the editor's font |
-| `rank-eval.ts` / `fuzzy-diag.ts` | stdout | Completion-quality measurement; run before and after any ranking change |
+| `build-structures-json.ts` | `data/ck3/structures.json` | Harvests every `_*.info` doc (CK3-only) |
+| `build-gui-schema.ts [--game]` | `data/<id>/guiSchema.json` | Widget types + property counts from vanilla `gui/` |
+| `build-freqs.ts [--game]` | `data/<id>/freqs.json` | Per-context usage counts. CK3 regen stays byte-identical modulo `meta.generated` unless the game patched |
+| `import-cwt-types.ts <clone>` | `games/eu5/schema.generated.ts` | Importer from a pinned cwtools-eu5-config clone; update the pinned commit in the file header AND `THIRD-PARTY-NOTICES.md` |
+| `audit-schema-coverage.ts [--game]` | stdout | Schema vs game folders; gaps 0 or documented |
+| `gen-brand.ts` / `gen-icons.ts` | `media/` | Geometry in `brandGeometry.ts`; guide in `docs/file-icons.md` |
+| `gen-codicon-glyphs.ts` | `webviews/exampleWiki/codiconGlyphs.ts` | Inlines the codicons named in `protocol/kinds.ts` |
+| `rank-eval.ts` / `fuzzy-diag.ts` | stdout | Completion-quality measurement |
 
 ## Conventions
 
-- User-facing prose (README, CHANGELOG entries, UI copy, release notes)
-  avoids em dashes; code comments follow the existing style.
+- User-facing prose avoids em dashes; code comments follow existing style.
 - Comments state constraints and provenance ("measured", "per batch 03"),
-  not narration of the code below them.
-- The vsix stays self-contained: everything is esbuild-bundled, so new
-  runtime npm deps are almost never the answer.
-- Upstream sources: see "Upstream sources & acknowledgements" in
-  [README.md](README.md). Adding one extends that table AND the relevant
-  notices file (`THIRD-PARTY-NOTICES.md`, `data/ck3/wikidocs/ATTRIBUTION.md`
-  pattern).
+  not narration.
+- The vsix stays self-contained (esbuild-bundled); new runtime npm deps are
+  almost never the answer.
+- Adding an upstream source extends the README table AND the relevant
+  notices file (`THIRD-PARTY-NOTICES.md`, `data/ck3/wikidocs/ATTRIBUTION.md`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,10 +25,10 @@ folder-to-definition-kind table; **harvest** = build-time script output in
 `data/<id>/*.json`; **tiger** = ck3-tiger/vic3-tiger; **loc** = Paradox
 localization (`*_l_<lang>.yml`, UTF-8 with BOM).
 
-## Hard rules (no override; if a task fights one, stop and ask Joel)
+## Hard rules (no override; if a task fights one, stop and ask the maintainer)
 
 1. **Never commit or push to `main`.** `main` = one squash commit per PR,
-   created only by Joel. Check your branch before the first edit; never use
+   created only by the maintainer. Check your branch before the first edit; never use
    a worktree with `main` checked out. Old release recipes that push `main`
    directly are superseded.
 2. **Never hand-code game knowledge from memory.** Find it in the game
@@ -158,7 +158,7 @@ does, end with:
 pnpm run package:test   # compile, vsce package, code --install-extension --force
 ```
 
-then tell Joel it is installed and VS Code needs `Developer: Reload Window`.
+then say it is installed and VS Code needs `Developer: Reload Window`.
 Skip only for changes with nothing to try in the editor, and say so. Never
 commit a vsix.
 
@@ -176,7 +176,7 @@ commit a vsix.
    gh pr create --base main --title "<title>" --body "<why, with numbers>"
    ```
    Multi-PR efforts may target an `integration/<version>` branch.
-4. **Stop and hand Joel the PR link.** The squash merge is his call.
+4. **Stop and hand over the PR link.** The squash merge is the maintainer's call.
 5. Sourcery reviews every PR (`gh pr checks <n>`). A finding is a pointer,
    not a verdict: verify, fix what is real, dismiss false positives with a
    written reason. With stacked PRs, fix on the branch the file belongs to.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ localization workflow no other tool has.
 [![VS Code extension](https://img.shields.io/badge/VS%20Code-Paradox%20Modding%20Toolkit-007ACC.svg?logo=visualstudiocode)](https://marketplace.visualstudio.com/items?itemName=JDeffner.px-toolkit)
 [![npm @px-lsp/server](https://img.shields.io/npm/v/@px-lsp/server?logo=npm&label=%40px-lsp%2Fserver)](https://www.npmjs.com/package/@px-lsp/server)
 ![Editor agnostic](https://img.shields.io/badge/also-any%20LSP%20client-brightgreen.svg)
+[![Discord](https://img.shields.io/badge/Discord-join-5865F2.svg?logo=discord&logoColor=white)](https://discord.gg/DfEJ2H9hj4)
 
 [Install](#install) · [What you get](#what-you-get) ·
 [Outside VS Code](#not-just-vs-code) · [Repo layout](#repo-layout) ·

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,61 @@
+# Security Policy
+
+## Supported versions
+
+Only the latest release of each package gets security fixes.
+
+| Package | Where |
+|---|---|
+| `JDeffner.px-toolkit` (VS Code extension) | VS Code Marketplace, GitHub Releases |
+| `@px-lsp/server`, `@px-lsp/protocol` | npm |
+
+Update to the current version before you report a problem that an older
+version shows.
+
+## Reporting a vulnerability
+
+Do not open a public issue for a security problem.
+
+Use GitHub private vulnerability reporting:
+https://github.com/JDeffner/paradox-modding-toolkit/security/advisories/new
+
+Include:
+
+- The package and version.
+- Steps to reproduce, or a proof of concept.
+- What an attacker gains (file read, code execution, data sent off the
+  machine).
+
+You get a first reply within 7 days. A confirmed problem gets a fix in the
+next release and a GitHub Security Advisory with credit to you, unless you
+ask to stay anonymous.
+
+## Scope
+
+In scope:
+
+- The extension host code (`packages/vscode`), the LSP server
+  (`packages/server`) and the protocol package (`packages/protocol`).
+- Webview panels (GUI editor, event graph, Examples Wiki, DDS viewer,
+  Workshop panel).
+- The tiger download and run path.
+- The Steam Workshop upload bridge.
+- Files the toolkit writes into a mod (localization, scaffolds, descriptor).
+
+Out of scope:
+
+- Bugs in ck3-tiger, vic3-tiger, steamworks.js or the Paradox games.
+- Problems that need a malicious VS Code extension or a compromised machine.
+- Mod content that crashes the game. The games fail silently by design;
+  that is a modding bug, not a security bug.
+
+## What the toolkit does with your machine
+
+The toolkit reads game files, mod folders and log dumps that you configure.
+It does not send data off the machine except:
+
+- Downloading tiger binaries from their GitHub releases when you ask.
+- Uploading a mod to Steam Workshop when you ask, through the local Steam
+  client.
+
+If you find behavior outside this list, report it.

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -237,9 +237,11 @@ completes a query box from the answer it already has instead of asking again.
 predates it simply omits it.
 
 `paradox/eventGraph` reports a namespace (or the whole mod) as its
-DEFINITIONS, not as the endpoints of the edges between them: an event nothing
-calls yet is still part of its namespace, and deriving the node set from edges
-hid exactly the event the author had just written. Edges that pass through a
+DEFINITIONS, not as the endpoints of the edges between them, and then applies
+`connectedOnly` (on unless the request says `false`): definitions with no edge
+are dropped before their cards are read, `root` always stays, and a graph that
+lost every node says so in `emptyReason`. A client that wants the event the
+author just wrote, edges or not, sends `connectedOnly: false`. Edges that pass through a
 scripted effect are followed transitively (visited-guarded, three hops) and
 answered as a direct `from` -> `to` edge whose `label` reads
 `via effect_a -> effect_b`, so an event whose `trigger_event` sits inside a

--- a/packages/protocol/CHANGELOG.md
+++ b/packages/protocol/CHANGELOG.md
@@ -6,6 +6,12 @@ the shared helpers change. Before the split it moved inside the extension's
 version (up to 0.3.2); that history is in the extension changelog
 (`packages/vscode/CHANGELOG.md`).
 
+## Unreleased
+
+- `EventGraphParams.connectedOnly` (default true): definitions with no edge
+  are left out of `paradox/eventGraph` before their cards are read; `root`
+  always stays. Send `false` for the whole namespace.
+
 ## 0.2.0
 
 Ships with the toolkit's 0.3.5 pre-release, ahead of 0.4.0.

--- a/packages/protocol/src/protocol.ts
+++ b/packages/protocol/src/protocol.ts
@@ -1364,6 +1364,13 @@ export interface EventGraphParams {
   /** Also read each mod event's `theme`. Off by default: it costs one parse per
    *  event file, and only a client that draws the theme's art needs it. */
   themes?: boolean;
+  /**
+   * Leave out every definition that has no edge in the answer. ON by default
+   * (absent = true): the pruned definitions are dropped before their cards
+   * are read, so a mod with hundreds of standalone events stays cheap. `root`
+   * is always kept. Send `false` to see the whole namespace, edges or not.
+   */
+  connectedOnly?: boolean;
 }
 /**
  * One row of a mod event's card, in EXECUTION order (immediate, then the

--- a/packages/server/src/overview/eventGraph.ts
+++ b/packages/server/src/overview/eventGraph.ts
@@ -378,6 +378,23 @@ export function computeEventGraph(
   }
   labelEdges(data, graphEdges, sites);
 
+  // Connected only (the default): a definition no edge touches is dropped here,
+  // BEFORE the card facts are read, since that read is the expensive part.
+  // The queried root stays so a lone event still answers its own query.
+  let pruned = 0;
+  if (params.connectedOnly ?? true) {
+    const linked = new Set<string>();
+    for (const e of graphEdges) {
+      linked.add(e.from);
+      linked.add(e.to);
+    }
+    for (const id of [...selected]) {
+      if (linked.has(id) || id === params.root) continue;
+      selected.delete(id);
+      pruned++;
+    }
+  }
+
   // What each node fires, for the card's third line. Free: the edges are here.
   const firesCount = new Map<string, number>();
   for (const e of graphEdges) firesCount.set(e.from, (firesCount.get(e.from) ?? 0) + 1);
@@ -425,7 +442,10 @@ export function computeEventGraph(
   nodes.sort((a, b) => a.id.localeCompare(b.id));
   const graph: EventGraph = { nodes, edges: graphEdges, truncated, suggestions: suggestionsOf(vocabulary) };
   if (nodes.length === 0) {
-    const reason = emptyReason(data, params, inFocus);
+    const reason =
+      pruned > 0
+        ? `${pruned} definition(s) are here but none is connected to another. Turn "Connected only" off to show them.`
+        : emptyReason(data, params, inFocus);
     if (reason) graph.emptyReason = reason;
   }
   return graph;

--- a/packages/server/test/lspSmoke.test.ts
+++ b/packages/server/test/lspSmoke.test.ts
@@ -114,6 +114,12 @@ smoke.3 = {
 		set_variable = { name = smoke_toll value = 5 }
 	}
 }
+# Nothing fires this and it fires nothing: the graph's default leaves it out.
+smoke.3 = {
+	type = character_event
+	title = smoke.3.t
+}
+
 `;
 
 // Parent-mod fixture (submod workflow): indexed via settings.parentPaths.
@@ -566,6 +572,19 @@ describe.skipIf(!hasServer)("LSP smoke over node IPC (the client's transport)", 
     expect(graph.suggestions?.ids).toContain("smoke.2");
     expect(graph.suggestions?.namespaces).toContain("smoke");
     expect(graph.suggestions?.namespaces).toContain("psmoke");
+  });
+
+  it("paradox/eventGraph leaves unconnected definitions out unless asked for them", async () => {
+    const ids = async (params: object) => {
+      const graph = (await conn.sendRequest("paradox/eventGraph", params)) as {
+        nodes: Array<{ id: string }>;
+      };
+      return graph.nodes.map((n) => n.id);
+    };
+    expect(await ids({ namespace: "smoke" })).not.toContain("smoke.3");
+    expect(await ids({ namespace: "smoke", connectedOnly: false })).toContain("smoke.3");
+    // The queried root stays even when nothing links to it.
+    expect(await ids({ root: "smoke.3" })).toContain("smoke.3");
   });
 
   it("paradox/exampleWiki answers the searchable catalog", async () => {

--- a/packages/vscode/CHANGELOG.md
+++ b/packages/vscode/CHANGELOG.md
@@ -214,11 +214,15 @@ release these notes belong to.
   VS Code notification and a line in the output channel, so it reaches you
   even after you switch away from the Workshop tab, and errors stay
   readable instead of fading like the old in-panel toasts (which are gone).
-  Steam's bare error phrases carry advice now: "limit exceeded" says the
-  description is over Steam's 8000-character cap, "access denied" points at
-  the logged-in account not owning the item, and so on. An oversized
-  preview image is announced when the upload keeps the current one, instead
-  of being dropped in silence.
+  Steam's raw codes are rewritten as advice: `k_EResultLimitExceeded` says a
+  field is over Steam's limit (8000 characters for the description, 128 for
+  the title), `k_EResultAccessDenied` points at the logged-in account not
+  owning the item, and about thirty codes in all say what to do next. The
+  Steamworks operation and code stay in parentheses, so a support thread
+  still has the exact failure. A value Steam refuses outright is named
+  ("Steam rejected the preview image") instead of surfacing as a bare
+  "returned false". An oversized preview image is announced when the upload
+  keeps the current one, instead of being dropped in silence.
 
 - **The changenote box explains itself.** A source dropdown under it shows
   where the text came from - "From changelog: 1.2.md", "From last git

--- a/packages/vscode/CHANGELOG.md
+++ b/packages/vscode/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+- **Event graph: Connected only, on by default.** A rail tool leaves out every
+  event nothing fires and that fires nothing. The server drops them before it
+  reads their cards, so a mod with hundreds of standalone events opens faster.
+  Turn it off to see the whole namespace; the queried event always stays.
+
 ## 0.3.6 (beta, pre-release) - Workshop safety fix
 
 - **"Link existing item" is gone from the Workshop panel.** The button let a

--- a/packages/vscode/README.md
+++ b/packages/vscode/README.md
@@ -13,6 +13,7 @@ overview, and a localization workflow no other tool has.
 [![License: GPL-3.0-or-later](https://img.shields.io/badge/license-GPL--3.0--or--later-blue.svg)](LICENSE)
 ![Status: beta](https://img.shields.io/badge/status-beta-orange.svg)
 ![VS Code](https://img.shields.io/badge/VS%20Code-%5E1.90-007ACC.svg?logo=visualstudiocode)
+[![Discord](https://img.shields.io/badge/Discord-join-5865F2.svg?logo=discord&logoColor=white)](https://discord.gg/DfEJ2H9hj4)
 
 </div>
 

--- a/packages/vscode/src/steam/bridge.ts
+++ b/packages/vscode/src/steam/bridge.ts
@@ -181,7 +181,9 @@ async function main(): Promise<void> {
           needsAgreement = needsAgreement || r.needsToAcceptAgreement;
         } catch (e) {
           const lang = job.submits[i].language;
-          fail(`${lang ? `uploading the ${lang} translation` : "upload"} failed: ${errText(e)}`);
+          // No prefix for the main submit: every caller already says an
+          // upload failed, and "upload failed - upload failed:" reads badly.
+          fail(lang ? `uploading the ${lang} translation failed: ${errText(e)}` : errText(e));
         }
       }
       done({ action: "publish", itemId: job.itemId, needsToAcceptAgreement: needsAgreement });

--- a/packages/vscode/src/steam/steamErrors.ts
+++ b/packages/vscode/src/steam/steamErrors.ts
@@ -1,71 +1,105 @@
 /**
- * One-line advice for the Steam error phrases the native layer produces
- * (steamworks-rs maps EResult codes to short strings like "limit exceeded" -
- * accurate, but bare). The hint says what the phrase usually means for a
- * Workshop upload, so a failure is actionable without a Steamworks manual.
+ * Turns the Steam bridge's raw failures into a sentence a modder can act on.
+ *
+ * steamwand throws two message shapes. Both are exact, and both are
+ * Steamworks jargon:
+ *   "SubmitItemUpdate failed: k_EResultAccessDenied"   (a non-OK EResult)
+ *   "steamwand: SetItemTags returned false (invalid handle or argument?)"
+ * We put the plain-language cause in front and keep the operation and the
+ * code in parentheses, because a support thread needs the exact code.
+ *
+ * The table is keyed on the EResult NAME on purpose. It used to be keyed on
+ * prose ("access denied", "limit exceeded"), which is what steamworks-rs
+ * emitted; moving the bridge to steamwand changed every message to an enum
+ * name, no key matched any more, and all advice went silently missing.
  *
  * No vscode imports: unit-tested in plain Node.
  */
 
-const HINTS: { match: RegExp; hint: string }[] = [
-  {
-    match: /limit exceeded/i,
-    hint: "usually the description: Steam caps it at 8000 characters (and titles at 128)",
-  },
-  {
-    match: /file was not found/i,
-    hint: "a path Steam was given does not exist - re-check the preview image and the mod's content",
-  },
-  {
-    match: /access denied|insufficient privilege/i,
-    hint:
-      "the logged-in Steam account cannot edit this item - a linked remote_file_id must belong " +
-      "to the account Steam is logged in as",
-  },
-  {
-    match: /user not logged on/i,
-    hint: "log into Steam first",
-  },
-  {
-    match: /isn't a network connection|connect failed|no connection/i,
-    hint: "Steam appears to be offline - check the client's connection and retry",
-  },
-  {
-    match: /operation timed out/i,
-    hint: "Steam did not answer in time - usually transient, retry the upload",
-  },
-  {
-    match: /parameter is invalid/i,
-    hint: "often a malformed tag or visibility value - check the descriptor's tags block",
-  },
-  {
-    match: /request is a duplicate/i,
-    hint: "Steam already processed an identical update - refresh the panel before retrying",
-  },
-  {
-    match: /banned|account disabled|access revoked/i,
-    hint: "Steam has restricted the item or the account - check the item's Workshop page",
-  },
-  {
-    match: /service is read only|requested service is unavailable/i,
-    hint: "a Steam-side outage - wait and retry",
-  },
-  {
-    match: /disk being full/i,
-    hint: "Steam ran out of disk space while preparing the upload",
-  },
-  {
-    match: /generic failure/i,
-    hint:
-      "Steam's catch-all - often transient, sometimes a tag or image it refuses. Retry once, " +
-      "then check the item on its Workshop page",
-  },
-];
+/**
+ * EResult name without its `k_EResult` prefix -> what the code means for a
+ * Workshop upload. Only the codes an upload can realistically hit; the full
+ * enum is 131 entries, and listing one we have nothing to say about is worse
+ * than the fallback sentence.
+ *
+ * Exported so the test can check every key against the enum steamwand ships:
+ * a typo here fires no hint and nothing else would notice.
+ */
+export const RESULT_HINTS: Record<string, string> = {
+  Fail: "Steam's catch-all failure, often transient. Retry once, then check the item on its Workshop page",
+  NoConnection: "Steam has no connection. Check the Steam client and retry",
+  ConnectFailed: "Steam could not reach its servers. Check the Steam client and retry",
+  RemoteDisconnect: "Steam dropped the connection during the call. Retry the upload",
+  IOFailure: "Steam could not read or write the files for this upload. Retry, and check the disk",
+  Busy: "Steam is busy with another task. Wait a moment and retry",
+  Timeout: "Steam did not answer in time. This is usually transient, so retry the upload",
+  InvalidParam:
+    "Steam rejected one of the values. Check the tags, the visibility and the title in the descriptor",
+  FileNotFound: "a path Steam was given does not exist. Check the preview image and the mod's content folder",
+  AccessDenied:
+    "the Steam account you are logged in as may not edit this item. The Workshop ID in the " +
+    "descriptor must belong to that account",
+  InsufficientPrivilege:
+    "the Steam account may not publish right now. A community ban or another restriction on the " +
+    "account blocks Workshop uploads",
+  NotLoggedOn: "Steam is not logged in. Log in and retry",
+  LimitExceeded:
+    "a field is over Steam's limit. The description caps at 8000 characters and the title at 128",
+  RateLimitExceeded: "too many Workshop updates in a short time. Wait a few minutes and retry",
+  DuplicateRequest: "Steam already has an identical update in flight. Refresh the panel before retrying",
+  Banned: "Steam has banned this item or this account. Check the item's Workshop page",
+  Revoked: "Steam has withdrawn access to this item. Check the item's Workshop page",
+  Blocked: "Steam blocked the request for this account. Check the account's status on Steam",
+  AccountDisabled: "the Steam account is disabled, so it cannot publish",
+  Suspended: "the Steam account is suspended, so it cannot publish",
+  ServiceUnavailable: "Steam's Workshop service is down. Wait and retry",
+  ServiceReadOnly: "Steam is in read-only mode, so it accepts no updates right now. Wait and retry",
+  DiskFull: "the disk ran out of space while Steam prepared the upload",
+  ItemDeleted: "this Workshop item no longer exists. It was deleted on Steam, so link or create another item",
+  InvalidItemType: "Steam refuses this item type here. Check the item was created for this game",
+  MustAgreeToSSA: "the account has not accepted the Steam Subscriber Agreement. Accept it on Steam and retry",
+  Cancelled: "the upload was cancelled",
+  NotModified: "nothing in this update differs from what Steam already has",
+  LockingFailed: "Steam could not save the change on its side. Retry the upload",
+  PersistFailed: "Steam could not save the change on its side. Retry the upload",
+  ValueOutOfRange: "one value is outside the range Steam accepts. Check the visibility and the tags",
+};
 
-/** Advice for a Steam error message, or null when no phrase is recognized. */
+/** Flat setter -> the value Steam refused, for the "returned false" shape. */
+const REJECTED_VALUE: Record<string, string> = {
+  StartItemUpdate: "the item handle",
+  SetItemTitle: "the title",
+  SetItemDescription: "the description",
+  SetItemTags: "the tags",
+  SetItemVisibility: "the visibility",
+  SetItemContent: "the content folder",
+  SetItemPreview: "the preview image",
+  SetItemUpdateLanguage: "the language code",
+};
+
+/** `<Op> failed: k_EResultAccessDenied`, or the `EResult(<n>)` fallback name. */
+const RESULT_FAILURE = /(\w+) failed: (k_EResult(\w+)|EResult\(\d+\))/i;
+/** `steamwand: <Op> returned false (invalid handle or argument?)`. */
+const SETTER_FAILURE = /steamwand: (\w+) returned false(?: \([^)]*\))?/i;
+
+/**
+ * The message with its Steam failure rewritten in plain language, or null
+ * when it carries no Steam failure (a bridge or staging error passes through
+ * unchanged). Surrounding text is kept, so the step that failed still reads
+ * first.
+ */
 export function explainSteamError(message: string): string | null {
-  for (const { match, hint } of HINTS) {
-    if (match.test(message)) return hint;
+  const result = RESULT_FAILURE.exec(message);
+  if (result) {
+    const [segment, operation, code, name] = result;
+    const hint = (name && RESULT_HINTS[name]) || "Steam refused the request";
+    return message.replace(segment, () => `${hint} (${operation}: ${code})`);
+  }
+  const setter = SETTER_FAILURE.exec(message);
+  if (setter) {
+    const [segment, operation] = setter;
+    const value = REJECTED_VALUE[operation] ?? "one of the values it was given";
+    return message.replace(segment, () => `Steam rejected ${value} (${operation})`);
   }
   return null;
 }

--- a/packages/vscode/src/steam/workshop.ts
+++ b/packages/vscode/src/steam/workshop.ts
@@ -312,10 +312,9 @@ export function friendlyError(e: unknown, meta: GameMeta): string {
       `Steam must be running and logged in to an account that owns ${meta.name}.`
     );
   }
-  // Steam's EResult phrases are accurate but bare ("limit exceeded"); say
-  // what the phrase usually means for a Workshop upload.
-  const hint = explainSteamError(msg);
-  return hint ? `${msg} (${hint})` : msg;
+  // steamwand names the raw code ("SubmitItemUpdate failed:
+  // k_EResultAccessDenied"); say what it means, code kept for support.
+  return explainSteamError(msg) ?? msg;
 }
 
 export function registerWorkshop(

--- a/packages/vscode/src/webviews/dashboard/actions.ts
+++ b/packages/vscode/src/webviews/dashboard/actions.ts
@@ -40,12 +40,6 @@ export function actionGroups(meta: GameMeta, gameProblems: number): ActionGroup[
           tip: "Graph of what fires what in the focused mod.",
         },
         {
-          label: "Mod Report",
-          command: "px.modReport",
-          icon: "fileText",
-          tip: "Content counts, localization coverage and problems.",
-        },
-        {
           label: "Simulate Event",
           command: "px.simulateEvent",
           icon: "flaskConical",
@@ -82,23 +76,6 @@ export function actionGroups(meta: GameMeta, gameProblems: number): ActionGroup[
       ],
     },
     {
-      label: "Share",
-      items: [
-        {
-          label: "Steam Workshop Panel",
-          command: "px.openWorkshopManager",
-          icon: "cloudUpload",
-          tip: "The mod's Workshop listing, and where uploads happen.",
-        },
-        {
-          label: "Open Workshop Page",
-          command: "px.openWorkshopPage",
-          icon: "externalLink",
-          tip: "Open the mod's Workshop page in the browser.",
-        },
-      ],
-    },
-    {
       label: "Create",
       items: [
         {
@@ -112,6 +89,23 @@ export function actionGroups(meta: GameMeta, gameProblems: number): ActionGroup[
           command: "px.newContent",
           icon: "plus",
           tip: "Scaffold an event, decision or trait into the right folder.",
+        },
+      ],
+    },
+    {
+      label: "Share",
+      items: [
+        {
+          label: "Steam Workshop Panel",
+          command: "px.openWorkshopManager",
+          icon: "cloudUpload",
+          tip: "The mod's Workshop listing, and where uploads happen.",
+        },
+        {
+          label: "Open Workshop Page",
+          command: "px.openWorkshopPage",
+          icon: "externalLink",
+          tip: "Open the mod's Workshop page in the browser.",
         },
       ],
     },
@@ -135,6 +129,12 @@ export function actionGroups(meta: GameMeta, gameProblems: number): ActionGroup[
           command: "px.showExamplesWiki",
           icon: "bookOpen",
           tip: "Search every trigger, effect and datafunction the game has.",
+        },
+        {
+          label: "Mod Report",
+          command: "px.modReport",
+          icon: "fileText",
+          tip: "Content counts, localization coverage and problems.",
         },
       ],
     },

--- a/packages/vscode/src/webviews/eventGraph/app/main.ts
+++ b/packages/vscode/src/webviews/eventGraph/app/main.ts
@@ -49,6 +49,7 @@ let ui: UiState = {
   railCollapsed: false,
   titleMode: "raw",
   banner: false,
+  connectedOnly: true,
 };
 let currentGraph: EventGraph | null = null;
 let currentParams: EventGraphParams = {};
@@ -525,10 +526,10 @@ window.addEventListener("keydown", (ev) => {
 // ---------------------------------------------------------------------------
 
 function baseParams(): EventGraphParams {
-  return { maxNodes: currentParams.maxNodes, themes: ui.banner };
+  return { maxNodes: currentParams.maxNodes, themes: ui.banner, connectedOnly: ui.connectedOnly ?? true };
 }
 function fetchGraph(params: EventGraphParams): void {
-  send({ type: "fetch", params: { ...params, themes: ui.banner } });
+  send({ type: "fetch", params: { ...params, themes: ui.banner, connectedOnly: ui.connectedOnly ?? true } });
 }
 
 $("titleRaw").onclick = () => setTitleMode("raw");
@@ -625,6 +626,13 @@ $("toolAll").onclick = () => {
 $("toolSource").onclick = () => {
   const node = currentGraph?.nodes.find((n) => n.id === selectedId);
   if (node?.file) send({ type: "open", file: node.file, line: node.line });
+};
+$("toolConnected").onclick = () => {
+  ui = { ...ui, connectedOnly: !(ui.connectedOnly ?? true) };
+  saveUi();
+  $("toolConnected").setAttribute("aria-pressed", String(ui.connectedOnly));
+  // The pruning happens on the server, so either direction is a round trip.
+  fetchGraph(currentParams);
 };
 $("toolBanner").onclick = () => {
   ui = { ...ui, banner: !ui.banner };
@@ -977,6 +985,7 @@ function applyUi(next: UiState | undefined): void {
   if (ui.panelCollapsed !== side.collapsed) side.toggle(ui.panelCollapsed);
   setTitleMode(ui.titleMode);
   $("toolBanner").setAttribute("aria-pressed", String(ui.banner));
+  $("toolConnected").setAttribute("aria-pressed", String(ui.connectedOnly ?? true));
   view.setOptions({ banner: ui.banner });
   if (ui.simX !== undefined && ui.simY !== undefined) sim.setPosition(ui.simX, ui.simY);
   updatePanelToggle();

--- a/packages/vscode/src/webviews/eventGraph/html.ts
+++ b/packages/vscode/src/webviews/eventGraph/html.ts
@@ -422,6 +422,7 @@ ${uiCss}
       <button id="titleLoc" class="px-toggle" data-size="sm" aria-pressed="false" data-tip="Caption every card with its localized title" data-tip-wrap>Loc</button>
     </div>
     <button id="toolBanner" class="tool px-btn" data-variant="ghost" data-size="icon-sm" aria-pressed="false" data-tip="Draw each event's background illustration behind its card" data-tip-wrap>${icon("image")}</button>
+    <button id="toolConnected" class="tool px-btn" data-variant="ghost" data-size="icon-sm" aria-pressed="true" data-tip="Connected only: leave out every event nothing fires and that fires nothing. They are not even read, which keeps big mods fast." data-tip-wrap>${icon("link")}</button>
     <div class="px-separator" data-orientation="vertical"></div>
     <button id="undo" class="px-btn" data-variant="ghost" data-size="icon-sm" data-tip="Nothing to undo" disabled>${icon("undo")}</button>
     <button id="redo" class="px-btn" data-variant="ghost" data-size="icon-sm" data-tip="Nothing to redo" disabled>${icon("redo")}</button>

--- a/packages/vscode/src/webviews/eventGraph/messages.ts
+++ b/packages/vscode/src/webviews/eventGraph/messages.ts
@@ -27,6 +27,8 @@ export interface UiState {
   titleMode: "raw" | "loc";
   /** Draw the event's theme illustration behind its card. */
   banner: boolean;
+  /** Ask only for definitions that have an edge (the server never reads the rest). */
+  connectedOnly?: boolean;
   /** Where the simulation window was left, in page pixels. */
   simX?: number;
   simY?: number;

--- a/packages/vscode/test/steamErrors.test.ts
+++ b/packages/vscode/test/steamErrors.test.ts
@@ -1,29 +1,69 @@
 /**
- * The Steam-error advice table (steam/steamErrors.ts): the phrases the
- * native layer's EResult mapping produces get a one-line hint, everything
- * unrecognized passes through unchanged.
+ * The Steam-error rewriter (steam/steamErrors.ts). The fixtures are the exact
+ * message shapes steamwand throws, because the previous table was keyed on
+ * the phrases of the OLD native layer and silently matched nothing after the
+ * bridge moved to steamwand.
  */
 import { describe, expect, it } from "vitest";
-import { explainSteamError } from "../src/steam/steamErrors";
+import { EResult } from "steamwand.js/dist/generated/enums";
+import { RESULT_HINTS, explainSteamError } from "../src/steam/steamErrors";
+
+/** What bridge.ts hands friendlyError for a failed main submit. */
+const submitFailed = (name: string) => `SubmitItemUpdate failed: ${name}`;
 
 describe("explainSteamError", () => {
-  it("explains the phrases uploads actually hit", () => {
-    expect(explainSteamError("upload failed: limit exceeded")).toContain("8000 characters");
-    expect(explainSteamError("a file was not found")).toContain("preview image");
-    expect(explainSteamError("access denied")).toContain("logged-in Steam account");
-    expect(explainSteamError("insufficient privilege")).toContain("logged-in Steam account");
-    expect(explainSteamError("user not logged on")).toContain("log into Steam");
-    expect(explainSteamError("there isn't a network connection to steam or it failed to connect")).toContain(
-      "offline"
+  it("explains the codes an upload actually hits", () => {
+    expect(explainSteamError(submitFailed("k_EResultAccessDenied"))).toBe(
+      "the Steam account you are logged in as may not edit this item. The Workshop ID in the " +
+        "descriptor must belong to that account (SubmitItemUpdate: k_EResultAccessDenied)"
     );
-    expect(explainSteamError("operation timed out")).toContain("retry");
-    expect(explainSteamError("a parameter is invalid")).toContain("tag");
-    expect(explainSteamError("a generic failure from the steamworks API")).toContain("catch-all");
+    expect(explainSteamError(submitFailed("k_EResultLimitExceeded"))).toContain("8000 characters");
+    expect(explainSteamError(submitFailed("k_EResultNotLoggedOn"))).toContain("Log in and retry");
+    expect(explainSteamError("CreateItem failed: k_EResultFileNotFound")).toContain("preview image");
+    expect(explainSteamError(submitFailed("k_EResultTimeout"))).toContain("retry the upload");
   });
 
-  it("returns null for anything it does not recognize", () => {
+  it("keeps the text around the failure", () => {
+    expect(
+      explainSteamError(`uploading the german translation failed: ${submitFailed("k_EResultBanned")}`)
+    ).toBe(
+      "uploading the german translation failed: Steam has banned this item or this account. " +
+        "Check the item's Workshop page (SubmitItemUpdate: k_EResultBanned)"
+    );
+  });
+
+  it("still names an unmapped or unknown code", () => {
+    expect(explainSteamError(submitFailed("k_EResultInvalidSteamID"))).toBe(
+      "Steam refused the request (SubmitItemUpdate: k_EResultInvalidSteamID)"
+    );
+    // eResultName's fallback for a value not in the shipped enum.
+    expect(explainSteamError(submitFailed("EResult(9999)"))).toBe(
+      "Steam refused the request (SubmitItemUpdate: EResult(9999))"
+    );
+  });
+
+  it("names the field a rejected setter was given", () => {
+    expect(explainSteamError("steamwand: SetItemTags returned false (invalid handle or argument?)")).toBe(
+      "Steam rejected the tags (SetItemTags)"
+    );
+    expect(explainSteamError("steamwand: SetLanguage returned false (invalid handle or argument?)")).toBe(
+      "Steam rejected one of the values it was given (SetLanguage)"
+    );
+  });
+
+  it("returns null for anything that is not a Steam failure", () => {
     expect(explainSteamError("unexpected bridge reply")).toBeNull();
     expect(explainSteamError("Steam bridge exited with code 127")).toBeNull();
+    expect(explainSteamError("content folder does not exist: F:/mods/x")).toBeNull();
     expect(explainSteamError("")).toBeNull();
+  });
+
+  it("keys only on EResult names steamwand can emit", () => {
+    const names = new Set(Object.keys(EResult));
+    for (const key of Object.keys(RESULT_HINTS)) {
+      // steamwand spells one entry K_EResult..., so accept either prefix.
+      expect(names.has(`k_EResult${key}`) || names.has(`K_EResult${key}`)).toBe(true);
+      expect(explainSteamError(`Op failed: k_EResult${key}`)).toContain(RESULT_HINTS[key]);
+    }
   });
 });


### PR DESCRIPTION
`EventGraphParams.connectedOnly` (absent = true): definitions with no edge are dropped before their cards are read, so the parse cost of standalone events is never paid. `root` always stays, and a graph pruned to nothing explains itself in `emptyReason`. A rail tool toggles it (persisted in the panel's UI state). Protocol doc and wiki mirror updated; smoke test covers default, `false`, and the kept root.

Checks: tsc, lint, boundary, lspSmoke 41/41.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Make event graph queries faster by pruning standalone definitions by default while improving Workshop failure guidance and repository security guidance.

New Features:
- Add default connected-only pruning to event graph requests, with an option to include standalone definitions and an explanatory empty-graph reason.
- Add a persisted event graph control for toggling connected-only mode.
- Add a security policy and Discord community links.

Bug Fixes:
- Improve Steam Workshop error handling so Steamworks result codes and rejected fields produce actionable messages while preserving diagnostic context.
- Avoid duplicated upload-failure wording for primary Workshop submissions.

Enhancements:
- Streamline and consolidate the repository's agent-facing development guide.
- Reorganize dashboard action groups.

Documentation:
- Document connected-only event graph behavior in the protocol reference and package changelog.

Tests:
- Extend LSP smoke coverage for default pruning, disabling pruning, and retaining the queried root.
- Expand Steam error tests across mapped, unknown, and rejected-value failures.