### PR TITLE
test: event graph node selection follows the connectedOnly default

### DIFF
--- a/packages/server/test/eventGraphEdges.test.ts
+++ b/packages/server/test/eventGraphEdges.test.ts
@@ -7,6 +7,10 @@
  *    empty;
  *  - a `trigger_event` written inside a scripted_effect body belonged to no
  *    event, so the event that calls that effect looked like it fires nothing.
+ *
+ * The node set is still the namespace's DEFINITIONS. `connectedOnly` (on unless
+ * the request says `false`) then drops the ones no edge touches, so the tests
+ * that care about an edge-less event ask for it with `connectedOnly: false`.
  */
 import { describe, expect, it, beforeAll, afterAll } from "vitest";
 import * as fs from "fs";
@@ -137,12 +141,17 @@ afterAll(() => {
 
 describe("event graph node selection", () => {
   it("lists every event of a namespace, including ones no edge touches", () => {
-    const graph = computeEventGraph(data, { namespace: "ns" });
+    const graph = computeEventGraph(data, { namespace: "ns", connectedOnly: false });
     expect(graph.nodes.map((n) => n.id).sort()).toEqual(["ns.1", "ns.2", "ns.9"]);
   });
 
+  it("leaves the edge-less event out by default, so big mods stay cheap", () => {
+    const graph = computeEventGraph(data, { namespace: "ns" });
+    expect(graph.nodes.map((n) => n.id).sort()).toEqual(["ns.1", "ns.2"]);
+  });
+
   it("lists the mod's definitions with no query at all", () => {
-    const ids = computeEventGraph(data, {}).nodes.map((n) => n.id);
+    const ids = computeEventGraph(data, { connectedOnly: false }).nodes.map((n) => n.id);
     expect(ids).toContain("ns.9");
   });
 


### PR DESCRIPTION
Two tests in `packages/server/test/eventGraphEdges.test.ts` fail on `development`:
`lists every event of a namespace, including ones no edge touches` and
`lists the mod's definitions with no query at all`. Both expect `ns.9`, the
fixture event no edge touches.

This is the tests, not the code. 9b8fb28 ("feat(event-graph): connected-only
pruning, on by default, before the card read") made the pruning the default on
purpose: the commit message, `docs/PROTOCOL.md`, `packages/protocol/CHANGELOG.md`,
`packages/vscode/CHANGELOG.md` and the new `lspSmoke.test.ts` case all state that
a definition with no edge is dropped before its card is read, that `root` always
stays, and that a client wanting the whole namespace sends `connectedOnly: false`.
The two failing tests encoded the pre-9b8fb28 contract.

What changed:

- The test whose purpose is "the node set is the namespace's DEFINITIONS, not the
  edge endpoints" now asks with `connectedOnly: false`, the parameter the request
  exposes for exactly that. Same for the no-query test.
- A new case pins the default the other way: `{ namespace: "ns" }` answers
  `["ns.1", "ns.2"]` only.
- The file header says the node set is still the definitions, with the pruning
  applied after.

No production code touched, so no user-visible behavior changed and no new
changelog bullet: the feature's own bullet is already under Unreleased from
9b8fb28.

Checks: `npx vitest run eventGraph` 6 files / 48 tests green (the edges file went
11 to 12 tests), `npx tsc --noEmit` clean, `pnpm run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)