### PR TITLE
Calendar: declare the display calendar in the mod (.px-toolkit/calendar.json), .pxignore language

### DIFF
--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -83,7 +83,9 @@ interface ParadoxSettings {
   locLanguage: string;         // "english", ...
   scopeInlayHints: boolean;
   hoverDetail?: "compact" | "standard" | "full"; // how much a hover shows; default "standard"
-  calendar?: CalendarSetting;  // custom era calendar for date display (inlay hints + hover); absent = off
+  calendar?: CalendarSetting;  // FALLBACK custom era calendar for date display (inlay hints + hover); absent = off.
+                               //   A mod's own <mod>/.px-toolkit/calendar.json (same shape) wins for files under
+                               //   that mod; the server reads it itself and re-reads it when the file changes
                                //   { epoch: number; after: string; before?: string;
                                //     months?: { name: string; days: number }[] }
                                //   script year >= epoch displays as (year-epoch+1) <after>,

--- a/docs/file-icons.md
+++ b/docs/file-icons.md
@@ -17,6 +17,7 @@ Each of the contributed languages in `package.json` has a file icon via the `ico
 | `paradox-info` | Paradox Format Docs | circled "i" | `#58A6FF` / `#2361A8` |
 | `paradox-mod` | Paradox Mod Descriptor | jigsaw puzzle piece | `#E8925A` / `#BC5A18` |
 | `dds` | DDS Texture | picture frame with mountain and sun | `#DD6FA8` / `#A83A78` |
+| `pxignore` | Paradox Toolkit Ignore (`.pxignore`) | slashed circle | `#9AA4B2` / `#5B6470` |
 
 The `dds` language entry exists only to carry the file icon (`.dds` files open in the `px.ddsPreview` custom editor); its static `extensions` association means the icon shows in the explorer without opening files, unlike the dynamically-detected script languages.
 

--- a/packages/protocol/CHANGELOG.md
+++ b/packages/protocol/CHANGELOG.md
@@ -8,6 +8,10 @@ version (up to 0.3.2); that history is in the extension changelog
 
 ## Unreleased
 
+- `calendarFile`: `readCalendarFile` / `writeCalendarFile` / `isCalendarFile`
+  / `calendarFilePath` for the per-mod display calendar at
+  `<mod>/.px-toolkit/calendar.json` (the JSON form of `CalendarSetting`,
+  sanitized on read; an unusable file is told apart from a missing one).
 - `configDir`: `resolveConfigDir` / `migrateConfigDir` locate a mod's
   `.px-toolkit/` folder, falling back to (and renaming) the pre-0.4.0 per-game
   name. `readWorkshopMeta` / `upsertWorkshopMeta` now take that folder path

--- a/packages/protocol/src/calendarFile.ts
+++ b/packages/protocol/src/calendarFile.ts
@@ -1,0 +1,81 @@
+/**
+ * The per-mod calendar declaration: `<mod>/.px-toolkit/calendar.json`, the
+ * JSON form of calendar.ts `CalendarSetting`. A display calendar is a fact
+ * about the mod, so it travels with the mod (committed, one per mod, read by
+ * every client and by the server itself) instead of living in one editor's
+ * window-scoped `px.calendar` setting. The setting stays as the fallback for
+ * a mod without the file.
+ *
+ * No `vscode` imports: unit-tested in plain Node.
+ */
+import * as fs from "fs";
+import * as path from "path";
+import { sanitizeCalendar, type CalendarSetting } from "./calendar";
+import { migrateConfigDir, resolveConfigDir, type ConfigDirNames } from "./configDir";
+
+export const CALENDAR_FILE = "calendar.json";
+
+export interface CalendarFile {
+  /** Where the declaration was read from (or would be written to). */
+  file: string;
+  /** The declared calendar, when the file parses and sanitizes. */
+  calendar?: CalendarSetting;
+  /** Why an existing file yields no calendar: unparsable JSON or an unusable shape. */
+  error?: string;
+}
+
+/** The path the file is read from: the mod's config dir (legacy name included). */
+export function calendarFilePath(modRoot: string, names: ConfigDirNames): string {
+  return path.join(resolveConfigDir(modRoot, names), CALENDAR_FILE);
+}
+
+/**
+ * Read `<mod>/.px-toolkit/calendar.json`. Null when the file does not exist;
+ * a `CalendarFile` without `calendar` when it exists but is not usable, so a
+ * client can say so instead of silently showing no dates.
+ */
+export function readCalendarFile(modRoot: string, names: ConfigDirNames): CalendarFile | null {
+  const file = calendarFilePath(modRoot, names);
+  let text: string;
+  try {
+    text = fs.readFileSync(file, "utf8");
+  } catch {
+    return null;
+  }
+  let raw: unknown;
+  try {
+    raw = JSON.parse(text.replace(/^\uFEFF/, ""));
+  } catch (err) {
+    return { file, error: `not valid JSON (${(err as Error).message})` };
+  }
+  const calendar = sanitizeCalendar(raw);
+  if (!calendar) {
+    return {
+      file,
+      error:
+        'not a usable calendar: needs a whole-number "epoch" (1 or more), a non-empty "after" era label, ' +
+        'a "before" label different from "after" when present, and distinct "months" with 1 to 999 days each',
+    };
+  }
+  return { file, calendar };
+}
+
+/**
+ * Write the declaration into the mod (renaming a legacy config dir first,
+ * like every other config-dir write). Returns the file path.
+ */
+export function writeCalendarFile(modRoot: string, names: ConfigDirNames, cal: CalendarSetting): string {
+  const dir = migrateConfigDir(modRoot, names);
+  fs.mkdirSync(dir, { recursive: true });
+  const file = path.join(dir, CALENDAR_FILE);
+  fs.writeFileSync(file, JSON.stringify(cal, null, 2) + "\n", "utf8");
+  return file;
+}
+
+/** True when `fsPath` is a calendar declaration file (any config dir name). */
+export function isCalendarFile(fsPath: string, names: ConfigDirNames): boolean {
+  const parts = fsPath.split(/[\\/]/);
+  if (parts.length < 2 || parts[parts.length - 1].toLowerCase() !== CALENDAR_FILE) return false;
+  const dir = parts[parts.length - 2].toLowerCase();
+  return dir === names.configDirName.toLowerCase() || dir === names.legacyConfigDirName?.toLowerCase();
+}

--- a/packages/protocol/test/calendarFile.test.ts
+++ b/packages/protocol/test/calendarFile.test.ts
@@ -1,0 +1,78 @@
+/**
+ * The per-mod calendar file (calendarFile.ts): read from the mod's config dir
+ * (legacy name included), absent vs unusable told apart, written through the
+ * config-dir migration, and recognized by path for cache invalidation.
+ */
+import { describe, expect, it, afterEach } from "vitest";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { isCalendarFile, readCalendarFile, writeCalendarFile } from "../src/calendarFile";
+
+const NAMES = { configDirName: ".px-toolkit", legacyConfigDirName: ".ck3modding" };
+const CAL = { epoch: 4000, after: "AD", before: "BC" };
+
+const tmps: string[] = [];
+function tmp(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "px-calfile-"));
+  tmps.push(dir);
+  return dir;
+}
+afterEach(() => {
+  for (const dir of tmps.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+});
+
+function write(root: string, dirName: string, text: string): string {
+  const file = path.join(root, dirName, "calendar.json");
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, text, "utf8");
+  return file;
+}
+
+describe("readCalendarFile", () => {
+  it("returns null without a file and the sanitized calendar with one", () => {
+    const root = tmp();
+    expect(readCalendarFile(root, NAMES)).toBeNull();
+    const file = write(root, ".px-toolkit", "\uFEFF" + JSON.stringify({ ...CAL, extra: 1 }));
+    expect(readCalendarFile(root, NAMES)).toEqual({ file, calendar: CAL });
+  });
+
+  it("reads a legacy config dir when the current one is absent", () => {
+    const root = tmp();
+    const file = write(root, ".ck3modding", JSON.stringify(CAL));
+    expect(readCalendarFile(root, NAMES)?.file).toBe(file);
+  });
+
+  it("tells an unparsable file apart from an unusable calendar, both without a calendar", () => {
+    const root = tmp();
+    write(root, ".px-toolkit", "{ epoch: 4000 ");
+    const broken = readCalendarFile(root, NAMES);
+    expect(broken?.calendar).toBeUndefined();
+    expect(broken?.error).toMatch(/not valid JSON/);
+    write(root, ".px-toolkit", JSON.stringify({ epoch: "soon", after: "AD" }));
+    const unusable = readCalendarFile(root, NAMES);
+    expect(unusable?.calendar).toBeUndefined();
+    expect(unusable?.error).toMatch(/not a usable calendar/);
+  });
+});
+
+describe("writeCalendarFile", () => {
+  it("writes into the current config dir, renaming a legacy one first", () => {
+    const root = tmp();
+    fs.mkdirSync(path.join(root, ".ck3modding"));
+    const file = writeCalendarFile(root, NAMES, CAL);
+    expect(file).toBe(path.join(root, ".px-toolkit", "calendar.json"));
+    expect(fs.existsSync(path.join(root, ".ck3modding"))).toBe(false);
+    expect(readCalendarFile(root, NAMES)?.calendar).toEqual(CAL);
+  });
+});
+
+describe("isCalendarFile", () => {
+  it("matches calendar.json directly under a config dir only", () => {
+    expect(isCalendarFile("C:\\mods\\m\\.px-toolkit\\calendar.json", NAMES)).toBe(true);
+    expect(isCalendarFile("/mods/m/.ck3modding/calendar.json", NAMES)).toBe(true);
+    expect(isCalendarFile("/mods/m/.px-toolkit/workshop/calendar.json", NAMES)).toBe(false);
+    expect(isCalendarFile("/mods/m/calendar.json", NAMES)).toBe(false);
+    expect(isCalendarFile("/mods/m/.px-toolkit/schema.json", NAMES)).toBe(false);
+  });
+});

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -6,6 +6,13 @@ changes. Before the split it moved inside the extension's version (up to
 0.3.2); that history is in the extension changelog
 (`packages/vscode/CHANGELOG.md`).
 
+## Unreleased
+
+- Date inlay hints and hover read the owning mod's
+  `<mod>/.px-toolkit/calendar.json` before the `calendar` setting, cached per
+  mod root and dropped when the file changes (the server's own watcher now
+  covers `**/calendar.json`). The hover's rule line names the source.
+
 ## 0.3.0
 
 Ships with the toolkit's 0.3.5 pre-release, ahead of 0.4.0.

--- a/packages/server/src/features/calendarDates.ts
+++ b/packages/server/src/features/calendarDates.ts
@@ -72,11 +72,14 @@ export function calendarHints(cal: CalendarSetting, document: TextDocument, rang
   return hints;
 }
 
-/** Hover on a date token: the display form plus the calendar rule in force. */
+/** Hover on a date token: the display form plus the calendar rule in force,
+ * labelled with where the rule came from (`.px-toolkit/calendar.json` or the
+ * `px.calendar` setting). */
 export function provideDateHover(
   cal: CalendarSetting | undefined,
   document: TextDocument,
-  position: Position
+  position: Position,
+  source = "px.calendar"
 ): Hover | null {
   if (!cal || !isScriptLanguage(document.languageId)) return null;
   const lineText = getLineText(document, position.line);
@@ -90,7 +93,7 @@ export function provideDateHover(
   const eras = cal.before ? `${cal.before} / ${cal.after}` : cal.after;
   const value =
     `\`${script}\` → **${display}**\n\n` +
-    `*px.calendar: epoch ${cal.epoch} (${eras}), ${monthsOf(cal).length} months*`;
+    `*${source}: epoch ${cal.epoch} (${eras}), ${monthsOf(cal).length} months*`;
   return {
     contents: { kind: MarkupKind.Markdown, value },
     range: {

--- a/packages/server/src/features/inlayHints.ts
+++ b/packages/server/src/features/inlayHints.ts
@@ -21,6 +21,7 @@ import type { SchemaEntry } from "../schema/types";
 import type { Scope } from "../scopes/model";
 import { walkStatements } from "../parser";
 import { calendarHints } from "./calendarDates";
+import type { CalendarSetting } from "@px-lsp/protocol/calendar";
 
 const HINT_MAX_LEN = 60;
 
@@ -34,12 +35,14 @@ export function provideInlayHints(
   document: TextDocument,
   range: Range,
   rootScopes: Set<Scope> | null,
-  entry: SchemaEntry | null
+  entry: SchemaEntry | null,
+  /** The mod's own `.px-toolkit/calendar.json` when it has one; defaults to the setting. */
+  calendar: CalendarSetting | undefined = settings.calendar
 ): InlayHint[] {
   if (document.languageId === "paradox-loc") return translationOverlayHints(data, settings, document, range);
   const hints = locPreviewHints(data, document, range);
   if (settings.scopeInlayHints) hints.push(...scopeHints(data, document, range, rootScopes, entry));
-  if (settings.calendar) hints.push(...calendarHints(settings.calendar, document, range));
+  if (calendar) hints.push(...calendarHints(calendar, document, range));
   return hints;
 }
 

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -158,7 +158,8 @@ import { CompletionFeature } from "./features/completion";
 import { provideHover } from "./features/hover";
 import { setHoverDetail } from "./features/hoverRender";
 import { provideDateHover } from "./features/calendarDates";
-import { sanitizeCalendar } from "@px-lsp/protocol/calendar";
+import { sanitizeCalendar, type CalendarSetting } from "@px-lsp/protocol/calendar";
+import { isCalendarFile, readCalendarFile } from "@px-lsp/protocol/calendarFile";
 import { provideTextureHover } from "./features/textureHover";
 import { provideDefinition, provideLocDefinition } from "./features/definition";
 import { SEMANTIC_LEGEND, provideSemanticTokens } from "./features/semanticTokens";
@@ -578,6 +579,30 @@ function workspaceRootOf(fsPath: string): string | null {
   const lower = fsPath.toLowerCase();
   if (settings.modPath && lower.startsWith(settings.modPath.toLowerCase())) return settings.modPath;
   return workspaceModRoots().find((r) => lower.startsWith(r.toLowerCase())) ?? null;
+}
+
+/**
+ * The display calendar a file's dates follow: the owning mod's
+ * `<mod>/.px-toolkit/calendar.json` (read once per root, dropped when the file
+ * changes), else the window-scoped `calendar` setting. `source` names which one
+ * for the hover, so a wrong date can be traced to its declaration.
+ */
+const calendarByRoot = new Map<string, { calendar: CalendarSetting; source: string } | null>();
+function calendarFor(fsPath: string): { calendar: CalendarSetting | undefined; source: string } {
+  const root = workspaceRootOf(fsPath);
+  if (root) {
+    const key = root.toLowerCase();
+    let cached = calendarByRoot.get(key);
+    if (cached === undefined) {
+      const read = readCalendarFile(root, activeProfile());
+      cached = read?.calendar
+        ? { calendar: read.calendar, source: path.relative(root, read.file).replace(/\\/g, "/") }
+        : null;
+      calendarByRoot.set(key, cached);
+    }
+    if (cached) return cached;
+  }
+  return { calendar: settings.calendar, source: "px.calendar" };
 }
 
 /** Schema entry for the folder a file lives in (structure/ambient/root-scope seed). */
@@ -1105,6 +1130,7 @@ async function buildIndex(): Promise<void> {
   const tBuild = Date.now();
   const generation = ++scanGeneration;
   clearPathCaches();
+  calendarByRoot.clear();
   schema = loadSchema([...(settings.modPath ? [settings.modPath] : []), ...workspaceModRoots()], log);
   data.completableKinds = new Set([
     ...schema.entries.filter((e) => e.completable !== false).map((e) => e.kind),
@@ -1432,7 +1458,11 @@ connection.onInitialized(() => {
   // ourselves when the client supports dynamic registration.
   if (!clientOwnFileWatcher && clientWatchedFilesDynamic) {
     void connection.client.register(DidChangeWatchedFilesNotification.type, {
-      watchers: [{ globPattern: "**/*.{txt,yml,gui,mod}" }, { globPattern: "**/metadata.json" }],
+      watchers: [
+        { globPattern: "**/*.{txt,yml,gui,mod}" },
+        { globPattern: "**/metadata.json" },
+        { globPattern: "**/calendar.json" },
+      ],
     });
   }
   // Bundled frequency tables for completion ranking (§C3); fail-soft to empty.
@@ -1547,6 +1577,7 @@ function applyModFileChange(fsPath: string): void {
   const lower = fsPath.toLowerCase();
   if (lower.endsWith(".mod") || lower.endsWith("metadata.json")) refreshModOrigin();
   if (lower.endsWith(".gui")) invalidateGuiDefsCache();
+  if (isCalendarFile(fsPath, activeProfile())) calendarByRoot.clear();
   // Full re-harvest when a mod defines file or a gui file WITH textformatting
   // changed. Not on every .gui: the harvest reads only those out of gui/, and
   // autosave fires this after every GUI editor gesture.
@@ -1846,7 +1877,8 @@ connection.onHover((params) =>
     if (!isScriptLanguage(doc.languageId)) return null;
     const fsPath = URI.parse(doc.uri).fsPath;
     const entry = schemaEntryForFile(fsPath);
-    const dateHover = provideDateHover(settings.calendar, doc, params.position);
+    const { calendar, source } = calendarFor(fsPath);
+    const dateHover = provideDateHover(calendar, doc, params.position, source);
     if (dateHover) return dateHover;
     const texture = provideTextureHover(settings, doc, params.position, entry?.kind);
     if (texture) return texture;
@@ -1933,11 +1965,20 @@ connection.languages.inlayHint.on((params) =>
   indexRead(`inlayHint ${perfName(params.textDocument.uri)}`, () => {
     const doc = documents.get(params.textDocument.uri);
     if (!doc) return [];
-    const entry = schemaEntryForFile(URI.parse(doc.uri).fsPath);
+    const fsPath = URI.parse(doc.uri).fsPath;
+    const entry = schemaEntryForFile(fsPath);
     const rootScopes = entry?.rootScopes?.length
       ? new Set(entry.rootScopes.map((s) => s.toLowerCase()))
       : null;
-    return provideInlayHints(data, settings, doc, params.range, rootScopes, entry);
+    return provideInlayHints(
+      data,
+      settings,
+      doc,
+      params.range,
+      rootScopes,
+      entry,
+      calendarFor(fsPath).calendar
+    );
   })
 );
 

--- a/packages/vscode/CHANGELOG.md
+++ b/packages/vscode/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## Unreleased
 
+- **The display calendar lives in the mod.** A total-conversion mod declares
+  its era system in `<mod>/.px-toolkit/calendar.json` (`Paradox: Declare
+  Calendar` writes an editable example), committed with the mod and read
+  wherever the mod is opened: one calendar per mod in a multi-mod window, and
+  bare LSP clients need no settings plumbing because the server reads the file
+  itself. Date hints, hover, Insert Date and Generate Calendar Localization all
+  use it; the hover names the source (`.px-toolkit/calendar.json` or the
+  setting). `px.calendar` stays as the fallback for a mod without the file. A
+  stray declaration in a mod's own `.vscode/settings.json` now offers **Move
+  Into Mod**, which writes the file where it counts. The file is validated
+  against a schema as you edit it.
+- **`.pxignore` is a language.** The upload ignore list gets its own language
+  mode: `#` comments, `!` negation, trailing `/` folder markers, `*` / `**` /
+  `?` globs and character classes each highlighted, `#` toggles a comment, and
+  a slashed-circle file icon.
+
 - **Required DLC and required items in the Workshop panel.** A Requirements
   section lists the game's DLC as Steam reports it (unowned ones marked) and
   the required Workshop items, with installed mods and declared dependencies

--- a/packages/vscode/media/fileicons/pxignore-dark.svg
+++ b/packages/vscode/media/fileicons/pxignore-dark.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <circle cx="8" cy="8" r="5.85" fill="none" stroke="#9AA4B2" stroke-width="1.5"/>
+  <line x1="4.1" y1="4.1" x2="11.9" y2="11.9" stroke="#9AA4B2" stroke-width="1.5"/>
+</svg>

--- a/packages/vscode/media/fileicons/pxignore-light.svg
+++ b/packages/vscode/media/fileicons/pxignore-light.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <circle cx="8" cy="8" r="5.85" fill="none" stroke="#5B6470" stroke-width="1.5"/>
+  <line x1="4.1" y1="4.1" x2="11.9" y2="11.9" stroke="#5B6470" stroke-width="1.5"/>
+</svg>

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -41,6 +41,21 @@
         }
       },
       {
+        "id": "pxignore",
+        "aliases": [
+          "Paradox Toolkit Ignore",
+          ".pxignore"
+        ],
+        "filenames": [
+          ".pxignore"
+        ],
+        "configuration": "./pxignore-language-configuration.json",
+        "icon": {
+          "light": "./media/fileicons/pxignore-light.svg",
+          "dark": "./media/fileicons/pxignore-dark.svg"
+        }
+      },
+      {
         "id": "paradox",
         "aliases": [
           "Paradox Script"
@@ -159,6 +174,11 @@
         "path": "./syntaxes/bbcode.tmLanguage.json"
       },
       {
+        "language": "pxignore",
+        "scopeName": "source.pxignore",
+        "path": "./syntaxes/pxignore.tmLanguage.json"
+      },
+      {
         "language": "paradox",
         "scopeName": "source.paradox",
         "path": "./syntaxes/paradox.tmLanguage.json"
@@ -268,6 +288,11 @@
         "command": "px.jumpToScriptReference",
         "category": "Paradox Localization",
         "title": "Go to Script Usage"
+      },
+      {
+        "command": "px.declareCalendar",
+        "category": "Paradox",
+        "title": "Declare Calendar (Display Calendar)"
       },
       {
         "command": "px.insertDate",
@@ -811,7 +836,7 @@
             "default": null,
             "order": 6,
             "scope": "window",
-            "markdownDescription": "Custom era calendar for total-conversion mods: show how script dates display in game (inlay hints + hover) and enable `Paradox: Insert Date`. Example: `{ \"epoch\": 4000, \"after\": \"AD\", \"before\": \"BC\" }` makes script year 3000 display as `1000 BC` and 4000 as `1 AD`. Optional `months` replaces the standard 12: `[{ \"name\": \"Narvinye\", \"days\": 30 }, ...]`. Window-scoped: set it in the settings of the folder you OPEN (or the `.code-workspace`) and commit it; a `.vscode/settings.json` inside a mod subfolder is ignored by VS Code. `Paradox: Generate Calendar Localization` writes the matching game-side loc (era math + date-format overrides) into the mod.",
+            "markdownDescription": "Fallback for mods without their own calendar file. A mod declares its display calendar in `<mod>/.px-toolkit/calendar.json` (`Paradox: Declare Calendar` writes it): one per mod, committed with it, read wherever the mod is opened, and it wins over this setting. Same shape here: `{ \"epoch\": 4000, \"after\": \"AD\", \"before\": \"BC\" }` makes script year 3000 display as `1000 BC` and 4000 as `1 AD` (inlay hints + hover, `Paradox: Insert Date`). Optional `months` replaces the standard 12: `[{ \"name\": \"Narvinye\", \"days\": 30 }, ...]`. Window-scoped, so it can hold one calendar per window and a `.vscode/settings.json` inside a mod subfolder is ignored by VS Code. `Paradox: Generate Calendar Localization` writes the matching game-side loc (era math + date-format overrides) into the mod.",
             "properties": {
               "epoch": {
                 "type": "integer",
@@ -998,6 +1023,10 @@
         {
           "command": "px.insertDate",
           "when": "px.isCk3Workspace && editorTextFocus"
+        },
+        {
+          "command": "px.declareCalendar",
+          "when": "px.isCk3Workspace"
         },
         {
           "command": "px.generateCalendarLoc",
@@ -1433,6 +1462,15 @@
       {
         "fileMatch": "**/.metadata/metadata.json",
         "url": "./schemas/pdx-metadata.schema.json"
+      },
+      {
+        "fileMatch": [
+          "**/.px-toolkit/calendar.json",
+          "**/.ck3modding/calendar.json",
+          "**/.vic3modding/calendar.json",
+          "**/.eu5modding/calendar.json"
+        ],
+        "url": "./schemas/calendar.schema.json"
       }
     ],
     "keybindings": [

--- a/packages/vscode/pxignore-language-configuration.json
+++ b/packages/vscode/pxignore-language-configuration.json
@@ -1,0 +1,7 @@
+{
+  "comments": { "lineComment": "#" },
+  "brackets": [["[", "]"]],
+  "autoClosingPairs": [{ "open": "[", "close": "]" }],
+  "surroundingPairs": [["[", "]"]],
+  "wordPattern": "[^\\s/]+"
+}

--- a/packages/vscode/schemas/calendar.schema.json
+++ b/packages/vscode/schemas/calendar.schema.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Paradox Modding Toolkit display calendar",
+  "description": "How this mod's script dates display in game. Script dates stay on the engine's single year axis; this declares the era system the mod shows instead (\"1000 BC\", \"312 TA\"). Read by the toolkit for date hints, hover and Insert Date, and by Generate Calendar Localization for the game-side loc.",
+  "type": "object",
+  "required": ["epoch", "after"],
+  "properties": {
+    "epoch": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Script year displayed as year 1 of the later era. With 4000, script year 4000 reads \"1 AD\", 3999 reads \"1 BC\" and 3000 reads \"1000 BC\". There is no year zero."
+    },
+    "after": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Era label for script years at or after the epoch (e.g. AD, TA, AC)."
+    },
+    "before": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Era label for script years before the epoch (e.g. BC). Omit for a single-era calendar. Must differ from the later era's label."
+    },
+    "months": {
+      "type": "array",
+      "minItems": 1,
+      "description": "Custom month names and day counts, first month first. Omit for the standard 12 months (February 28: the engine has no leap years). The names must be distinct. Day counts steer the editor only; the game keeps its own month lengths, and month names reach the game only when exactly 12 are declared.",
+      "items": {
+        "type": "object",
+        "required": ["name", "days"],
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Display name (\"March\", \"Narvinye\")."
+          },
+          "days": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 999,
+            "description": "Day count of this month."
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/vscode/src/calendarInsert.ts
+++ b/packages/vscode/src/calendarInsert.ts
@@ -1,29 +1,89 @@
 /**
- * `Paradox: Insert Date` - type a date the way the mod's custom calendar
- * displays it ("1000 BC", "1000 BC March 15") and insert the script date the
- * game logic needs ("3000.1.1"). The conversion previews live in the input
- * box before anything is committed; existing dates are never rewritten.
- * Mapping logic: @px-lsp/protocol/calendar. Configured via `px.calendar`.
+ * The display-calendar commands. A total-conversion mod declares its calendar
+ * once, in `<mod>/.px-toolkit/calendar.json` (committed with the mod, one per
+ * mod); the window-scoped `px.calendar` setting is the fallback for a mod
+ * without the file.
+ *
+ * - `Paradox: Declare Calendar` writes that file (an editable example) and
+ *   opens it.
+ * - `Paradox: Insert Date` - type a date the way the mod displays it ("1000
+ *   BC", "1000 BC March 15") and insert the script date the game logic needs
+ *   ("3000.1.1"). The conversion previews live in the input box before
+ *   anything is committed; existing dates are never rewritten.
+ * - `Paradox: Generate Calendar Localization` writes the GAME side of the
+ *   calendar into the mod.
+ *
+ * Mapping logic: @px-lsp/protocol/calendar.
  */
 import * as vscode from "vscode";
 import * as fs from "fs";
 import * as path from "path";
 import { convertDisplayInput, type CalendarSetting } from "@px-lsp/protocol/calendar";
+import { CALENDAR_FILE, readCalendarFile, writeCalendarFile } from "@px-lsp/protocol/calendarFile";
 import { generateCalendarLoc } from "@px-lsp/protocol/calendarLoc";
 import type { PxConfig } from "./config";
 import { metaFor } from "./meta";
 
 const BOM = "\uFEFF";
 
-export async function insertDateCommand(calendar: CalendarSetting | undefined): Promise<void> {
-  if (!calendar) {
-    const open = "Open Settings";
-    const pick = await vscode.window.showInformationMessage(
-      "Insert Date needs the mod's calendar declared in the px.calendar setting " +
-        '(e.g. { "epoch": 4000, "after": "AD", "before": "BC" } in the workspace settings.json).',
-      open
+/** What `Declare Calendar` writes: valid as is, meant to be edited. */
+const EXAMPLE_CALENDAR: CalendarSetting = { epoch: 4000, after: "AD", before: "BC" };
+
+/**
+ * The calendar in force for `cfg.modPath`: the mod's own file first, the
+ * setting second. `problem` carries the reason an existing file gave no
+ * calendar, so the commands can say so instead of silently using the fallback.
+ */
+export function calendarForMod(cfg: PxConfig): { calendar: CalendarSetting | undefined; problem?: string } {
+  if (!cfg.modPath) return { calendar: cfg.calendar };
+  const read = readCalendarFile(cfg.modPath, metaFor(cfg.gameId));
+  if (read?.calendar) return { calendar: read.calendar };
+  return {
+    calendar: cfg.calendar,
+    problem: read ? `${path.relative(cfg.modPath, read.file)} is ${read.error}.` : undefined,
+  };
+}
+
+/** No calendar for this mod: say where it goes and offer to write it there. */
+async function offerToDeclare(cfg: PxConfig, what: string, problem?: string): Promise<void> {
+  const declare = "Declare Calendar";
+  const dir = metaFor(cfg.gameId).configDirName;
+  const where = cfg.modPath
+    ? `${path.basename(cfg.modPath)}/${dir}/${CALENDAR_FILE}`
+    : `the mod's ${dir}/${CALENDAR_FILE}`;
+  const pick = await vscode.window.showInformationMessage(
+    `${what} needs the mod's calendar declared in ${where} ` +
+      '(e.g. { "epoch": 4000, "after": "AD", "before": "BC" }).' +
+      (problem ? ` ${problem}` : ""),
+    declare
+  );
+  if (pick === declare) await declareCalendarCommand(cfg);
+}
+
+/** `Paradox: Declare Calendar` - write `.px-toolkit/calendar.json` (or open the existing one). */
+export async function declareCalendarCommand(cfg: PxConfig): Promise<void> {
+  if (!cfg.modPath) {
+    void vscode.window.showWarningMessage(
+      "Paradox Modding Toolkit: no mod folder found. Open your mod folder (the one with the mod's descriptor) as a workspace folder."
     );
-    if (pick === open) await vscode.commands.executeCommand("workbench.action.openWorkspaceSettingsFile");
+    return;
+  }
+  const names = metaFor(cfg.gameId);
+  const existing = readCalendarFile(cfg.modPath, names);
+  const file = existing?.file ?? writeCalendarFile(cfg.modPath, names, cfg.calendar ?? EXAMPLE_CALENDAR);
+  await vscode.window.showTextDocument(vscode.Uri.file(file));
+  if (!existing) {
+    void vscode.window.showInformationMessage(
+      `Wrote ${path.relative(cfg.modPath, file)}. Set "epoch" to the script year that displays as year 1 ` +
+        'and name the era labels; leave "before" out for a single-era calendar. Commit the file with the mod.'
+    );
+  }
+}
+
+export async function insertDateCommand(cfg: PxConfig): Promise<void> {
+  const { calendar, problem } = calendarForMod(cfg);
+  if (!calendar) {
+    await offerToDeclare(cfg, "Insert Date", problem);
     return;
   }
   const editor = vscode.window.activeTextEditor;
@@ -57,20 +117,15 @@ export async function insertDateCommand(calendar: CalendarSetting | undefined): 
 
 /**
  * `Paradox: Generate Calendar Localization` - write the GAME side of the
- * calendar declared in `px.calendar`: the era-math datafunction keys plus the
+ * mod's calendar: the era-math datafunction keys plus the
  * `localization/replace/` overrides of the engine's date-format (and, with
  * custom months, month-name) keys. Deterministic filenames, so running it
- * again after a `px.calendar` change regenerates in place.
+ * again after a calendar change regenerates in place.
  */
 export async function generateCalendarLocCommand(cfg: PxConfig): Promise<void> {
-  if (!cfg.calendar) {
-    const open = "Open Settings";
-    const pick = await vscode.window.showInformationMessage(
-      "Generate Calendar Localization needs the mod's calendar declared in the px.calendar setting " +
-        '(e.g. { "epoch": 4000, "after": "AD", "before": "BC" } in the workspace settings.json).',
-      open
-    );
-    if (pick === open) await vscode.commands.executeCommand("workbench.action.openWorkspaceSettingsFile");
+  const { calendar, problem } = calendarForMod(cfg);
+  if (!calendar) {
+    await offerToDeclare(cfg, "Generate Calendar Localization", problem);
     return;
   }
   const meta = metaFor(cfg.gameId);
@@ -88,7 +143,7 @@ export async function generateCalendarLocCommand(cfg: PxConfig): Promise<void> {
     return;
   }
 
-  const { files, notes } = generateCalendarLoc(cfg.calendar, meta.calendarLoc, cfg.locLanguage);
+  const { files, notes } = generateCalendarLoc(calendar, meta.calendarLoc, cfg.locLanguage);
   const targets = files.map((f) => path.join(cfg.modPath!, ...f.relPath.split("/")));
   const existing = targets.filter((t) => fs.existsSync(t));
   if (existing.length > 0) {

--- a/packages/vscode/src/calendarSettingsCheck.ts
+++ b/packages/vscode/src/calendarSettingsCheck.ts
@@ -9,10 +9,14 @@
 import * as fs from "fs";
 import * as path from "path";
 import { sanitizeCalendar, type CalendarSetting } from "@px-lsp/protocol/calendar";
+import { readCalendarFile } from "@px-lsp/protocol/calendarFile";
+import type { ConfigDirNames } from "@px-lsp/protocol/configDir";
 
 export interface StrayCalendar {
   /** The ignored settings file that declares px.calendar. */
   file: string;
+  /** The mod the declaration belongs to: where `.px-toolkit/calendar.json` would go. */
+  modRoot: string;
   /** The declared calendar, when it parses and sanitizes; undefined when the
    * declaration is present but not usable (still worth telling the user). */
   calendar: CalendarSetting | undefined;
@@ -57,7 +61,7 @@ export function jsoncToJson(text: string): string {
 }
 
 /** The px.calendar value of one settings file, or null when absent/unreadable. */
-function calendarDeclaredIn(file: string): StrayCalendar | null {
+function calendarDeclaredIn(file: string): Omit<StrayCalendar, "modRoot"> | null {
   let text: string;
   try {
     text = fs.readFileSync(file, "utf8");
@@ -81,19 +85,26 @@ function calendarDeclaredIn(file: string): StrayCalendar | null {
  * each mod root and its parent (the mod-project folder in the projects
  * layout). Files under an effective root (an opened workspace folder, whose
  * settings VS Code does read) are skipped: a calendar there is not stray,
- * just absent or invalid, and other messages own that case.
+ * just absent or invalid, and other messages own that case. A mod that already
+ * declares its calendar in its own `.px-toolkit/calendar.json` is skipped too:
+ * that file is read wherever the mod is opened, so nothing is stray there.
  */
-export function findStrayCalendar(modRoots: string[], effectiveRoots: string[]): StrayCalendar | null {
+export function findStrayCalendar(
+  modRoots: string[],
+  effectiveRoots: string[],
+  names?: ConfigDirNames
+): StrayCalendar | null {
   const effective = new Set(effectiveRoots.map((r) => path.resolve(r).toLowerCase()));
   const seen = new Set<string>();
   for (const root of modRoots) {
     const resolved = path.resolve(root);
+    if (names && readCalendarFile(resolved, names)?.calendar) continue;
     for (const dir of [resolved, path.dirname(resolved)]) {
       const key = dir.toLowerCase();
       if (seen.has(key) || effective.has(key)) continue;
       seen.add(key);
       const hit = calendarDeclaredIn(path.join(dir, ".vscode", "settings.json"));
-      if (hit) return hit;
+      if (hit) return { ...hit, modRoot: resolved };
     }
   }
   return null;

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -18,6 +18,7 @@ import {
 } from "vscode-languageclient/node";
 import { modRootFor, readConfig, type PxConfig } from "./config";
 import { findStrayCalendar } from "./calendarSettingsCheck";
+import { writeCalendarFile } from "@px-lsp/protocol/calendarFile";
 import { ensureFileAssociations, wireLanguageDetection } from "./languageMode";
 import { isScriptLang, PARADOX_SCRIPT_LANGS } from "./langIds";
 import { findDownloadedTiger, tigerFlavorFor } from "./tigerDownload";
@@ -48,7 +49,7 @@ import { WikiPanel, IMAGE_GUIDELINES_ARTICLE } from "./webviews/wiki/panel";
 import { EventSimPanel } from "./webviews/eventSim/panel";
 import { GuiTreePanel } from "./webviews/guiTree/panel";
 import { GuiEditorPanel } from "./webviews/guiEditor/panel";
-import { generateCalendarLocCommand, insertDateCommand } from "./calendarInsert";
+import { declareCalendarCommand, generateCalendarLocCommand, insertDateCommand } from "./calendarInsert";
 import { setTabIconRoot } from "./webviews/tabIcons";
 import { FlagBuilderPanel } from "./webviews/flagBuilder/panel";
 import { readModName } from "@px-lsp/protocol/modName";
@@ -236,28 +237,30 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   // A px.calendar declared in a mod's (or mod project's) own .vscode while the
   // OPENED folder has none: VS Code ignores that file, so every calendar
   // feature silently does nothing. The setting is window-scoped; say so once
-  // per workspace and offer to adopt the calendar where it counts.
+  // per workspace and offer to move the calendar into the mod itself
+  // (`.px-toolkit/calendar.json`), which is read wherever the mod is opened.
   if (cfg.isCk3Workspace && !cfg.calendar && !context.workspaceState.get<boolean>("px.strayCalendarNotice")) {
     const stray = findStrayCalendar(
       [...(cfg.modPath ? [cfg.modPath] : []), ...cfg.workspaceMods],
-      (vscode.workspace.workspaceFolders ?? []).map((f) => f.uri.fsPath)
+      (vscode.workspace.workspaceFolders ?? []).map((f) => f.uri.fsPath),
+      metaFor(cfg.gameId)
     );
     if (stray) {
       void context.workspaceState.update("px.strayCalendarNotice", true);
-      const actions = stray.calendar ? ["Use This Calendar", "Open Settings File"] : ["Open Settings File"];
+      const actions = stray.calendar ? ["Move Into Mod", "Open Settings File"] : ["Open Settings File"];
       void vscode.window
         .showWarningMessage(
           `Paradox Modding Toolkit: ${path.basename(path.dirname(path.dirname(stray.file)))} declares ` +
             "px.calendar in its own .vscode/settings.json, but VS Code only reads that file when the " +
-            "folder itself is opened. Put the calendar in the settings of the folder you open " +
-            "(or the .code-workspace) to activate the date preview.",
+            `folder itself is opened. Declare the calendar in the mod instead: ${metaFor(cfg.gameId).configDirName}/calendar.json ` +
+            "travels with the mod and is read wherever it is opened.",
           ...actions
         )
         .then((choice) => {
-          if (choice === "Use This Calendar") {
-            void vscode.workspace
-              .getConfiguration("px")
-              .update("calendar", stray.calendar, vscode.ConfigurationTarget.Workspace);
+          if (choice === "Move Into Mod" && stray.calendar) {
+            const file = writeCalendarFile(stray.modRoot, metaFor(cfg.gameId), stray.calendar);
+            notifyModFileChanged(file);
+            void vscode.window.showTextDocument(vscode.Uri.file(file));
           } else if (choice === "Open Settings File") {
             void vscode.window.showTextDocument(vscode.Uri.file(stray.file));
           }
@@ -507,13 +510,17 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     log(`watching ${watchRoots.length} root(s) for mod file changes`);
     for (const root of watchRoots) {
       // .mod included so origin labels (descriptor name= in hovers) stay fresh.
-      const w = vscode.workspace.createFileSystemWatcher(
-        new vscode.RelativePattern(vscode.Uri.file(root), "**/*.{txt,yml,gui,mod}")
-      );
-      w.onDidChange((uri) => notifyModFileChanged(uri.fsPath));
-      w.onDidCreate((uri) => notifyModFileChanged(uri.fsPath));
-      w.onDidDelete((uri) => notifyModFileChanged(uri.fsPath));
-      modWatchers.push(w);
+      // calendar.json: the mod's display calendar (.px-toolkit/calendar.json),
+      // which the server caches per mod until the file changes.
+      for (const glob of ["**/*.{txt,yml,gui,mod}", "**/calendar.json"]) {
+        const w = vscode.workspace.createFileSystemWatcher(
+          new vscode.RelativePattern(vscode.Uri.file(root), glob)
+        );
+        w.onDidChange((uri) => notifyModFileChanged(uri.fsPath));
+        w.onDidCreate((uri) => notifyModFileChanged(uri.fsPath));
+        w.onDidDelete((uri) => notifyModFileChanged(uri.fsPath));
+        modWatchers.push(w);
+      }
     }
   };
   wireModWatcher();
@@ -615,7 +622,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       openLocalizationSideBySide(lookupLoc, arg)
     ),
     vscode.commands.registerCommand("px.jumpToScriptReference", () => jumpToScriptReference(tracker, cfg)),
-    vscode.commands.registerCommand("px.insertDate", () => insertDateCommand(cfgForActive().calendar)),
+    vscode.commands.registerCommand("px.declareCalendar", () => declareCalendarCommand(cfgForActive())),
+    vscode.commands.registerCommand("px.insertDate", () => insertDateCommand(cfgForActive())),
     vscode.commands.registerCommand("px.generateCalendarLoc", () =>
       generateCalendarLocCommand(cfgForActive())
     ),

--- a/packages/vscode/syntaxes/pxignore.tmLanguage.json
+++ b/packages/vscode/syntaxes/pxignore.tmLanguage.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "name": "Paradox Toolkit Ignore",
+  "scopeName": "source.pxignore",
+  "patterns": [{ "include": "#comment" }, { "include": "#pattern" }],
+  "repository": {
+    "comment": {
+      "match": "^\\s*(#).*$",
+      "name": "comment.line.number-sign.pxignore",
+      "captures": { "1": { "name": "punctuation.definition.comment.pxignore" } }
+    },
+    "pattern": {
+      "begin": "^\\s*(?=\\S)",
+      "end": "$",
+      "name": "meta.pattern.pxignore",
+      "patterns": [
+        {
+          "match": "^\\s*(!)",
+          "captures": { "1": { "name": "keyword.operator.negation.pxignore" } }
+        },
+        { "match": "\\\\.", "name": "constant.character.escape.pxignore" },
+        { "match": "\\*\\*", "name": "keyword.operator.glob.globstar.pxignore" },
+        { "match": "[*?]", "name": "keyword.operator.glob.pxignore" },
+        { "match": "\\[[^\\]]*\\]", "name": "keyword.operator.glob.class.pxignore" },
+        { "match": "/(?=\\s*$)", "name": "keyword.operator.directory.pxignore" },
+        { "match": "/", "name": "punctuation.separator.path.pxignore" },
+        { "match": "[^\\s/*?\\[\\\\]+", "name": "string.unquoted.pattern.pxignore" }
+      ]
+    }
+  }
+}

--- a/packages/vscode/test/calendarSettingsCheck.test.ts
+++ b/packages/vscode/test/calendarSettingsCheck.test.ts
@@ -54,7 +54,20 @@ describe("findStrayCalendar", () => {
     const file = writeSettings(project, `{\n  // era math\n  ${CAL.slice(1)}`);
     const hit = findStrayCalendar([modRoot], [opened]);
     expect(hit?.file).toBe(file);
+    expect(hit?.modRoot).toBe(modRoot);
     expect(hit?.calendar).toEqual({ epoch: 4000, after: "AD", before: "BC" });
+  });
+
+  it("skips a mod that already declares its calendar in .px-toolkit/calendar.json", () => {
+    const opened = tmp();
+    const project = path.join(opened, "My Mod");
+    const modRoot = path.join(project, "mod");
+    fs.mkdirSync(path.join(modRoot, ".px-toolkit"), { recursive: true });
+    writeSettings(project, CAL);
+    const names = { configDirName: ".px-toolkit" };
+    expect(findStrayCalendar([modRoot], [opened], names)).not.toBeNull();
+    fs.writeFileSync(path.join(modRoot, ".px-toolkit", "calendar.json"), '{ "epoch": 4000, "after": "AD" }');
+    expect(findStrayCalendar([modRoot], [opened], names)).toBeNull();
   });
 
   it("skips settings under an opened root and reports nothing when clean", () => {

--- a/scripts/gen-icons.ts
+++ b/scripts/gen-icons.ts
@@ -1,5 +1,5 @@
 /**
- * Generates the file-type icons (7 glyphs x light/dark) into
+ * Generates the file-type icons (8 glyphs x light/dark) into
  * packages/vscode/media/fileicons/ (see docs/file-icons.md).
  *
  * Run: npx esbuild scripts/gen-icons.ts --bundle --platform=node \
@@ -131,6 +131,15 @@ const icons: Record<string, IconDef> = {
   <rect x="1.75" y="2.75" width="12.5" height="10.5" rx="1.6" fill="none" stroke="${c}" stroke-width="1.5"/>
   <circle fill="${c}" cx="10.4" cy="5.9" r="1.2"/>
   <path fill="${c}" d="M3.3 11.5 6.3 6.9l2.2 3.2 1.3-1.7 2.6 3.1Z"/>`,
+  },
+  // Toolkit ignore list (.pxignore): a slashed circle, the "leave this out"
+  // sign. Neutral slate, since the file is about what is NOT content.
+  pxignore: {
+    dark: "#9AA4B2",
+    light: "#5B6470",
+    body: (c) => `
+  <circle cx="8" cy="8" r="5.85" fill="none" stroke="${c}" stroke-width="1.5"/>
+  <line x1="4.1" y1="4.1" x2="11.9" y2="11.9" stroke="${c}" stroke-width="1.5"/>`,
   },
   // Mod Descriptor: jigsaw puzzle piece with top and right knobs. The same
   // shape as before, scaled and re-centred so the whole piece (knob apexes


### PR DESCRIPTION
## Why

A display calendar is a fact about the mod, not about one person's editor. The window-scoped `px.calendar` setting gave it the wrong home:

- one value per window, so a multi-mod workspace could not give each mod its own calendar;
- silently ignored when declared in a mod's own `.vscode/settings.json` under the mod-projects layout (the toolkit grew a warning plus an adopt button for that symptom);
- every bare LSP client had to plumb it through initialization options.

## What

- **`<mod>/.px-toolkit/calendar.json`** is the declaration (same shape as `CalendarSetting`). It sits next to the mod's other toolkit data (`workshop/`, `schema.json`), is committed with the mod and read wherever the mod is opened.
- **Server:** inlay hints and hover resolve the calendar per owning mod root (`readCalendarFile`, cached, dropped when the file changes; the server's own watcher now covers `**/calendar.json`). The hover's rule line names the source (`.px-toolkit/calendar.json` or `px.calendar`). Wire contract unchanged: `settings.calendar` stays as the fallback and `docs/PROTOCOL.md` says so (wiki mirror updated locally, not pushed).
- **Extension:** new `Paradox: Declare Calendar` writes an editable example and opens it; Insert Date and Generate Calendar Localization read the file first and offer to declare one when missing (an unusable file is named, not silently skipped). The stray-settings notice offers **Move Into Mod**. A JSON schema validates the file (`contributes.jsonValidation`). The mod watcher forwards `calendar.json` changes.
- **`.pxignore` language:** `#` comments, `!` negation, trailing `/` folder markers, `*` / `**` / `?` globs and character classes highlighted, `#` comment toggling, a slashed-circle file icon (added to `gen-icons.ts`, table row in `docs/file-icons.md`).
- Changelog bullets in `packages/vscode`, `packages/server`, `packages/protocol`.

## Verification

- `npx tsc --noEmit` clean; eslint + prettier clean on every touched file; `check-game-boundary.mjs` clean.
- New `packages/protocol/test/calendarFile.test.ts` (5 tests: read / legacy dir / unusable vs unparsable / write with migration / path recognition); `calendarSettingsCheck.test.ts` extended (mod root reported, mods with their own file skipped). Touched suites: 8 files, 46 tests pass.
- Test vsix built and installed via `scripts/package-test.mjs` (pnpm's pre-run install check had to be disabled: this branch's lockfile does not match `pnpm-workspace.yaml` overrides under pnpm 11; unrelated to this PR).

## Hit-every-surface

- Games: file location comes from each profile's `configDirName`; the schema glob lists the legacy per-game dir names too. Generation stays CK3-only as before.
- Clients: the server reads the file itself, so neovim / Studio get the hints with no settings change.
- Entry points: palette entries for the new command (`px.isCk3Workspace`), same as the existing calendar commands; no Project-panel row, matching them.
- Not done here (release PR material): wiki pages Custom-Calendars and Configuration still describe `px.calendar` as the primary home.

Stacked on #41 (`feat/in-mod-layout`), which introduces `.px-toolkit/` and `.pxignore`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Move display calendar declarations into each mod's toolkit metadata and add first-class `.pxignore` language support.

New Features:
- Add per-mod display calendar declarations in `<mod>/.px-toolkit/calendar.json`, including extension commands, validation, migration support, and fallback to `px.calendar`.
- Add `.pxignore` language support with syntax highlighting, comment toggling, and a dedicated file icon.

Bug Fixes:
- Ensure calendar declarations work consistently in multi-mod workspaces and are available to all LSP clients without additional initialization settings.
- Provide actionable handling for missing, invalid, or misplaced calendar declarations instead of silently ignoring them.

Enhancements:
- Resolve calendars per owning mod in server date hints and hovers, cache them with file-change invalidation, and identify the calendar source in hover details.
- Update calendar-related commands and stray-settings detection to use and promote the per-mod declaration.

Documentation:
- Document the per-mod calendar fallback behavior in the protocol and add `.pxignore` to the file icon reference.

Tests:
- Add protocol coverage for calendar file reading, writing, migration, validation, and path recognition, and extend calendar settings checks.

Chores:
- Update package changelogs for the protocol, server, and VS Code extension changes.