### PR TITLE
Release 0.4.1 (beta): file constants and modding guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,9 +125,10 @@ docs, image guidelines, diagnostics, mod report and credits.*
   `<mod>/.px-toolkit/calendar.json`, committed with the mod, and every script
   date shows its in-game form: `3000.1.1` reads `1000 BC` on hover and as an
   inlay hint.
-- **A wiki that lists the other tools.** A Modding Tools page per game
-  collects the validators, translators and editors other modders built, with
-  the ones the toolkit replaces left out.
+- **A wiki that lists the guides and the other tools.** A Modding Guides
+  page per game links every modding page of that game's wiki, and a Modding
+  Tools page collects the validators, translators and editors other modders
+  built, with the ones the toolkit replaces left out.
 - **Large workspaces are the design case.** A game install plus five Workshop
   mods, all indexed, opens in 61 s cold where it used to take 143, and one
   command stops VS Code itself crawling the game's textures and audio.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ localization workflow no other tool has.
 
 </div>
 
-> **Beta (0.3.x).** Young project, useful day to day, rough edges included.
+> **Beta.** Young project, useful day to day, rough edges included.
 > Bug reports and missing-feature complaints are the point, not a nuisance:
 > open an [issue](https://github.com/JDeffner/paradox-modding-toolkit/issues).
 

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -184,8 +184,9 @@ as a field report. The workspace is `cultivation.code-workspace`: the CK3
 install plus five workspace mods (Cultivation Mod, Custom Name Lists, Gesta,
 Hide Decisions, Mod Testing), a sixth excluded by `px.excludedMods`, 473,227
 definitions. Warm file cache, two runs per version, medians shown; the raw rows
-are in `packages/server/test/perf/history.json`. Recorded 2026-09-05 on the
-machine named at the top of this page.
+are in `packages/server/test/perf/history.json`. Recorded 2026-09-05 (0.4.1 on
+2026-09-06, after the workspace mods grew by 30 definitions) on the machine
+named at the top of this page.
 
 | version | time to indexed | completion, cold | completion, after save | completion, warm | heap after index | peak RSS |
 |---|---|---|---|---|---|---|
@@ -195,6 +196,7 @@ machine named at the top of this page.
 | 0.3.6 | 7.7 s | 199 ms | 186 ms | 8 ms | 266 MB | 856 MB |
 | 0.4.0 | 8.1 s | 252 ms | 184 ms | 10 ms | 267 MB | 852 MB |
 | 0.4.0 + realign-coa-editor | 7.8 s | 225 ms | 167 ms | 8 ms | 267 MB | 850 MB |
+| 0.4.1 | 5.9 s | 150 ms | 138 ms | 7 ms | 268 MB | 813 MB |
 
 What the rows say:
 

--- a/docs/release/0.4.1.md
+++ b/docs/release/0.4.1.md
@@ -1,0 +1,68 @@
+# Paradox Modding Toolkit 0.4.1 (beta)
+
+A small release with one editor feature people asked for, one wiki page, and
+a Workshop panel fix.
+
+### `@name` constants are first-class
+
+Vanilla files declare constants at the top and use them by name further down:
+
+```
+@scheme_beneficial_modifier_default_duration = 1825
+...
+days = @scheme_beneficial_modifier_default_duration
+```
+
+The game substitutes the text while it reads the file, so these names exist
+only in that file and were invisible to the toolkit. Now, in script and gui
+files of every game:
+
+- **Hover** on a use shows the value, the declaring line and how often the
+  file uses it. On the declaration it also says what a constant is.
+- **Go to Definition** (F12) jumps to the declaration.
+- **Completion** after `@` offers the file's constants with their values.
+- **An inlay hint** beside every use shows the value in grey, so
+  `days = @scheme_beneficial_modifier_default_duration` reads `= 1825`
+  without a hover.
+- **Inline math** is evaluated: a bare name inside `@[ ... ]` resolves like a
+  use, and a value such as `@[base / 20]` shows what it comes to, `→ 1`.
+  Every one of the 575 inline-math declarations in the CK3 buildings,
+  men-at-arms, script value and gui files evaluates.
+- A constant standing for a script value (`@cost = major_gold_value`) shows
+  that script value's definition on the same card.
+
+Nothing is indexed across files, so this costs nothing at startup or while
+typing. A hover on a constant in the game's largest script file, the 77,774
+line `00_landed_titles.txt`, takes 4 ms.
+
+### Modding Guides in the wiki
+
+A new wiki page per game lists the modding pages of that game's own wiki,
+taken from its Modding navbox, one card per page with a line on what the
+page covers, written from the page's own lead paragraph. Grouped as the wiki
+groups them (basics, script reference, scripting, interface and localization,
+map, graphics, audio, guides), with the same chips to filter as the Modding
+Tools page. 45 pages for Crusader Kings III, 55 for Victoria 3, 52 for
+Europa Universalis V.
+
+### Workshop panel
+
+The mod menu ends with "Upload a mod that is not in this workspace…", which
+picks any mod folder on disk and adds it to the menu for the session. The
+menu shows even when the workspace holds a single mod. The panel's Create
+Descriptor button now writes the descriptor into the mod the panel is on; it
+used to write into the focused workspace mod whichever mod the panel showed.
+
+### Also
+
+The README beta notes no longer name a version. `@px-lsp/server` 0.3.2 and
+`@px-lsp/protocol` 0.2.2 carry the constants feature and its `local_constant`
+kind.
+
+### Full changelog
+
+[CHANGELOG.md](https://github.com/JDeffner/paradox-modding-toolkit/blob/main/packages/vscode/CHANGELOG.md).
+
+Beta means young, not unusable. Tell me what breaks:
+[issues](https://github.com/JDeffner/paradox-modding-toolkit/issues) or the
+[Discord](https://discord.gg/DfEJ2H9hj4).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "px-lsp",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "private": true,
   "license": "GPL-3.0-or-later",
   "engines": {

--- a/packages/protocol/CHANGELOG.md
+++ b/packages/protocol/CHANGELOG.md
@@ -6,6 +6,12 @@ the shared helpers change. Before the split it moved inside the extension's
 version (up to 0.3.2); that history is in the extension changelog
 (`packages/vscode/CHANGELOG.md`).
 
+## Unreleased
+
+- `kinds.ts` names `local_constant` (the `@name = value` file constants'
+  hover badge: `symbol-constant`, grey). Never indexed, so no completion or
+  tree consumer sees it.
+
 ## 0.2.1
 
 Ships with the toolkit's 0.4.0 release.

--- a/packages/protocol/CHANGELOG.md
+++ b/packages/protocol/CHANGELOG.md
@@ -6,7 +6,9 @@ the shared helpers change. Before the split it moved inside the extension's
 version (up to 0.3.2); that history is in the extension changelog
 (`packages/vscode/CHANGELOG.md`).
 
-## Unreleased
+## 0.2.2
+
+Ships with the toolkit's 0.4.1 release.
 
 - `kinds.ts` names `local_constant` (the `@name = value` file constants'
   hover badge: `symbol-constant`, grey). Never indexed, so no completion or

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@px-lsp/protocol",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "license": "GPL-3.0-or-later",
   "description": "Wire contract (custom LSP requests/notifications, settings types) and shared helpers for the px-lsp language server and its clients.",
   "keywords": [

--- a/packages/protocol/src/kinds.ts
+++ b/packages/protocol/src/kinds.ts
@@ -166,6 +166,8 @@ const SCRIPT: Record<string, KindStyle> = {
 
   // grey: syntax and everything else.
   scope_word: c("symbol-constant", "Constant"),
+  // `@name = value` file constants: a hover badge only, they are never indexed.
+  local_constant: c("symbol-constant", "Constant"),
   structure_key: c("symbol-struct", "Struct"),
   descriptor_field: c("symbol-struct", "Struct"),
   keyword: c("symbol-keyword", "Keyword"),

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -6,6 +6,15 @@ changes. Before the split it moved inside the extension's version (up to
 0.3.2); that history is in the extension changelog
 (`packages/vscode/CHANGELOG.md`).
 
+## Unreleased
+
+- `@name` file constants get hover and definition: `provideConstantHover`
+  and `provideConstantDefinition` (`features/atConstants.ts`) answer from the
+  open document alone, before the usual script and gui providers run. They
+  cover `@name` uses, declarations and bare operands inside `@[ ... ]`; the
+  hover card carries the value, the declaring line and the in-file use
+  count, plus the indexed definition when the value is a script name.
+
 ## 0.3.1
 
 Ships with the toolkit's 0.4.0 release.

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -12,7 +12,8 @@ changes. Before the split it moved inside the extension's version (up to
   and `provideConstantDefinition` (`features/atConstants.ts`) answer from the
   open document alone, before the usual script and gui providers run. They
   cover `@name` uses, declarations and bare operands inside `@[ ... ]`; the
-  hover card carries the value, the declaring line and the in-file use
+  hover card carries the value (with the number an `@[ ... ]` expression
+  comes to, via `evaluateConstant`), the declaring line and the in-file use
   count, plus the indexed definition when the value is a script name.
 
 ## 0.3.1

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -6,15 +6,20 @@ changes. Before the split it moved inside the extension's version (up to
 0.3.2); that history is in the extension changelog
 (`packages/vscode/CHANGELOG.md`).
 
-## Unreleased
+## 0.3.2
 
-- `@name` file constants get hover and definition: `provideConstantHover`
-  and `provideConstantDefinition` (`features/atConstants.ts`) answer from the
-  open document alone, before the usual script and gui providers run. They
-  cover `@name` uses, declarations and bare operands inside `@[ ... ]`; the
-  hover card carries the value (with the number an `@[ ... ]` expression
-  comes to, via `evaluateConstant`), the declaring line and the in-file use
-  count, plus the indexed definition when the value is a script name.
+Ships with the toolkit's 0.4.1 release.
+
+- `@name` file constants get hover, definition, completion and inlay hints
+  (`features/atConstants.ts`), answered from the open document alone before
+  the usual script and gui providers run. They cover `@name` uses,
+  declarations and bare operands inside `@[ ... ]`; the hover card carries
+  the value (with the number an `@[ ... ]` expression comes to, via
+  `evaluateConstant`), the declaring line and the in-file use count, plus the
+  indexed definition when the value is a script name. `@` is a completion
+  trigger character; after it only the file's constants are offered, each
+  item replacing from the `@`. Every use of a declared constant gets an
+  inlay hint with its value. The LSP smoke suite covers all four requests.
 
 ## 0.3.1
 

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@px-lsp/server",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "license": "GPL-3.0-or-later",
   "description": "Language server for Paradox script (Crusader Kings III first), usable over node-ipc or stdio from any LSP client.",
   "keywords": [

--- a/packages/server/src/features/atConstants.ts
+++ b/packages/server/src/features/atConstants.ts
@@ -65,6 +65,86 @@ function useCount(text: string, name: string, declared: boolean): number {
   return declared ? all - 1 : all;
 }
 
+/**
+ * The number a constant's value comes to, following `@[ ... ]` inline math and
+ * `@other` references through the file's own declarations; null when a value
+ * is not numeric (`= major_gold_value`, a path), an operand is undeclared, or
+ * the math divides by zero. Depth-capped so `@a = @b` / `@b = @a` ends.
+ */
+export function evaluateConstant(value: string, decls: Map<string, ConstantDecl>, depth = 0): number | null {
+  if (depth > 16) return null;
+  const v = value.trim();
+  if (/^[+-]?(\d+\.?\d*|\.\d+)$/.test(v)) return Number(v);
+  if (/^@[A-Za-z0-9_]+$/.test(v)) {
+    const d = decls.get(v.slice(1));
+    return d ? evaluateConstant(d.value, decls, depth + 1) : null;
+  }
+  const math = /^@\[(.*)\]$/.exec(v);
+  if (!math) return null;
+  // Recursive descent over + - * / and parentheses; operands are numbers or
+  // names declared in this file.
+  const src = math[1];
+  let i = 0;
+  const skip = () => {
+    while (i < src.length && src[i] === " ") i++;
+  };
+  const atom = (): number | null => {
+    skip();
+    if (src[i] === "(") {
+      i++;
+      const inner = sum();
+      skip();
+      if (src[i] !== ")") return null;
+      i++;
+      return inner;
+    }
+    if (src[i] === "-") {
+      i++;
+      const n = atom();
+      return n === null ? null : -n;
+    }
+    const m = /^(\d+\.?\d*|\.\d+|[A-Za-z_][A-Za-z0-9_]*)/.exec(src.slice(i));
+    if (!m) return null;
+    i += m[0].length;
+    if (/^[\d.]/.test(m[0])) return Number(m[0]);
+    const d = decls.get(m[0]);
+    return d ? evaluateConstant(d.value, decls, depth + 1) : null;
+  };
+  const product = (): number | null => {
+    let left = atom();
+    for (;;) {
+      skip();
+      const op = src[i];
+      if (op !== "*" && op !== "/") return left;
+      i++;
+      const right = atom();
+      if (left === null || right === null) return null;
+      if (op === "/" && right === 0) return null;
+      left = op === "*" ? left * right : left / right;
+    }
+  };
+  const sum = (): number | null => {
+    let left = product();
+    for (;;) {
+      skip();
+      const op = src[i];
+      if (op !== "+" && op !== "-") return left;
+      i++;
+      const right = product();
+      if (left === null || right === null) return null;
+      left = op === "+" ? left + right : left - right;
+    }
+  };
+  const result = sum();
+  skip();
+  return i === src.length && result !== null && Number.isFinite(result) ? result : null;
+}
+
+/** At most four decimals, no trailing zeros: what a modder would type. */
+function formatNumber(n: number): string {
+  return String(Math.round(n * 10000) / 10000);
+}
+
 /** null when the cursor is not on a constant; the caller then goes on to its usual hover. */
 export function provideConstantHover(
   data: ServerData,
@@ -75,21 +155,31 @@ export function provideConstantHover(
   const ref = constantRefAt(lineText, position.character);
   if (!ref) return null;
   const text = document.getText();
-  const decl = constantDeclarations(text).get(ref.name);
+  const decls = constantDeclarations(text);
+  const decl = decls.get(ref.name);
   const uses = useCount(text, ref.name, decl !== undefined);
-  const where = decl
-    ? decl.line === position.line
-      ? "Declared here"
-      : `Declared on line ${decl.line + 1}`
-    : "Not declared in this file";
+  const usesText = `used ${uses} ${uses === 1 ? "time" : "times"} in this file`;
+  // The value, and what it comes to when it is inline math or another constant.
+  let headTail: string | undefined;
+  if (decl) {
+    headTail = `= ${decl.value}`;
+    const n = evaluateConstant(decl.value, decls);
+    if (n !== null && String(n) !== decl.value) headTail += ` → ${formatNumber(n)}`;
+  }
+  // What a constant IS is said where it is declared, and where it is missing:
+  // a resolved use only needs the value, the line and the count.
+  const what = "Text the game substitutes while reading this file, so the name only works in this file.";
+  const doc = !decl
+    ? `Not declared in this file · ${usesText}.\n\n${what}`
+    : decl.line === position.line
+      ? `${what}\n\nDeclared here · ${usesText}.`
+      : `Declared on line ${decl.line + 1} · ${usesText}.`;
   const card: CardInput = {
     kind: "local_constant",
     badgeLabel: "constant",
     name: `@${ref.name}`,
-    headTail: decl ? `= ${decl.value}` : undefined,
-    doc:
-      "Text the game substitutes while reading this file, so the name only works in this file.\n\n" +
-      `${where} · used ${uses} ${uses === 1 ? "time" : "times"} in this file.`,
+    headTail,
+    doc,
   };
   const cards = [card];
   // A constant standing for a script value (`= major_gold_value`) leads on to it.

--- a/packages/server/src/features/atConstants.ts
+++ b/packages/server/src/features/atConstants.ts
@@ -220,7 +220,7 @@ export function constantHints(document: TextDocument, range: Range): InlayHint[]
   const lastLine = Math.min(range.end.line, document.lineCount - 1);
   for (let line = range.start.line; line <= lastLine; line++) {
     const text = getLineText(document, line).split("#")[0];
-    const re = /@([A-Za-z0-9_]+)(?![A-Za-z0-9_!\[])/g;
+    const re = /@([A-Za-z0-9_]+)(?![A-Za-z0-9_![])/g;
     let m: RegExpExecArray | null;
     while ((m = re.exec(text)) !== null) {
       const decl = decls.get(m[1]);

--- a/packages/server/src/features/atConstants.ts
+++ b/packages/server/src/features/atConstants.ts
@@ -7,10 +7,19 @@
  * alone. Engine-wide: measured in every supported game's events/, common/ and
  * gui/ trees, declared the same way in each, so there is no GameProfile gate.
  */
-import { MarkupKind, type Hover, type Location, type Position } from "vscode-languageserver/node";
+import {
+  CompletionItemKind,
+  MarkupKind,
+  type CompletionList,
+  type Hover,
+  type InlayHint,
+  type Location,
+  type Position,
+  type Range,
+} from "vscode-languageserver/node";
 import type { TextDocument } from "vscode-languageserver-textdocument";
 import type { ServerData } from "../serverData";
-import { getLineText } from "../documents";
+import { getLineText, isScriptLanguage } from "../documents";
 import { wordRangeAt } from "../wordAt";
 import { definitionCards } from "./hover";
 import { renderHoverMarkdown, type CardInput } from "./hoverRender";
@@ -145,6 +154,89 @@ function formatNumber(n: number): string {
   return String(Math.round(n * 10000) / 10000);
 }
 
+/** True for the languages that declare `@name` constants: script and gui, not loc. */
+export function declaresConstants(languageId: string): boolean {
+  return isScriptLanguage(languageId) || languageId === "paradox-gui";
+}
+
+/** `= 1825`, or `= @[base / 20] → 1` when the value is math or another constant. */
+function valueTail(decl: ConstantDecl, decls: Map<string, ConstantDecl>): string {
+  const n = evaluateConstant(decl.value, decls);
+  return n !== null && String(n) !== decl.value ? `= ${decl.value} → ${formatNumber(n)}` : `= ${decl.value}`;
+}
+
+/**
+ * Completion after `@`, and for a bare operand inside `@[ ... ]`: the file's
+ * own constants and nothing else, since nothing else can stand there. null
+ * when the cursor is in neither place, so the usual provider runs.
+ */
+export function provideConstantCompletion(document: TextDocument, position: Position): CompletionList | null {
+  const before = getLineText(document, position.line).slice(0, position.character);
+  const at = /@([A-Za-z0-9_]*)$/.exec(before);
+  let bare = false;
+  let partialLength: number;
+  if (at) {
+    partialLength = at[0].length;
+  } else {
+    const open = before.lastIndexOf("@[");
+    if (open === -1 || before.slice(open + 2).includes("]")) return null;
+    bare = true;
+    partialLength = /[A-Za-z0-9_]*$/.exec(before)![0].length;
+  }
+  const decls = constantDeclarations(document.getText());
+  // The replaced range starts at the `@` (or the operand's first letter) so the
+  // client filters `@sch` against the `@`-prefixed labels.
+  const range: Range = {
+    start: { line: position.line, character: position.character - partialLength },
+    end: position,
+  };
+  let order = 0;
+  const items = [...decls].map(([name, decl]) => {
+    const label = bare ? name : `@${name}`;
+    return {
+      label,
+      kind: CompletionItemKind.Constant,
+      detail: valueTail(decl, decls),
+      // Declaration order, the order the file's author chose.
+      sortText: String(order++).padStart(4, "0"),
+      textEdit: { range, newText: label },
+    };
+  });
+  return { isIncomplete: false, items };
+}
+
+const HINT_MAX = 40;
+
+/**
+ * The value beside every `@name` use in `range`, as an inlay hint: `= 1825`,
+ * or the computed number for math and chained constants. Declarations and
+ * undeclared names get none; the comment part of a line is skipped.
+ */
+export function constantHints(document: TextDocument, range: Range): InlayHint[] {
+  if (!declaresConstants(document.languageId)) return [];
+  const decls = constantDeclarations(document.getText());
+  if (decls.size === 0) return [];
+  const hints: InlayHint[] = [];
+  const lastLine = Math.min(range.end.line, document.lineCount - 1);
+  for (let line = range.start.line; line <= lastLine; line++) {
+    const text = getLineText(document, line).split("#")[0];
+    const re = /@([A-Za-z0-9_]+)(?![A-Za-z0-9_!\[])/g;
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(text)) !== null) {
+      const decl = decls.get(m[1]);
+      if (!decl || (decl.line === line && decl.character === m.index)) continue;
+      const n = evaluateConstant(decl.value, decls);
+      const shown = n !== null ? formatNumber(n) : decl.value;
+      hints.push({
+        position: { line, character: m.index + m[0].length },
+        label: `= ${shown.length > HINT_MAX ? shown.slice(0, HINT_MAX - 1) + "…" : shown}`,
+        paddingLeft: true,
+      });
+    }
+  }
+  return hints;
+}
+
 /** null when the cursor is not on a constant; the caller then goes on to its usual hover. */
 export function provideConstantHover(
   data: ServerData,
@@ -160,12 +252,7 @@ export function provideConstantHover(
   const uses = useCount(text, ref.name, decl !== undefined);
   const usesText = `used ${uses} ${uses === 1 ? "time" : "times"} in this file`;
   // The value, and what it comes to when it is inline math or another constant.
-  let headTail: string | undefined;
-  if (decl) {
-    headTail = `= ${decl.value}`;
-    const n = evaluateConstant(decl.value, decls);
-    if (n !== null && String(n) !== decl.value) headTail += ` → ${formatNumber(n)}`;
-  }
+  const headTail = decl ? valueTail(decl, decls) : undefined;
   // What a constant IS is said where it is declared, and where it is missing:
   // a resolved use only needs the value, the line and the count.
   const what = "Text the game substitutes while reading this file, so the name only works in this file.";

--- a/packages/server/src/features/atConstants.ts
+++ b/packages/server/src/features/atConstants.ts
@@ -1,0 +1,129 @@
+/**
+ * `@name` constants: `@name = value` near the top of a script or gui file,
+ * then `@name` (or a bare `name` inside `@[ ... ]` inline math) anywhere in the
+ * SAME file. The reader substitutes the text while it loads the file, so a
+ * constant is not a database entry: no other file sees it, the index never
+ * lists it, and hover and go-to-definition answer from the open document
+ * alone. Engine-wide: measured in every supported game's events/, common/ and
+ * gui/ trees, declared the same way in each, so there is no GameProfile gate.
+ */
+import { MarkupKind, type Hover, type Location, type Position } from "vscode-languageserver/node";
+import type { TextDocument } from "vscode-languageserver-textdocument";
+import type { ServerData } from "../serverData";
+import { getLineText } from "../documents";
+import { wordRangeAt } from "../wordAt";
+import { definitionCards } from "./hover";
+import { renderHoverMarkdown, type CardInput } from "./hoverRender";
+
+export interface ConstantRef {
+  name: string;
+  /** Character offsets on the line; `@name` includes the `@`, a math operand does not. */
+  start: number;
+  end: number;
+}
+
+export interface ConstantDecl {
+  line: number;
+  /** Where the `@` sits. */
+  character: number;
+  value: string;
+}
+
+const NAME = /^[A-Za-z0-9_]+$/;
+
+/** The constant the cursor is on: a `@name` use or declaration, or an operand of `@[ ... ]`. */
+export function constantRefAt(lineText: string, character: number): ConstantRef | null {
+  const range = wordRangeAt(lineText, character);
+  if (!range || !NAME.test(range.word)) return null;
+  if (lineText[range.start - 1] === "@") {
+    // `@icon!` in a quoted string is a loc icon, not a constant.
+    if (lineText[range.end] === "!") return null;
+    return { name: range.word, start: range.start - 1, end: range.end };
+  }
+  // Inside an unclosed `@[` before the word: a numeric literal is not a name.
+  const open = lineText.lastIndexOf("@[", range.start);
+  if (open === -1 || lineText.slice(open + 2, range.start).includes("]")) return null;
+  if (/^\d/.test(range.word)) return null;
+  return { name: range.word, start: range.start, end: range.end };
+}
+
+/** Every `@name = value` declaration in the document, first one wins. */
+export function constantDeclarations(text: string): Map<string, ConstantDecl> {
+  const out = new Map<string, ConstantDecl>();
+  const lines = text.split("\n");
+  for (let line = 0; line < lines.length; line++) {
+    const m = /^([ \t]*)@([A-Za-z0-9_]+)[ \t]*=[ \t]*([^#\r\n]*)/.exec(lines[line]);
+    if (!m || out.has(m[2])) continue;
+    out.set(m[2], { line, character: m[1].length, value: m[3].trim() });
+  }
+  return out;
+}
+
+/** Uses of `@name` in the document, the declaration not counted. */
+function useCount(text: string, name: string, declared: boolean): number {
+  const all = text.match(new RegExp(`@${name}(?![A-Za-z0-9_])`, "g"))?.length ?? 0;
+  return declared ? all - 1 : all;
+}
+
+/** null when the cursor is not on a constant; the caller then goes on to its usual hover. */
+export function provideConstantHover(
+  data: ServerData,
+  document: TextDocument,
+  position: Position
+): Hover | null {
+  const lineText = getLineText(document, position.line);
+  const ref = constantRefAt(lineText, position.character);
+  if (!ref) return null;
+  const text = document.getText();
+  const decl = constantDeclarations(text).get(ref.name);
+  const uses = useCount(text, ref.name, decl !== undefined);
+  const where = decl
+    ? decl.line === position.line
+      ? "Declared here"
+      : `Declared on line ${decl.line + 1}`
+    : "Not declared in this file";
+  const card: CardInput = {
+    kind: "local_constant",
+    badgeLabel: "constant",
+    name: `@${ref.name}`,
+    headTail: decl ? `= ${decl.value}` : undefined,
+    doc:
+      "Text the game substitutes while reading this file, so the name only works in this file.\n\n" +
+      `${where} · used ${uses} ${uses === 1 ? "time" : "times"} in this file.`,
+  };
+  const cards = [card];
+  // A constant standing for a script value (`= major_gold_value`) leads on to it.
+  if (decl && NAME.test(decl.value) && !/^\d/.test(decl.value)) {
+    cards.push(...definitionCards(data, data.index.lookup(decl.value)));
+  }
+  return {
+    contents: { kind: MarkupKind.Markdown, value: renderHoverMarkdown(cards) },
+    range: {
+      start: { line: position.line, character: ref.start },
+      end: { line: position.line, character: ref.end },
+    },
+  };
+}
+
+/**
+ * null when the cursor is not on a constant. A `@name` with no declaration
+ * yields [] (nothing else can resolve it); a bare math operand without one
+ * yields null so the usual lookup still runs.
+ */
+export function provideConstantDefinition(document: TextDocument, position: Position): Location[] | null {
+  const lineText = getLineText(document, position.line);
+  const ref = constantRefAt(lineText, position.character);
+  if (!ref) return null;
+  const decl = constantDeclarations(document.getText()).get(ref.name);
+  if (!decl) return lineText[ref.start] === "@" ? [] : null;
+  if (decl.line === position.line) return [];
+  return [
+    {
+      uri: document.uri,
+      range: {
+        start: { line: decl.line, character: decl.character },
+        end: { line: decl.line, character: decl.character + ref.name.length + 1 },
+      },
+    },
+  ];
+}

--- a/packages/server/src/features/hover.ts
+++ b/packages/server/src/features/hover.ts
@@ -334,7 +334,7 @@ function atKeyPosition(document: TextDocument, position: Position): boolean {
  * The name-wide reference count renders once, on the first card, because it is
  * a property of the name, not of any one definition.
  */
-function definitionCards(
+export function definitionCards(
   data: ServerData,
   defs: Array<ReturnType<ServerData["index"]["lookup"]>[number]>,
   at?: { uri: string; line: number; character: number }

--- a/packages/server/src/features/inlayHints.ts
+++ b/packages/server/src/features/inlayHints.ts
@@ -21,6 +21,7 @@ import type { SchemaEntry } from "../schema/types";
 import type { Scope } from "../scopes/model";
 import { walkStatements } from "../parser";
 import { calendarHints } from "./calendarDates";
+import { constantHints } from "./atConstants";
 import type { CalendarSetting } from "@px-lsp/protocol/calendar";
 
 const HINT_MAX_LEN = 60;
@@ -41,6 +42,7 @@ export function provideInlayHints(
 ): InlayHint[] {
   if (document.languageId === "paradox-loc") return translationOverlayHints(data, settings, document, range);
   const hints = locPreviewHints(data, document, range);
+  hints.push(...constantHints(document, range));
   if (settings.scopeInlayHints) hints.push(...scopeHints(data, document, range, rootScopes, entry));
   if (calendar) hints.push(...calendarHints(calendar, document, range));
   return hints;

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -175,7 +175,12 @@ import { sanitizeCalendar, type CalendarSetting } from "@px-lsp/protocol/calenda
 import { isCalendarFile, readCalendarFile } from "@px-lsp/protocol/calendarFile";
 import { provideTextureHover } from "./features/textureHover";
 import { provideDefinition, provideLocDefinition } from "./features/definition";
-import { provideConstantDefinition, provideConstantHover } from "./features/atConstants";
+import {
+  declaresConstants,
+  provideConstantCompletion,
+  provideConstantDefinition,
+  provideConstantHover,
+} from "./features/atConstants";
 import { SEMANTIC_LEGEND, provideSemanticTokens } from "./features/semanticTokens";
 import { provideInlayHints } from "./features/inlayHints";
 import { computeScopeAt } from "./features/scopeAt";
@@ -1440,7 +1445,10 @@ connection.onInitialize((params: InitializeParams): InitializeResult => {
         change: TextDocumentSyncKind.Incremental,
         save: true,
       },
-      completionProvider: { resolveProvider: true, triggerCharacters: [":", ".", "[", "'", "|", "#", "/"] },
+      completionProvider: {
+        resolveProvider: true,
+        triggerCharacters: [":", ".", "[", "'", "|", "#", "/", "@"],
+      },
       signatureHelpProvider: { triggerCharacters: ["{", "("], retriggerCharacters: ["=", ","] },
       hoverProvider: true,
       definitionProvider: true,
@@ -1913,6 +1921,11 @@ connection.onCompletion((params) =>
   indexRead(`completion ${perfName(params.textDocument.uri)}`, () => {
     const doc = documents.get(params.textDocument.uri);
     if (!doc) return [];
+    // After `@`, only the file's own constants can follow: script and gui alike.
+    if (declaresConstants(doc.languageId)) {
+      const constants = provideConstantCompletion(doc, params.position);
+      if (constants) return constants;
+    }
     if (doc.languageId === "paradox-gui") {
       const result = provideGuiCompletion(data, doc, doc.offsetAt(params.position), settings);
       return { isIncomplete: result.isIncomplete, items: result.items };
@@ -1947,7 +1960,7 @@ connection.onHover((params) =>
     const doc = documents.get(params.textDocument.uri);
     if (!doc) return null;
     // `@name` file constants come first: script and gui files declare them alike.
-    if (doc.languageId === "paradox-gui" || isScriptLanguage(doc.languageId)) {
+    if (declaresConstants(doc.languageId)) {
       const constant = provideConstantHover(data, doc, params.position);
       if (constant) return constant;
     }

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -175,6 +175,7 @@ import { sanitizeCalendar, type CalendarSetting } from "@px-lsp/protocol/calenda
 import { isCalendarFile, readCalendarFile } from "@px-lsp/protocol/calendarFile";
 import { provideTextureHover } from "./features/textureHover";
 import { provideDefinition, provideLocDefinition } from "./features/definition";
+import { provideConstantDefinition, provideConstantHover } from "./features/atConstants";
 import { SEMANTIC_LEGEND, provideSemanticTokens } from "./features/semanticTokens";
 import { provideInlayHints } from "./features/inlayHints";
 import { computeScopeAt } from "./features/scopeAt";
@@ -1945,6 +1946,11 @@ connection.onHover((params) =>
   indexRead(`hover ${perfName(params.textDocument.uri)}`, () => {
     const doc = documents.get(params.textDocument.uri);
     if (!doc) return null;
+    // `@name` file constants come first: script and gui files declare them alike.
+    if (doc.languageId === "paradox-gui" || isScriptLanguage(doc.languageId)) {
+      const constant = provideConstantHover(data, doc, params.position);
+      if (constant) return constant;
+    }
     if (doc.languageId === "paradox-gui") {
       const texture = provideTextureHover(settings, doc, params.position);
       if (texture) return texture;
@@ -2025,6 +2031,8 @@ connection.onDefinition((params) =>
     // Plain loc-key jumps stay with the client-side script-usage provider.
     if (doc.languageId === "paradox-loc") return provideLocDefinition(data, doc, params.position);
     if (!isScriptLanguage(doc.languageId) && doc.languageId !== "paradox-gui") return [];
+    const constant = provideConstantDefinition(doc, params.position);
+    if (constant) return constant;
     if (doc.languageId === "paradox-gui") {
       // Types, templates and blockoverride targets resolve through the FIOS
       // store first (what the game actually uses); loc keys etc. fall through.

--- a/packages/server/test/atConstants.test.ts
+++ b/packages/server/test/atConstants.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it } from "vitest";
 import { TextDocument } from "vscode-languageserver-textdocument";
 import {
   constantDeclarations,
+  constantHints,
   constantRefAt,
   evaluateConstant,
+  provideConstantCompletion,
   provideConstantDefinition,
   provideConstantHover,
 } from "../src/features/atConstants";
@@ -132,5 +134,44 @@ describe("@ constants: value arithmetic and doc placement", () => {
     expect(md(0, 3)).not.toContain("→");
     // Nothing to compute: the expression stands alone.
     expect(md(4, 3)).toContain("= @[base / 0]\n");
+  });
+});
+
+describe("@ constants: completion and inlay hints", () => {
+  const TEXT = [
+    "@duration = 1825",
+    "@cost = @[duration / 365]",
+    "@label = major_gold_value",
+    "e.1 = {",
+    "\tdays = @dur",
+    "\tgold = @[ du",
+    "\tvalue = @cost # was @duration",
+    "\tother = @nope",
+    "}",
+  ].join("\n");
+  const d = TextDocument.create("file:///m/events/c.txt", "paradox", 1, TEXT);
+
+  it("after @ offers the file's constants with their values, replacing from the @", () => {
+    const list = provideConstantCompletion(d, { line: 4, character: 12 })!;
+    expect(list.items.map((i) => i.label)).toEqual(["@duration", "@cost", "@label"]);
+    expect(list.items[1].detail).toBe("= @[duration / 365] → 5");
+    expect(list.items[0].textEdit).toEqual({
+      range: { start: { line: 4, character: 8 }, end: { line: 4, character: 12 } },
+      newText: "@duration",
+    });
+    // Inside @[ ... ] the names go bare; elsewhere the usual provider runs.
+    expect(provideConstantCompletion(d, { line: 5, character: 13 })!.items[0].label).toBe("duration");
+    expect(provideConstantCompletion(d, { line: 4, character: 4 })).toBeNull();
+  });
+
+  it("hints the value beside each use, never on the declaration, an unknown name or a comment", () => {
+    const hints = constantHints(d, { start: { line: 0, character: 0 }, end: { line: 8, character: 0 } });
+    // Line 1's operand sits inside @[ ... ] without an @: no hint there, by design.
+    expect(hints.map((h) => [h.position.line, h.label])).toEqual([[6, "= 5"]]);
+    // Loc files never declare constants.
+    const loc = TextDocument.create("file:///m/l_english.yml", "paradox-loc", 1, TEXT);
+    expect(constantHints(loc, { start: { line: 0, character: 0 }, end: { line: 8, character: 0 } })).toEqual(
+      []
+    );
   });
 });

--- a/packages/server/test/atConstants.test.ts
+++ b/packages/server/test/atConstants.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import { TextDocument } from "vscode-languageserver-textdocument";
+import { constantRefAt, provideConstantDefinition, provideConstantHover } from "../src/features/atConstants";
+import { ServerData } from "../src/serverData";
+
+// Shape of game/events/scheme_events/agent_events.txt: declared once at the
+// top, used by name further down, and one value that is itself a script value.
+const TEXT = [
+  "namespace = agent_events",
+  "@scheme_beneficial_modifier_default_duration = 1825",
+  "@bet_value = major_gold_value # a script value",
+  "",
+  "agent_events.0021 = {",
+  "\timmediate = {",
+  "\t\tadd_scheme_modifier = {",
+  "\t\t\tdays = @scheme_beneficial_modifier_default_duration",
+  "\t\t}",
+  "\t\tadd_gold = @[ bet_value * 2 ]",
+  "\t\tadd_prestige = @missing",
+  "\t}",
+  "}",
+].join("\n");
+
+const doc = (uri = "file:///m/events/agent_events.txt") => TextDocument.create(uri, "paradox", 1, TEXT);
+
+describe("@ constants", () => {
+  it("finds a @name use, the operand of inline math, and nothing else", () => {
+    expect(constantRefAt("\t\t\tdays = @scheme_x", 12)).toEqual({ name: "scheme_x", start: 10, end: 19 });
+    expect(constantRefAt("\t\tadd_gold = @[ bet_value * 2 ]", 18)).toEqual({
+      name: "bet_value",
+      start: 16,
+      end: 25,
+    });
+    expect(constantRefAt("\t\tadd_gold = @[ bet_value * 2 ]", 28)).toBeNull(); // the literal 2
+    expect(constantRefAt("\t\tdays = plain_word", 12)).toBeNull();
+    expect(constantRefAt('\t\ttext = "@gold_icon!"', 14)).toBeNull(); // loc icon, not a constant
+  });
+
+  it("go-to-definition jumps to the declaration in the same file", () => {
+    const d = doc();
+    const use = provideConstantDefinition(d, { line: 7, character: 20 });
+    expect(use).toEqual([
+      { uri: d.uri, range: { start: { line: 1, character: 0 }, end: { line: 1, character: 44 } } },
+    ]);
+    // A math operand resolves the same way; the declaration itself goes nowhere.
+    expect(provideConstantDefinition(d, { line: 9, character: 18 })?.[0].range.start.line).toBe(2);
+    expect(provideConstantDefinition(d, { line: 1, character: 5 })).toEqual([]);
+    // Undeclared: a @name stops (nothing else can resolve it), a plain word falls through.
+    expect(provideConstantDefinition(d, { line: 10, character: 20 })).toEqual([]);
+    expect(provideConstantDefinition(d, { line: 0, character: 3 })).toBeNull();
+  });
+
+  it("hover shows the value, the declaring line and the use count", () => {
+    const data = new ServerData();
+    const hover = provideConstantHover(data, doc(), { line: 7, character: 20 });
+    expect(hover).not.toBeNull();
+    const md = hover!.contents as { value: string };
+    expect(md.value).toContain("@scheme_beneficial_modifier_default_duration");
+    expect(md.value).toContain("= 1825");
+    expect(md.value).toContain("Declared on line 2");
+    expect(md.value).toContain("used 1 time in this file");
+    expect(hover!.range).toEqual({ start: { line: 7, character: 10 }, end: { line: 7, character: 54 } });
+  });
+
+  it("a constant standing for an indexed name leads on to that definition", () => {
+    const data = new ServerData();
+    data.index.addAll([
+      {
+        name: "major_gold_value",
+        kind: "script_value",
+        file: "/g/common/script_values/00_a.txt",
+        line: 3,
+        source: "vanilla",
+      },
+    ]);
+    const md = provideConstantHover(data, doc(), { line: 9, character: 18 })!.contents as { value: string };
+    expect(md.value).toContain("major_gold_value");
+    expect(md.value).toContain("00_a.txt:4");
+  });
+
+  it("an undeclared @name still answers, and says so", () => {
+    const md = provideConstantHover(new ServerData(), doc(), { line: 10, character: 20 })!.contents as {
+      value: string;
+    };
+    expect(md.value).toContain("Not declared in this file");
+  });
+});

--- a/packages/server/test/atConstants.test.ts
+++ b/packages/server/test/atConstants.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest";
 import { TextDocument } from "vscode-languageserver-textdocument";
-import { constantRefAt, provideConstantDefinition, provideConstantHover } from "../src/features/atConstants";
+import {
+  constantDeclarations,
+  constantRefAt,
+  evaluateConstant,
+  provideConstantDefinition,
+  provideConstantHover,
+} from "../src/features/atConstants";
 import { ServerData } from "../src/serverData";
 
 // Shape of game/events/scheme_events/agent_events.txt: declared once at the
@@ -83,5 +89,48 @@ describe("@ constants", () => {
       value: string;
     };
     expect(md.value).toContain("Not declared in this file");
+  });
+});
+
+describe("@ constants: value arithmetic and doc placement", () => {
+  const MATH = [
+    "@base = 20",
+    "@spacing = @[base / 20]",
+    "@half = @[ (base + 10) * 0.5 - 1 ]",
+    "@alias = @base",
+    "@broken = @[base / 0]",
+    "@unknown = @[nope * 2]",
+    "@loop_a = @loop_b",
+    "@loop_b = @loop_a",
+    "x = @spacing",
+  ].join("\n");
+
+  it("computes inline math over the file's own declarations", () => {
+    const decls = constantDeclarations(MATH);
+    expect(evaluateConstant("@[base / 20]", decls)).toBe(1);
+    expect(evaluateConstant("@[ (base + 10) * 0.5 - 1 ]", decls)).toBe(14);
+    expect(evaluateConstant("@[base * -1]", decls)).toBe(-20);
+    expect(evaluateConstant("@base", decls)).toBe(20);
+    expect(evaluateConstant("1825", decls)).toBe(1825);
+    // Not a number: a script value name, a division by zero, an undeclared operand, a cycle.
+    expect(evaluateConstant("major_gold_value", decls)).toBeNull();
+    expect(evaluateConstant("@[base / 0]", decls)).toBeNull();
+    expect(evaluateConstant("@[nope * 2]", decls)).toBeNull();
+    expect(evaluateConstant("@loop_a", decls)).toBeNull();
+  });
+
+  it("shows the computed number after the expression, and the explanation only where it helps", () => {
+    const d = TextDocument.create("file:///m/gui/x.gui", "paradox-gui", 1, MATH);
+    const md = (line: number, character: number) =>
+      (provideConstantHover(new ServerData(), d, { line, character })!.contents as { value: string }).value;
+    // A use: value, computed number, line and count. No lecture.
+    expect(md(8, 6)).toContain("= @[base / 20] → 1");
+    expect(md(8, 6)).not.toContain("substitutes");
+    // The declaration carries the explanation; a plain number is not repeated after an arrow.
+    expect(md(0, 3)).toContain("substitutes");
+    expect(md(0, 3)).toContain("= 20\n");
+    expect(md(0, 3)).not.toContain("→");
+    // Nothing to compute: the expression stands alone.
+    expect(md(4, 3)).toContain("= @[base / 0]\n");
   });
 });

--- a/packages/server/test/lspSmoke.test.ts
+++ b/packages/server/test/lspSmoke.test.ts
@@ -535,6 +535,50 @@ describe.skipIf(!hasServer)("LSP smoke over node IPC (the client's transport)", 
     expect(refs.some((r) => r.uri.includes("smoke_events.txt") && r.range.start.line === 33)).toBe(true);
   });
 
+  it("@name constants: hover, completion, definition and inlay hints answer from the open file", async () => {
+    const text = [
+      "namespace = smoke_const",
+      "@px_smoke_days = 1825",
+      "@px_smoke_half = @[px_smoke_days / 2]",
+      "smoke_const.1 = {",
+      "	immediate = {",
+      "		add_gold = @px_smoke_half",
+      "		add_prestige = @px_",
+      "	}",
+      "}",
+    ].join("\n");
+    const uri = toUri(path.join(modDir, "events", "smoke_constants.txt"));
+    void conn.sendNotification("textDocument/didOpen", {
+      textDocument: { uri, languageId: "paradox", version: 1, text },
+    });
+    const hover = (await conn.sendRequest("textDocument/hover", {
+      textDocument: { uri },
+      position: { line: 5, character: 20 },
+    })) as { contents: { value: string } } | null;
+    expect(hover!.contents.value).toContain("@px_smoke_half");
+    expect(hover!.contents.value).toContain("= @[px_smoke_days / 2] → 912.5");
+
+    const completion = (await conn.sendRequest("textDocument/completion", {
+      textDocument: { uri },
+      position: { line: 6, character: 21 },
+    })) as { items: Array<{ label: string; detail?: string }> };
+    expect(completion.items.map((i) => i.label)).toEqual(["@px_smoke_days", "@px_smoke_half"]);
+    expect(completion.items[0].detail).toBe("= 1825");
+
+    const defs = (await conn.sendRequest("textDocument/definition", {
+      textDocument: { uri },
+      position: { line: 5, character: 20 },
+    })) as Array<{ uri: string; range: { start: { line: number } } }>;
+    expect(defs).toHaveLength(1);
+    expect(defs[0].range.start.line).toBe(2);
+
+    const hints = (await conn.sendRequest("textDocument/inlayHint", {
+      textDocument: { uri },
+      range: { start: { line: 0, character: 0 }, end: { line: 8, character: 0 } },
+    })) as Array<{ position: { line: number }; label: string }>;
+    expect(hints.filter((h) => h.position.line === 5).map((h) => h.label)).toEqual(["= 912.5"]);
+  });
+
   it("completion offers the parent-mod effect", async () => {
     const result = (await conn.sendRequest("textDocument/completion", {
       textDocument: { uri: eventsUri },

--- a/packages/server/test/perf/history.json
+++ b/packages/server/test/perf/history.json
@@ -336,6 +336,62 @@
         "peakRssMb": 858,
         "rssSamples": 20
       }
+    },
+    {
+      "version": "0.4.1",
+      "recordedAt": "2026-09-06",
+      "workspace": "cultivation.code-workspace",
+      "roots": 6,
+      "build": "working tree dist/server.js",
+      "machine": {
+        "cpu": "AMD Ryzen 7 5800X 8-Core Processor             ",
+        "totalMemGb": 32,
+        "node": "v24.12.0"
+      },
+      "results": {
+        "timeToIndexedMs": 5761,
+        "definitions": 473257,
+        "completionCold": 150,
+        "completionWarm": 6,
+        "semanticTokens": 1,
+        "hover": 3,
+        "documentSymbol": 1,
+        "completionAfterSave": 148,
+        "tokensAfterSave": 1,
+        "heapMb": 268,
+        "rssAtBuildMb": 702,
+        "internedIdentifiers": 551751,
+        "peakRssMb": 809,
+        "rssSamples": 15
+      }
+    },
+    {
+      "version": "0.4.1",
+      "recordedAt": "2026-09-06",
+      "workspace": "cultivation.code-workspace",
+      "roots": 6,
+      "build": "working tree dist/server.js",
+      "machine": {
+        "cpu": "AMD Ryzen 7 5800X 8-Core Processor             ",
+        "totalMemGb": 32,
+        "node": "v24.12.0"
+      },
+      "results": {
+        "timeToIndexedMs": 6030,
+        "definitions": 473257,
+        "completionCold": 150,
+        "completionWarm": 7,
+        "semanticTokens": 1,
+        "hover": 3,
+        "documentSymbol": 1,
+        "completionAfterSave": 127,
+        "tokensAfterSave": 1,
+        "heapMb": 268,
+        "rssAtBuildMb": 701,
+        "internedIdentifiers": 551751,
+        "peakRssMb": 816,
+        "rssSamples": 16
+      }
     }
   ]
 }

--- a/packages/server/test/perf/profileWorkspace.ts
+++ b/packages/server/test/perf/profileWorkspace.ts
@@ -317,16 +317,20 @@ console.log(`\nwrote ${outDir}/results.json and server.log`);
 
 // The version history: one row per run, the doc's table is drawn from it.
 if (historyFile) {
+  // The file is `{ note, runs: [...] }`, one row per run, keyed the way
+  // history.json already is (version + build), so the doc's table reads it.
   const file = path.resolve(historyFile);
-  const history: unknown[] = fs.existsSync(file)
-    ? (JSON.parse(fs.readFileSync(file, "utf8")) as unknown[])
-    : [];
-  history.push({
-    label: label ?? "unlabelled",
+  const history: { note?: string; runs: unknown[] } = fs.existsSync(file)
+    ? (JSON.parse(fs.readFileSync(file, "utf8")) as { note?: string; runs: unknown[] })
+    : { runs: [] };
+  history.runs.push({
+    version: label ?? "unlabelled",
     recordedAt: new Date().toISOString().slice(0, 10),
     workspace: path.basename(wsFile),
     roots: modRoots.length + (gamePath ? 1 : 0),
-    server: SERVER,
+    build: SERVER.includes("worktree")
+      ? `dist/server.js of a worktree (${SERVER})`
+      : "working tree dist/server.js",
     machine: {
       cpu: os.cpus()[0]?.model ?? "?",
       totalMemGb: Math.round(os.totalmem() / 1073741824),

--- a/packages/vscode/CHANGELOG.md
+++ b/packages/vscode/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## Unreleased
+
+- **Hover and Go to Definition work on `@name` constants.** `@duration = 1825`
+  at the top of a file, then `days = @duration` further down: the hover shows
+  the value, the declaring line and how often the file uses it, and F12 jumps
+  to the declaration. The same goes for a bare name inside `@[ ... ]` inline
+  math. A constant standing for a script value (`@cost = major_gold_value`)
+  shows that definition on the same card. The game substitutes these while
+  reading the file, so they only exist in that file: the hover says so, and
+  nothing is indexed across files. Script and gui files alike, every game.
+- **Wiki: a Modding Guides page per game.** The game wiki's modding pages
+  for the game the switch is on, one card per page with a line on what the
+  page covers, grouped as the wiki groups them (basics, script reference,
+  scripting, interface and localization, map, graphics, audio, guides).
+  45 pages for CK3, 55 for Vic3, 52 for EU5, taken from each wiki's Modding
+  navbox; the chips filter by group.
+- **The Workshop panel manages mods outside the workspace.** Its mod menu
+  now also lists the mods in your projects folder and in the game's own mod
+  folder, each marked with where it comes from, and ends with "Browse for a
+  mod folder" for any other place on disk. The menu shows even when the
+  workspace holds a single mod. A picked mod without a descriptor gets the
+  same "Create Descriptor" offer as before, and that button now writes the
+  descriptor into the mod the panel is on; it used to write into the focused
+  workspace mod whichever mod the panel showed.
+
 ## 0.4.0 (beta) - the visual creators release
 
 Everything the 0.3.5 and 0.3.6 pre-releases carried is now a normal release:

--- a/packages/vscode/CHANGELOG.md
+++ b/packages/vscode/CHANGELOG.md
@@ -6,8 +6,9 @@
   at the top of a file, then `days = @duration` further down: the hover shows
   the value, the declaring line and how often the file uses it, and F12 jumps
   to the declaration. The same goes for a bare name inside `@[ ... ]` inline
-  math. A constant standing for a script value (`@cost = major_gold_value`)
-  shows that definition on the same card. The game substitutes these while
+  math, and a value that is inline math shows what it comes to
+  (`= @[base / 20] → 1`). A constant standing for a script value
+  (`@cost = major_gold_value`) shows that definition on the same card. The game substitutes these while
   reading the file, so they only exist in that file: the hover says so, and
   nothing is indexed across files. Script and gui files alike, every game.
 - **Wiki: a Modding Guides page per game.** The game wiki's modding pages

--- a/packages/vscode/CHANGELOG.md
+++ b/packages/vscode/CHANGELOG.md
@@ -1,16 +1,20 @@
 # Changelog
 
-## Unreleased
+## 0.4.1 (beta) - file constants and modding guides
 
-- **Hover and Go to Definition work on `@name` constants.** `@duration = 1825`
-  at the top of a file, then `days = @duration` further down: the hover shows
-  the value, the declaring line and how often the file uses it, and F12 jumps
-  to the declaration. The same goes for a bare name inside `@[ ... ]` inline
+- **`@name` constants get hover, Go to Definition, completion and an inlay
+  hint.** `@duration = 1825` at the top of a file, then `days = @duration`
+  further down: the hover shows the value, the declaring line and how often
+  the file uses it, F12 jumps to the declaration, typing `@` offers the
+  file's constants with their values, and every use carries its value as a
+  grey inlay hint. The same goes for a bare name inside `@[ ... ]` inline
   math, and a value that is inline math shows what it comes to
-  (`= @[base / 20] → 1`). A constant standing for a script value
-  (`@cost = major_gold_value`) shows that definition on the same card. The game substitutes these while
-  reading the file, so they only exist in that file: the hover says so, and
-  nothing is indexed across files. Script and gui files alike, every game.
+  (`= @[base / 20] → 1`); all 575 such declarations in the CK3 buildings,
+  men-at-arms, script value and gui files evaluate. A constant standing for
+  a script value (`@cost = major_gold_value`) shows that definition on the
+  same card. The game substitutes these while reading the file, so they only
+  exist in that file: nothing is indexed across files. Script and gui files
+  alike, every game.
 - **Wiki: a Modding Guides page per game.** The game wiki's modding pages
   for the game the switch is on, one card per page with a line on what the
   page covers, grouped as the wiki groups them (basics, script reference,

--- a/packages/vscode/CHANGELOG.md
+++ b/packages/vscode/CHANGELOG.md
@@ -17,14 +17,14 @@
   scripting, interface and localization, map, graphics, audio, guides).
   45 pages for CK3, 55 for Vic3, 52 for EU5, taken from each wiki's Modding
   navbox; the chips filter by group.
-- **The Workshop panel manages mods outside the workspace.** Its mod menu
-  now also lists the mods in your projects folder and in the game's own mod
-  folder, each marked with where it comes from, and ends with "Browse for a
-  mod folder" for any other place on disk. The menu shows even when the
-  workspace holds a single mod. A picked mod without a descriptor gets the
-  same "Create Descriptor" offer as before, and that button now writes the
-  descriptor into the mod the panel is on; it used to write into the focused
-  workspace mod whichever mod the panel showed.
+- **The Workshop panel uploads mods outside the workspace.** Its mod menu
+  lists the workspace mods as before and ends with "Upload a mod that is not
+  in this workspace", which picks any mod folder on disk and adds it to the
+  menu for the session, marked as outside the workspace. The menu shows even
+  when the workspace holds a single mod. A picked mod without a descriptor
+  gets the same "Create Descriptor" offer as before, and that button now
+  writes the descriptor into the mod the panel is on; it used to write into
+  the focused workspace mod whichever mod the panel showed.
 
 ## 0.4.0 (beta) - the visual creators release
 

--- a/packages/vscode/README.md
+++ b/packages/vscode/README.md
@@ -17,7 +17,7 @@ overview, and a localization workflow no other tool has.
 
 </div>
 
-> **Beta (0.3.x).** This is a young project and things will change. It is
+> **Beta.** This is a young project and things will change. It is
 > already useful day to day, but you will hit rough edges. Feedback is not just
 > welcome, it is the point: see [Contributing](#contributing--feedback) below.
 

--- a/packages/vscode/README.md
+++ b/packages/vscode/README.md
@@ -126,10 +126,11 @@ bottom says exactly where they stop.
   the game's own art and text as the preview. Every indexed value is a picker,
   the localization is written for you, and reopening something you already
   have rewrites only the lines you changed.
-- **The wiki lists the other tools too**: a **Modding Tools** page per game
-  collects the validators, translators, map and history editors other modders
-  built, curated from that game's own wiki list, with the ones the toolkit
-  replaces left out.
+- **The wiki lists the guides and the other tools too**: a **Modding
+  Guides** page per game links every modding page of that game's wiki with a
+  line on what it covers, and a **Modding Tools** page collects the
+  validators, translators, map and history editors other modders built, with
+  the ones the toolkit replaces left out.
 - **Multi-mod workspaces**: every workspace mod is a first-class mod, indexed
   together, with per-mod tiger baselines and no "primary mod" to configure.
 - **Built for the big workspaces**: a game install plus five Workshop mods,

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "px-toolkit",
   "displayName": "Paradox Modding Toolkit",
   "description": "Modding toolkit for Paradox games (Crusader Kings III, Victoria 3, Europa Universalis V): completion, go-to-definition, hover docs, tiger diagnostics, inline localization, event graph and a visual GUI editor.",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "publisher": "JDeffner",
   "author": {
     "name": "Joël Deffner"

--- a/packages/vscode/src/descriptorMod.ts
+++ b/packages/vscode/src/descriptorMod.ts
@@ -205,6 +205,46 @@ export interface DescriptorModFeature extends vscode.Disposable {
   refresh(): void;
 }
 
+/**
+ * The descriptor a mod root lacks, scaffolded from the folder name and the
+ * installed game version; an existing one is left alone. Returns the file
+ * path either way. Shared by the px.createDescriptor command (the focused
+ * mod) and the Workshop panel (whichever mod it is on).
+ */
+export function createDescriptorFile(
+  root: string,
+  gameId: string,
+  gamePath: string | null,
+  log: (msg: string) => void
+): string {
+  const meta = metaFor(gameId);
+  const file = path.join(root, ...descriptorRelPath(gameId));
+  if (fs.existsSync(file)) return file;
+  const folderName = path.basename(root);
+  const modName = folderName.replace(/[_-]+/g, " ").replace(/\b[a-z]/g, (c) => c.toUpperCase());
+  const detected = detectGameVersion(gamePath);
+  const version = (detected && wildcardVersion(detected)) ?? "1.*";
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(
+    file,
+    meta.descriptor === "metadata"
+      ? scaffoldMetadata({ name: modName, id: folderName, supportedGameVersion: version })
+      : scaffoldDescriptor(modName, version),
+    "utf8"
+  );
+  log(`created ${file}`);
+  // A metadata mod also needs a square thumbnail.png in its root: the
+  // launcher lists the mod without one, the Workshop upload refuses. We do
+  // not fabricate an image, so say it once, here.
+  if (meta.descriptor === "metadata" && !fs.existsSync(path.join(root, "thumbnail.png"))) {
+    void vscode.window.showInformationMessage(
+      `Paradox Modding Toolkit: ${descriptorRelPath(gameId).join("/")} created. ` +
+        `Add a square thumbnail.png to the mod root as well: ${meta.name} needs one for the Workshop upload.`
+    );
+  }
+  return file;
+}
+
 export function registerDescriptorMod(
   context: vscode.ExtensionContext,
   getConfig: () => PxConfig,
@@ -340,32 +380,7 @@ export function registerDescriptorMod(
       );
       return;
     }
-    const meta = metaFor(cfg.gameId);
-    const file = path.join(cfg.modPath, ...descriptorRelPath(cfg.gameId));
-    if (!fs.existsSync(file)) {
-      const folderName = path.basename(cfg.modPath);
-      const modName = folderName.replace(/[_-]+/g, " ").replace(/\b[a-z]/g, (c) => c.toUpperCase());
-      const detected = detectGameVersion(cfg.gamePath);
-      const version = (detected && wildcardVersion(detected)) ?? "1.*";
-      fs.mkdirSync(path.dirname(file), { recursive: true });
-      fs.writeFileSync(
-        file,
-        meta.descriptor === "metadata"
-          ? scaffoldMetadata({ name: modName, id: folderName, supportedGameVersion: version })
-          : scaffoldDescriptor(modName, version),
-        "utf8"
-      );
-      log(`created ${file}`);
-      // A metadata mod also needs a square thumbnail.png in its root: the
-      // launcher lists the mod without one, the Workshop upload refuses. We do
-      // not fabricate an image, so say it once, here.
-      if (meta.descriptor === "metadata" && !fs.existsSync(path.join(cfg.modPath, "thumbnail.png"))) {
-        void vscode.window.showInformationMessage(
-          `Paradox Modding Toolkit: ${descriptorRelPath(cfg.gameId).join("/")} created. ` +
-            `Add a square thumbnail.png to the mod root as well: ${meta.name} needs one for the Workshop upload.`
-        );
-      }
-    }
+    const file = createDescriptorFile(cfg.modPath, cfg.gameId, cfg.gamePath, log);
     refresh();
     const doc = await vscode.workspace.openTextDocument(vscode.Uri.file(file));
     await vscode.window.showTextDocument(doc);

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -16,7 +16,7 @@ import {
   type LanguageClientOptions,
   type ServerOptions,
 } from "vscode-languageclient/node";
-import { gameDocsSubdir, looksLikeMod, modRootFor, readConfig, type PxConfig } from "./config";
+import { modRootFor, readConfig, type PxConfig } from "./config";
 import { findStrayCalendar } from "./calendarSettingsCheck";
 import { writeCalendarFile } from "@px-lsp/protocol/calendarFile";
 import { ensureFileAssociations, wireLanguageDetection } from "./languageMode";
@@ -85,26 +85,12 @@ import { reduceEditorLoadCommand } from "./reduceEditorLoad";
 import { translateNextCommand } from "./translationLoop";
 import { newContentCommand } from "./scaffold/command";
 import { insertSnippetCommand } from "./insertSnippet";
-import { createModCommand, modProjectsDirSetting, moveModCommand } from "./modProjects/command";
+import { createModCommand, moveModCommand } from "./modProjects/command";
 import { registerDescriptorMod } from "./descriptorMod";
 import { registerWorkshop } from "./steam/workshop";
 import { registerBBCodeSupport } from "./bbcodeSupport";
 import { WorkshopPanel } from "./webviews/workshop/panel";
-import type { ModChoice } from "./webviews/workshop/messages";
 import * as fs from "fs";
-
-/** The mod folders directly inside `dir`, for the Workshop panel's mod picker. */
-function modFoldersIn(dir: string): string[] {
-  try {
-    return fs
-      .readdirSync(dir, { withFileTypes: true })
-      .filter((e) => e.isDirectory() || e.isSymbolicLink())
-      .map((e) => path.join(dir, e.name))
-      .filter(looksLikeMod);
-  } catch {
-    return [];
-  }
-}
 import {
   allClientCommandIds,
   configChangedNotification,
@@ -1341,28 +1327,15 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
   context.subscriptions.push(
     vscode.commands.registerCommand("px.openWorkshopManager", () => {
-      const meta = metaFor(cfg.gameId);
-      const mods: ModChoice[] = [...(cfg.modPath ? [cfg.modPath] : []), ...cfg.workspaceMods]
+      // Workspace mods only: listing the projects folder or the game's mod
+      // folder here confused which mod was about to be uploaded. A mod
+      // outside the workspace is picked through the panel's own entry.
+      const mods = [...(cfg.modPath ? [cfg.modPath] : []), ...cfg.workspaceMods]
         .filter((p, i, all) => all.indexOf(p) === i)
         .map((p) => ({ label: readModName(p), path: p }));
-      // Mods outside the workspace too: the projects folder and the game's own
-      // mod folder, so a mod can be published without opening it first. The
-      // panel's Browse entry covers every other place.
-      const known = new Set(mods.map((m) => m.path.toLowerCase()));
-      for (const [dir, hint] of [
-        [modProjectsDirSetting(), "projects folder"],
-        [gameDocsSubdir(meta, "mod"), "game mod folder"],
-      ] as const) {
-        if (!dir) continue;
-        for (const child of modFoldersIn(dir)) {
-          if (known.has(child.toLowerCase())) continue;
-          known.add(child.toLowerCase());
-          mods.push({ label: readModName(child), path: child, hint });
-        }
-      }
       WorkshopPanel.show(context, {
         gamePath: cfg.gamePath,
-        meta,
+        meta: metaFor(cfg.gameId),
         mods,
         active: views.focusRoot() ?? cfg.modPath,
         log,

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -16,7 +16,7 @@ import {
   type LanguageClientOptions,
   type ServerOptions,
 } from "vscode-languageclient/node";
-import { modRootFor, readConfig, type PxConfig } from "./config";
+import { gameDocsSubdir, looksLikeMod, modRootFor, readConfig, type PxConfig } from "./config";
 import { findStrayCalendar } from "./calendarSettingsCheck";
 import { writeCalendarFile } from "@px-lsp/protocol/calendarFile";
 import { ensureFileAssociations, wireLanguageDetection } from "./languageMode";
@@ -85,12 +85,26 @@ import { reduceEditorLoadCommand } from "./reduceEditorLoad";
 import { translateNextCommand } from "./translationLoop";
 import { newContentCommand } from "./scaffold/command";
 import { insertSnippetCommand } from "./insertSnippet";
-import { createModCommand, moveModCommand } from "./modProjects/command";
+import { createModCommand, modProjectsDirSetting, moveModCommand } from "./modProjects/command";
 import { registerDescriptorMod } from "./descriptorMod";
 import { registerWorkshop } from "./steam/workshop";
 import { registerBBCodeSupport } from "./bbcodeSupport";
 import { WorkshopPanel } from "./webviews/workshop/panel";
+import type { ModChoice } from "./webviews/workshop/messages";
 import * as fs from "fs";
+
+/** The mod folders directly inside `dir`, for the Workshop panel's mod picker. */
+function modFoldersIn(dir: string): string[] {
+  try {
+    return fs
+      .readdirSync(dir, { withFileTypes: true })
+      .filter((e) => e.isDirectory() || e.isSymbolicLink())
+      .map((e) => path.join(dir, e.name))
+      .filter(looksLikeMod);
+  } catch {
+    return [];
+  }
+}
 import {
   allClientCommandIds,
   configChangedNotification,
@@ -1327,18 +1341,28 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
   context.subscriptions.push(
     vscode.commands.registerCommand("px.openWorkshopManager", () => {
-      const mods = [...(cfg.modPath ? [cfg.modPath] : []), ...cfg.workspaceMods]
+      const meta = metaFor(cfg.gameId);
+      const mods: ModChoice[] = [...(cfg.modPath ? [cfg.modPath] : []), ...cfg.workspaceMods]
         .filter((p, i, all) => all.indexOf(p) === i)
         .map((p) => ({ label: readModName(p), path: p }));
-      if (!mods.length) {
-        void vscode.window.showWarningMessage(
-          "Paradox Modding Toolkit: open a mod folder as a workspace folder first."
-        );
-        return;
+      // Mods outside the workspace too: the projects folder and the game's own
+      // mod folder, so a mod can be published without opening it first. The
+      // panel's Browse entry covers every other place.
+      const known = new Set(mods.map((m) => m.path.toLowerCase()));
+      for (const [dir, hint] of [
+        [modProjectsDirSetting(), "projects folder"],
+        [gameDocsSubdir(meta, "mod"), "game mod folder"],
+      ] as const) {
+        if (!dir) continue;
+        for (const child of modFoldersIn(dir)) {
+          if (known.has(child.toLowerCase())) continue;
+          known.add(child.toLowerCase());
+          mods.push({ label: readModName(child), path: child, hint });
+        }
       }
       WorkshopPanel.show(context, {
         gamePath: cfg.gamePath,
-        meta: metaFor(cfg.gameId),
+        meta,
         mods,
         active: views.focusRoot() ?? cfg.modPath,
         log,

--- a/packages/vscode/src/modProjects/command.ts
+++ b/packages/vscode/src/modProjects/command.ts
@@ -32,7 +32,7 @@ import {
 
 const PREFIX = "Paradox Modding Toolkit";
 
-export function modProjectsDirSetting(): string | null {
+function modProjectsDirSetting(): string | null {
   const v = (vscode.workspace.getConfiguration("px").get<string>("modProjectsDir") ?? "").trim();
   return v === "" ? null : v;
 }

--- a/packages/vscode/src/modProjects/command.ts
+++ b/packages/vscode/src/modProjects/command.ts
@@ -32,7 +32,7 @@ import {
 
 const PREFIX = "Paradox Modding Toolkit";
 
-function modProjectsDirSetting(): string | null {
+export function modProjectsDirSetting(): string | null {
   const v = (vscode.workspace.getConfiguration("px").get<string>("modProjectsDir") ?? "").trim();
   return v === "" ? null : v;
 }

--- a/packages/vscode/src/webviews/wiki/app/main.ts
+++ b/packages/vscode/src/webviews/wiki/app/main.ts
@@ -469,6 +469,10 @@ $("helpBtn").addEventListener("click", () =>
             text: "is built when you open it, from the live index of the focused mod: content counts, problems, localization coverage and overrides. Rebuild makes a fresh one.",
           },
           {
+            lead: "Modding Guides",
+            text: "lists the game wiki's modding pages for the game the switch is on, one card per page with a line on what it covers, grouped the way the wiki groups them. The chips filter by group.",
+          },
+          {
             lead: "Modding Tools",
             text: "lists tools other modders built for the game the switch is on: map editors, translators, audio tools, history converters. Each card wears its type as an icon; the chips above the cards filter by type.",
           },

--- a/packages/vscode/src/webviews/wiki/moddingGuides.ts
+++ b/packages/vscode/src/webviews/wiki/moddingGuides.ts
@@ -1,0 +1,1036 @@
+/**
+ * The game wiki's modding pages, one list per game, for the wiki hub's
+ * Modding Guides page: where to read up on an area of modding before or
+ * while working in it.
+ *
+ * Taken from each wiki's Modding navbox on 2026-09-06 (the `base` of each
+ * list plus `/Modding` is the page the navbox sits on). The one-line text of
+ * every card was written from the page's own lead paragraph, not from its
+ * title. Redirect pages (Checksum, EU5's Event target and Mod files load
+ * order) are left out, as is Vic3's Grester's Compendium, a user page.
+ */
+
+import type { IconName } from "../shared/icons";
+import type { WikiCard } from "./messages";
+
+type Category =
+  | "Basics"
+  | "Script reference"
+  | "Scripting"
+  | "Interface and localization"
+  | "Map"
+  | "Graphics"
+  | "Audio"
+  | "Guides";
+
+export interface GuidePage {
+  title: string;
+  /** The wiki path, `/Sound_modding`. */
+  path: string;
+  category: Category;
+  what: string;
+}
+
+export interface GameGuideList {
+  /** The wiki's origin, `https://ck3.paradoxwikis.com`. */
+  base: string;
+  pages: GuidePage[];
+}
+
+/** The category order every game's page follows: the wiki's own groups, merged. */
+const CATEGORIES: Category[] = [
+  "Basics",
+  "Script reference",
+  "Scripting",
+  "Interface and localization",
+  "Map",
+  "Graphics",
+  "Audio",
+  "Guides",
+];
+
+const CATEGORY_ICONS: Record<Category, IconName> = {
+  Basics: "info",
+  "Script reference": "bookOpen",
+  Scripting: "variable",
+  "Interface and localization": "layoutTemplate",
+  Map: "map",
+  Graphics: "image",
+  Audio: "activity",
+  Guides: "sparkles",
+};
+
+export const MODDING_GUIDES: Record<string, GameGuideList> = {
+  ck3: {
+    base: "https://ck3.paradoxwikis.com",
+    pages: [
+      {
+        title: "Modding",
+        path: "/Modding",
+        category: "Basics",
+        what: "Entry page on modifying the game's assets or behaviour, covering creating, uploading and installing mods and load order.",
+      },
+      {
+        title: "Mod structure",
+        path: "/Mod_structure",
+        category: "Basics",
+        what: "Explains where mods live, the paired .mod file and mod folder, and the descriptor syntax and keys.",
+      },
+      {
+        title: "Mod compatibility",
+        path: "/Mod_compatibility",
+        category: "Basics",
+        what: "Explains practices and techniques that let mods work together, including shared variables, shared scripted effects and compatibility patches.",
+      },
+      {
+        title: "Mod troubleshooting",
+        path: "/Mod_troubleshooting",
+        category: "Basics",
+        what: "Debugging a mod: the developer console, the debug tools, localization debugging and error spam.",
+      },
+      {
+        title: "Console commands",
+        path: "/Console_commands",
+        category: "Basics",
+        what: "Lists the console commands available in debug mode, with debug info, cheats, artifact spawning and converting commands.",
+      },
+      {
+        title: "Scripting",
+        path: "/Scripting",
+        category: "Script reference",
+        what: "Introduces the custom scripting language mods use to add and change game content, with syntax, testing and documentation notes.",
+      },
+      {
+        title: "Scopes",
+        path: "/Scopes",
+        category: "Script reference",
+        what: "Explains scopes, the way script selects entities such as characters or titles before checking triggers or running effects.",
+      },
+      {
+        title: "Effects",
+        path: "/Effects",
+        category: "Script reference",
+        what: "Covers effects, the script commands that change the game state, including effect blocks, syntax, scripted effects and control effects.",
+      },
+      {
+        title: "Triggers",
+        path: "/Triggers",
+        category: "Script reference",
+        what: "Covers triggers, the checks that return true or false in a scope, plus trigger blocks, syntax and logic blocks.",
+      },
+      {
+        title: "Variables",
+        path: "/Variables",
+        category: "Script reference",
+        what: "Explains how to set, modify, remove and read script variables, including global variables, local variables and lists.",
+      },
+      {
+        title: "Modifier list",
+        path: "/Modifier_list",
+        category: "Script reference",
+        what: "Lists the game's modifiers and separates the two meanings of modifier, long term bonuses and random-effect chance changes.",
+      },
+      {
+        title: "AI modding",
+        path: "/AI_modding",
+        category: "Scripting",
+        what: "Explains which AI behaviour is hardcoded and how defines, chances, triggers, AI personality values and script can influence it.",
+      },
+      {
+        title: "Bookmarks modding",
+        path: "/Bookmarks_modding",
+        category: "Scripting",
+        what: "Shows how to add bookmarks so new characters and scenarios appear on the Select Start Date screen.",
+      },
+      {
+        title: "Characters modding",
+        path: "/Characters_modding",
+        category: "Scripting",
+        what: "Covers changing character appearance, data and behaviour, from adding gold to scripting new characters and visual effects.",
+      },
+      {
+        title: "Commands",
+        path: "/Commands",
+        category: "Scripting",
+        what: "Lists the commands, also called effects, used in event immediate and option blocks and in scripted effects.",
+      },
+      {
+        title: "Council modding",
+        path: "/Council_modding",
+        category: "Scripting",
+        what: "Describes the council position and council task files and how a council position is structured.",
+      },
+      {
+        title: "Culture modding",
+        path: "/Culture_modding",
+        category: "Scripting",
+        what: "Explains how to add cultures, culture groups, innovations and eras using the game's modular culture files.",
+      },
+      {
+        title: "Decisions modding",
+        path: "/Decisions_modding",
+        category: "Scripting",
+        what: "Covers scripting decisions, the optional actions rulers may take, including location, structure, localization, custom widgets and testing.",
+      },
+      {
+        title: "Dynasties modding",
+        path: "/Dynasties_modding",
+        category: "Scripting",
+        what: "Shows how to create dynasties and houses, and how to change an existing dynasty's name, coat of arms and motto.",
+      },
+      {
+        title: "Event modding",
+        path: "/Event_modding",
+        category: "Scripting",
+        what: "Covers writing events, the story bits that happen during a campaign, with location, structure, portraits, themes and triggers.",
+      },
+      {
+        title: "Governments modding",
+        path: "/Governments_modding",
+        category: "Scripting",
+        what: "Documents the government type files in common/governments and the fields that define one, such as council and vassal contracts.",
+      },
+      {
+        title: "History modding",
+        path: "/History_modding",
+        category: "Scripting",
+        what: "Explains the history folder and how to edit the starting data for characters, cultures, provinces, titles and wars.",
+      },
+      {
+        title: "Holdings modding",
+        path: "/Holdings_modding",
+        category: "Scripting",
+        what: "Explains how to define holding types in common/holdings, with variables, buildings, modifiers and localization.",
+      },
+      {
+        title: "Lifestyles modding",
+        path: "/Lifestyles_modding",
+        category: "Scripting",
+        what: "Covers lifestyles, the trees characters progress in, and how to script their focuses, perks, graphics and localization.",
+      },
+      {
+        title: "Regiments modding",
+        path: "/Regiments_modding",
+        category: "Scripting",
+        what: "Explains the men-at-arms regiment files, their variables, their use in innovations and traditions, and their localization.",
+      },
+      {
+        title: "Religions modding",
+        path: "/Religions_modding",
+        category: "Scripting",
+        what: "Explains how to add religion families, religions and faiths, with holy sites, graphics and localization.",
+      },
+      {
+        title: "Script values",
+        path: "/Script_values",
+        category: "Scripting",
+        what: "Describes script values, the functions in common/script_values that calculate a number usable almost anywhere in script.",
+      },
+      {
+        title: "Story cycles modding",
+        path: "/Story_cycles_modding",
+        category: "Scripting",
+        what: "Explains story cycles, event managers that fire events periodically and store related values, and how to create one.",
+      },
+      {
+        title: "Struggle modding",
+        path: "/Struggle_modding",
+        category: "Scripting",
+        what: "Shows how to create or change a struggle, covering setup, cultures, faiths, regions, conditions and graphics.",
+      },
+      {
+        title: "Title modding",
+        path: "/Title_modding",
+        category: "Scripting",
+        what: "Covers the landed_titles files, including titular titles, coats of arms, capital buildings, history and the full attribute list.",
+      },
+      {
+        title: "Trait modding",
+        path: "/Trait_modding",
+        category: "Scripting",
+        what: "Explains creating character traits that change attributes, opinions and personality, with categories, validation and special trait flags.",
+      },
+      {
+        title: "Interface",
+        path: "/Interface",
+        category: "Interface and localization",
+        what: "Explains modding the user interface, covering GUI basics, inspecting GUI, scripted GUIs, new windows and the checksum effect.",
+      },
+      {
+        title: "Data types",
+        path: "/Data_types",
+        category: "Interface and localization",
+        what: "Documents the bracketed data types used in GUI and localization, listing global promotes, global functions and object types.",
+      },
+      {
+        title: "Localization",
+        path: "/Localization",
+        category: "Interface and localization",
+        what: "Covers the text shown to players, including formatting, reusing entries, data types, special characters, linking and number formatting.",
+      },
+      {
+        title: "Customizable localization",
+        path: "/Customizable_localization",
+        category: "Interface and localization",
+        what: "Explains customizable localization, used when one text slot must show different wording depending on conditions.",
+      },
+      {
+        title: "Flavorization",
+        path: "/Flavorization",
+        category: "Interface and localization",
+        what: "Explains flavorization, how the game picks and prioritizes the title shown for a character, with grammar and examples.",
+      },
+      {
+        title: "Map modding",
+        path: "/Map_modding",
+        category: "Map",
+        what: "Covers editing the game map, including the heightmap, rivers, provinces, new titles and province terrain.",
+      },
+      {
+        title: "Terrain modding",
+        path: "/Terrain_modding",
+        category: "Map",
+        what: "Explains creating or changing terrain types, with scripting, graphics, localization and the modifiers terrains use.",
+      },
+      {
+        title: "3D models",
+        path: "/3D_models",
+        category: "Graphics",
+        what: "For modders with 3D experience: models for portraits, units, holdings and map objects, plus textures and formats.",
+      },
+      {
+        title: "Exporters",
+        path: "/Exporters",
+        category: "Graphics",
+        what: "Describes the Paradox exporter tools for Photoshop textures and Maya meshes and animations, with setup and installation steps.",
+      },
+      {
+        title: "Coat of arms modding",
+        path: "/Coat_of_arms_modding",
+        category: "Graphics",
+        what: "Covers scripting coats of arms for titles, dynasties and houses, with keywords, inheritance, dynamic coats and emblem modding.",
+      },
+      {
+        title: "Graphical assets",
+        path: "/Graphical_assets",
+        category: "Graphics",
+        what: "Documents the portrait palette assets for hair, skin and eyes, with their required size and DDS format.",
+      },
+      {
+        title: "Fonts",
+        path: "/Fonts",
+        category: "Graphics",
+        what: "Finding, converting and installing custom fonts, including TrueType to OpenType conversion.",
+      },
+      {
+        title: "Music modding",
+        path: "/Music_modding",
+        category: "Audio",
+        what: "Explains adding custom music tracks, listing them in the music player, and scripting when and where they play.",
+      },
+      {
+        title: "Sound modding",
+        path: "/Sound_modding",
+        category: "Audio",
+        what: "Explains importing sounds with FMOD Studio and playing them in game, with random, overlapping and 3D sound.",
+      },
+    ],
+  },
+  vic3: {
+    base: "https://vic3.paradoxwikis.com",
+    pages: [
+      {
+        title: "Scripted test",
+        path: "/Scripted_test",
+        category: "Basics",
+        what: "Scripted tests are utility files that check how often a defined game state is reached, without affecting gameplay.",
+      },
+      {
+        title: "Modding",
+        path: "/Modding",
+        category: "Basics",
+        what: "The main modding overview: getting started, the mod folder, tools, best practices, file priority, debugging, and common problems.",
+      },
+      {
+        title: "Mod",
+        path: "/Mod",
+        category: "Basics",
+        what: "A mod is any alteration of the game, from small tweaks to total conversions, with installation steps and mod lists.",
+      },
+      {
+        title: "Mod structure",
+        path: "/Mod_structure",
+        category: "Basics",
+        what: "The structure of a mod folder: its location, its metadata, the folder layout, and a folder template.",
+      },
+      {
+        title: "Mod compatibility",
+        path: "/Mod_compatibility",
+        category: "Basics",
+        what: "Compatibility mechanics that let several mods work together without relying on base game files, including inject and replace.",
+      },
+      {
+        title: "Troubleshooting",
+        path: "/Troubleshooting",
+        category: "Basics",
+        what: "Finding and fixing bugs with the error log, the debug log, and methods for identifying crash sources.",
+      },
+      {
+        title: "Console commands",
+        path: "/Console_commands",
+        category: "Basics",
+        what: "The game's debug mode and the list of console commands available in non-ironman games.",
+      },
+      {
+        title: "Defines",
+        path: "/Defines",
+        category: "Script reference",
+        what: "Engine variables that regulate basic game behaviour and settings not opened to scripting, such as approval thresholds and camera field of view.",
+      },
+      {
+        title: "Effect",
+        path: "/Effect",
+        category: "Script reference",
+        what: "Effects change the current game state, such as creating or killing a character or changing the ownership of a state.",
+      },
+      {
+        title: "Scope",
+        path: "/Scope",
+        category: "Script reference",
+        what: "Scopes are code objects such as countries and states that give effects and triggers the context they run in.",
+      },
+      {
+        title: "Trigger",
+        path: "/Trigger",
+        category: "Script reference",
+        what: "Triggers act as conditions that read the current game state, such as a character's ideology or a state's ownership.",
+      },
+      {
+        title: "Macro",
+        path: "/Macro",
+        category: "Script reference",
+        what: "Macros are reusable blocks of script, mainly scripted effects and scripted triggers, including how to pass parameters.",
+      },
+      {
+        title: "Modifier types",
+        path: "/Modifier_types",
+        category: "Script reference",
+        what: "Modifier types are the game script pieces that change game statistics or allow and block certain actions.",
+      },
+      {
+        title: "On actions",
+        path: "/On_actions",
+        category: "Script reference",
+        what: "On actions are effects called by specific circumstances, such as regular pulses, wars starting, or a character dying.",
+      },
+      {
+        title: "Script value",
+        path: "/Script_value",
+        category: "Script reference",
+        what: "Script values are mathematical calculations that build dynamic numbers from game values for effects, triggers, variables, and AI.",
+      },
+      {
+        title: "Variable",
+        path: "/Variable",
+        category: "Script reference",
+        what: "Variables are scripted event targets that hold values or scopes, including temporary lists, variable lists, and variable maps.",
+      },
+      {
+        title: "Decision modding",
+        path: "/Decision_modding",
+        category: "Scripting",
+        what: "Decisions are scripted effects that can be taken in certain circumstances, defined in common/decisions.",
+      },
+      {
+        title: "Event modding",
+        path: "/Event_modding",
+        category: "Scripting",
+        what: "How to write events, covering file location, file structure, event structure, hidden events, and event templates.",
+      },
+      {
+        title: "History modding",
+        path: "/History_modding",
+        category: "Scripting",
+        what: "History effects in common/history initialise the starting state of a new game: countries, politics, pops, literacy, and technologies.",
+      },
+      {
+        title: "Journal modding",
+        path: "/Journal_modding",
+        category: "Scripting",
+        what: "Journal entries represent ongoing situations or goals for the player, defined in common/journal_entries.",
+      },
+      {
+        title: "Modifier modding",
+        path: "/Modifier_modding",
+        category: "Scripting",
+        what: "Modifiers are containers of values that affect gameplay, defined as static modifiers or inside scripted types like laws.",
+      },
+      {
+        title: "Scripted gui",
+        path: "/Scripted_gui",
+        category: "Scripting",
+        what: "Scripted GUIs run effects when a button is clicked and set the validity or visibility of UI elements.",
+      },
+      {
+        title: "Building modding",
+        path: "/Building_modding",
+        category: "Scripting",
+        what: "How to add buildings and the production methods that drive them, plus building groups, map models, and localization.",
+      },
+      {
+        title: "Character modding",
+        path: "/Character_modding",
+        category: "Scripting",
+        what: "Character templates in common/character_templates, the create_character effect, character history and traits.",
+      },
+      {
+        title: "Country modding",
+        path: "/Country_modding",
+        category: "Scripting",
+        what: "Countries are defined by a few base characteristics, plus localization, map colour, flags, and country history files.",
+      },
+      {
+        title: "Culture modding",
+        path: "/Culture_modding",
+        category: "Scripting",
+        what: "Culture represents the abstracted ethnicity and traditions of pops and countries, with definitions and discrimination traits.",
+      },
+      {
+        title: "Decree modding",
+        path: "/Decree_modding",
+        category: "Scripting",
+        what: "Decrees add modifiers to specific states, with the decree definition explained.",
+      },
+      {
+        title: "Diplomacy modding",
+        path: "/Diplomacy_modding",
+        category: "Scripting",
+        what: "Diplomatic actions, diplomatic plays and secret goals, defined in common/diplomatic_actions. A short page so far.",
+      },
+      {
+        title: "Goods modding",
+        path: "/Goods_modding",
+        category: "Scripting",
+        what: "How to add goods, including text icons, localization, goods categories, building use, pop consumption, and discoverability.",
+      },
+      {
+        title: "Institution modding",
+        path: "/Institution_modding",
+        category: "Scripting",
+        what: "Institutions apply modifiers to incorporated states, covering their definition, levels, cost, modifiers, and how they are enabled.",
+      },
+      {
+        title: "Interest group modding",
+        path: "/Interest_group_modding",
+        category: "Scripting",
+        what: "Interest groups represent common socio-political interests, each with ideologies, three traits, and other characteristics.",
+      },
+      {
+        title: "Law modding",
+        path: "/Law_modding",
+        category: "Scripting",
+        what: "Laws make major changes to a country, covering law groups, law definitions, and their other effects.",
+      },
+      {
+        title: "Pop modding",
+        path: "/Pop_modding",
+        category: "Scripting",
+        what: "Pops are defined by their profession: profession definitions and profession modifiers.",
+      },
+      {
+        title: "Power bloc modding",
+        path: "/Power_bloc_modding",
+        category: "Scripting",
+        what: "Power blocs represent international organizations and empires, covering central identities, principle groups, principles, and related script values.",
+      },
+      {
+        title: "Religion modding",
+        path: "/Religion_modding",
+        category: "Scripting",
+        what: "Religion represents the abstracted faith of pops and countries, with religion definitions and discrimination traits.",
+      },
+      {
+        title: "Technology modding",
+        path: "/Technology_modding",
+        category: "Scripting",
+        what: "Technologies represent material, social, and political inventions that unlock mechanics or give modifiers, with eras and a walkthrough.",
+      },
+      {
+        title: "Treaty modding",
+        path: "/Treaty_modding",
+        category: "Scripting",
+        what: "Treaties are diplomatic agreements made of articles, covering treaty defines, article definitions, and the script documentation.",
+      },
+      {
+        title: "War goal modding",
+        path: "/War_goal_modding",
+        category: "Scripting",
+        what: "War goals are the diplomatic demands one country makes on another, defined in common/war_goal_types.",
+      },
+      {
+        title: "AI modding",
+        path: "/AI_modding",
+        category: "Scripting",
+        what: "AI modding changes AI behaviour through AI defines, AI strategies, and AI values.",
+      },
+      {
+        title: "Interface modding",
+        path: "/Interface_modding",
+        category: "Interface and localization",
+        what: "How to build custom interface panels and windows from GUI templates and types, and add them to the game.",
+      },
+      {
+        title: "GUI script",
+        path: "/GUI_script",
+        category: "Interface and localization",
+        what: "GUI script is the scripting style used in the game's GUI and localization, with its data types, functions, and promotes.",
+      },
+      {
+        title: "Localization",
+        path: "/Localization",
+        category: "Interface and localization",
+        what: "Localization files are UTF-8-BOM yml named _l_language, covering formatting, data functions, concepts, custom tooltips, and saved scopes.",
+      },
+      {
+        title: "Script localization",
+        path: "/Script_localization",
+        category: "Interface and localization",
+        what: "Script localization makes effects and triggers show different text depending on context, with custom descriptions and localization strings.",
+      },
+      {
+        title: "Map modding",
+        path: "/Map_modding",
+        category: "Map",
+        what: "How to mod the game map through files or the map editor: land, seas, rivers, provinces, and states.",
+      },
+      {
+        title: "Geographic region modding",
+        path: "/Geographic_region_modding",
+        category: "Map",
+        what: "Geographic regions are static script lists of state or strategic regions that make iteration simpler and faster.",
+      },
+      {
+        title: "State modding",
+        path: "/State_modding",
+        category: "Map",
+        what: "State regions are the map parts holding pops and buildings, with their characteristics, history, and strategic regions.",
+      },
+      {
+        title: "Model modding",
+        path: "/Model_modding",
+        category: "Graphics",
+        what: "A guide to editing existing 3D models or adding new ones to the game, with the tools needed.",
+      },
+      {
+        title: "Event images",
+        path: "/Event_images",
+        category: "Graphics",
+        what: "Event images are short bk2 videos used through media aliases in gfx/media_alias that pair a video with audio.",
+      },
+      {
+        title: "Graphical asset modding",
+        path: "/Graphical_asset_modding",
+        category: "Graphics",
+        what: "The game stores textures mainly as DirectDraw Surface dds files, covering both 2-D and 3-D assets.",
+      },
+      {
+        title: "Flag modding",
+        path: "/Flag_modding",
+        category: "Graphics",
+        what: "Country flags are picked by triggers from scripted coats of arms built from graphical elements, templates, and colours.",
+      },
+      {
+        title: "Sound modding",
+        path: "/Sound_modding",
+        category: "Audio",
+        what: "Sound modding uses FMOD Studio 2.02.03, covering project setup, importing sounds, and playing them in game.",
+      },
+      {
+        title: "Mod translation",
+        path: "/Mod_translation",
+        category: "Guides",
+        what: "How to translate mods with the ParaTranz platform, with existing projects and a setup guide.",
+      },
+      {
+        title: "New country modding",
+        path: "/New_country_modding",
+        category: "Guides",
+        what: "A guide to adding a new country that exists at the 1836 start: history, localization, pops, characters, flag.",
+      },
+      {
+        title: "Save-game editing",
+        path: "/Save-game_editing",
+        category: "Guides",
+        what: "Save files are zipped v3 archives holding a meta and a gamestate file, with their format and structure explained.",
+      },
+      {
+        title: "State modding guide",
+        path: "/State_modding_guide",
+        category: "Guides",
+        what: "A guide to creating a new state region without editing the province map, and to overwriting existing states.",
+      },
+    ],
+  },
+  eu5: {
+    base: "https://eu5.paradoxwikis.com",
+    pages: [
+      {
+        title: "Modding",
+        path: "/Modding",
+        category: "Basics",
+        what: "The entry point for altering the game: getting started, tools and utilities, common problems and terminology.",
+      },
+      {
+        title: "Mod",
+        path: "/Mod",
+        category: "Basics",
+        what: "What a mod is and how to install one, from small tweaks to total conversions, plus mod lists.",
+      },
+      {
+        title: "Mod structure",
+        path: "/Mod_structure",
+        category: "Basics",
+        what: "The mod folder location, the metadata file and the folder structure every mod needs.",
+      },
+      {
+        title: "Mod compatibility",
+        path: "/Mod_compatibility",
+        category: "Basics",
+        what: "Compatibility mechanics that let several mods work together without relying directly on base game files.",
+      },
+      {
+        title: "Console commands",
+        path: "/Console_commands",
+        category: "Basics",
+        what: "The debug mode console, how to open it, and the list of commands you can type there.",
+      },
+      {
+        title: "Defines",
+        path: "/Defines",
+        category: "Script reference",
+        what: "Engine variables that regulate basic game behaviour and settings not opened to scripting, plus the full list of defines.",
+      },
+      {
+        title: "Effect",
+        path: "/Effect",
+        category: "Script reference",
+        what: "Effects change the current game state, such as creating or killing a character or changing who owns a state.",
+      },
+      {
+        title: "Scope",
+        path: "/Scope",
+        category: "Script reference",
+        what: "Scopes are the game objects that effects and triggers run on, with iterators, event targets and scope types.",
+      },
+      {
+        title: "Scope link",
+        path: "/Scope_link",
+        category: "Script reference",
+        what: "Scope links, often called event targets, are the object, scope and value references used in game script.",
+      },
+      {
+        title: "Trigger",
+        path: "/Trigger",
+        category: "Script reference",
+        what: "Triggers read the game state and decide whether an event can occur or an action is available.",
+      },
+      {
+        title: "Color",
+        path: "/Color",
+        category: "Script reference",
+        what: "Script features for writing colors in game script, covering color modes, named colors and scripted math with colors.",
+      },
+      {
+        title: "Macro",
+        path: "/Macro",
+        category: "Script reference",
+        what: "Reusable blocks of script, mainly scripted effects and scripted triggers, including inline forms and arguments.",
+      },
+      {
+        title: "Mean time to happen",
+        path: "/Mean_time_to_happen",
+        category: "Script reference",
+        what: "The calculation syntax used for event frequencies and weights, with its scripted modifier blocks.",
+      },
+      {
+        title: "Modifier types",
+        path: "/Modifier_types",
+        category: "Script reference",
+        what: "Game script that modifies statistics or blocks actions, how to define new types, and the full list.",
+      },
+      {
+        title: "On actions",
+        path: "/On_actions",
+        category: "Script reference",
+        what: "Effects called by circumstances such as regular pulses, wars starting or a character dying, and how to mod them.",
+      },
+      {
+        title: "Script value",
+        path: "/Script_value",
+        category: "Script reference",
+        what: "Mathematical calculations that build dynamic numeric or boolean values from game values during play.",
+      },
+      {
+        title: "Variable",
+        path: "/Variable",
+        category: "Script reference",
+        what: "Special scope links that hold values or scopes, set by effects and checked by triggers, including lists and maps.",
+      },
+      {
+        title: "GUI script",
+        path: "/GUI_script",
+        category: "Script reference",
+        what: "The scripting style used in the game's GUI and localization files, with its data types, functions and promotes.",
+      },
+      {
+        title: "Localization",
+        path: "/Localization",
+        category: "Script reference",
+        what: "Writing localization yml files in UTF-8-BOM, with formatting, data functions, concepts, variables and custom tooltips.",
+      },
+      {
+        title: "Action modding",
+        path: "/Action_modding",
+        category: "Scripting",
+        what: "Creating new interactions between countries and other objects, built on the shared interaction target system.",
+      },
+      {
+        title: "Disaster modding",
+        path: "/Disaster_modding",
+        category: "Scripting",
+        what: "Disasters are internal situations that befall a country; this covers starting, running and ending them.",
+      },
+      {
+        title: "Event modding",
+        path: "/Event_modding",
+        category: "Scripting",
+        what: "Events present a nation with a choice or a notification; covers file location, structure, options and firing.",
+      },
+      {
+        title: "Mission modding",
+        path: "/Mission_modding",
+        category: "Scripting",
+        what: "Missions are task trees that guide countries through objectives with rewards, with their structure and attributes.",
+      },
+      {
+        title: "Modifier modding",
+        path: "/Modifier_modding",
+        category: "Scripting",
+        what: "Applying modifier types to countries and other entities with static modifiers, auto modifiers and new types.",
+      },
+      {
+        title: "Scripted gui",
+        path: "/Scripted_gui",
+        category: "Scripting",
+        what: "Custom GUI elements that run script effects, letting modders add interactive buttons to the interface.",
+      },
+      {
+        title: "Setup modding",
+        path: "/Setup_modding",
+        category: "Scripting",
+        what: "Building the savefile the game opens to start play, using managers and functions close to save-game editing.",
+      },
+      {
+        title: "Situation modding",
+        path: "/Situation_modding",
+        category: "Scripting",
+        what: "Situations represent complex political, economic and societal phenomena shown to a subset of countries.",
+      },
+      {
+        title: "Advance modding",
+        path: "/Advance_modding",
+        category: "Scripting",
+        what: "Creating new advances, the game's representation of technological progress, with syntax and localization.",
+      },
+      {
+        title: "Art modding",
+        path: "/Art_modding",
+        category: "Scripting",
+        what: "Creating new work of art types and artist types, and adding them to the game setup.",
+      },
+      {
+        title: "Building modding",
+        path: "/Building_modding",
+        category: "Scripting",
+        what: "Adding buildings and road types, plus production methods and the employment system behind the economy.",
+      },
+      {
+        title: "Character modding",
+        path: "/Character_modding",
+        category: "Scripting",
+        what: "Character interactions: actions performed on or by rulers, heirs and nobles, with structure and attributes.",
+      },
+      {
+        title: "Concept modding",
+        path: "/Concept_modding",
+        category: "Scripting",
+        what: "Creating new game concepts for use in the game, with the syntax and the localization they need.",
+      },
+      {
+        title: "Country modding",
+        path: "/Country_modding",
+        category: "Scripting",
+        what: "Countries are the base playable element and need both a country definition and a country setup.",
+      },
+      {
+        title: "Culture modding",
+        path: "/Culture_modding",
+        category: "Scripting",
+        what: "Culture definitions, culture groups, and languages and dialects, with many customisation options.",
+      },
+      {
+        title: "Disease modding",
+        path: "/Disease_modding",
+        category: "Scripting",
+        what: "New disease types and their spread rate and consequences, driven largely by dynamically calculated script values.",
+      },
+      {
+        title: "Estate modding",
+        path: "/Estate_modding",
+        category: "Scripting",
+        what: "Estates are a country's major power groups: Crown, Nobles, Clergy, Burghers, Peasants and others.",
+      },
+      {
+        title: "Goods modding",
+        path: "/Goods_modding",
+        category: "Scripting",
+        what: "New good types, raw materials added at game start, and the good demands of pops.",
+      },
+      {
+        title: "Institution modding",
+        path: "/Institution_modding",
+        category: "Scripting",
+        what: "Institutions are major societal developments that spread across the world over time, with their spread mechanics.",
+      },
+      {
+        title: "International organization modding",
+        path: "/International_organization_modding",
+        category: "Scripting",
+        what: "Organizations such as the Holy Roman Empire, coalitions, crusades and defensive leagues.",
+      },
+      {
+        title: "Law modding",
+        path: "/Law_modding",
+        category: "Scripting",
+        what: "Laws are policies countries adopt that give modifiers and affect gameplay, grouped into law categories.",
+      },
+      {
+        title: "War modding",
+        path: "/War_modding",
+        category: "Scripting",
+        what: "New casus belli and their wargoal definitions, plus scripted peace treaties to go with them.",
+      },
+      {
+        title: "Pop modding",
+        path: "/Pop_modding",
+        category: "Scripting",
+        what: "Population types representing social classes and occupations, with estate assignments and promotion chains.",
+      },
+      {
+        title: "Religion modding",
+        path: "/Religion_modding",
+        category: "Scripting",
+        what: "New religions and religious mechanics, with schools, aspects, figures, focuses and holy sites.",
+      },
+      {
+        title: "Subject type modding",
+        path: "/Subject_type_modding",
+        category: "Scripting",
+        what: "Subject types define how overlords and subjects interact, including war participation and diplomatic acceptance.",
+      },
+      {
+        title: "Trait modding",
+        path: "/Trait_modding",
+        category: "Scripting",
+        what: "Character traits that define the personality and abilities of rulers, generals, admirals and other characters.",
+      },
+      {
+        title: "Unit modding",
+        path: "/Unit_modding",
+        category: "Scripting",
+        what: "Creating new units and defining their abilities, categories, recruitment methods and levies.",
+      },
+      {
+        title: "Map modding",
+        path: "/Map_modding",
+        category: "Map",
+        what: "Editing land, seas, rivers and locations with the official map editor or by editing the game files.",
+      },
+      {
+        title: "Terrain modding",
+        path: "/Terrain_modding",
+        category: "Map",
+        what: "Changing the starting topography, vegetation and climate of a location and what each of them does.",
+      },
+      {
+        title: "Flag modding",
+        path: "/Flag_modding",
+        category: "Graphics",
+        what: "Country flags are picked by triggers from scripted coats of arms built out of graphical elements.",
+      },
+      {
+        title: "Interface modding guide",
+        path: "/Interface_modding_guide",
+        category: "Guides",
+        what: "A walkthrough of the moddable interface files, from the basics to a custom window and tooltip widgets.",
+      },
+      {
+        title: "Save-game editing",
+        path: "/Save-game_editing",
+        category: "Guides",
+        what: "The two forms of non-ironman save files and how to read and edit them, debug and packed.",
+      },
+      {
+        title: "Settlement position modding guide",
+        path: "/Settlement_position_modding_guide",
+        category: "Guides",
+        what: "Relocating the settlement position inside a location and updating the map objects afterwards.",
+      },
+    ],
+  },
+};
+
+/**
+ * ONE page for every game, like the Modding Tools page: every card names its
+ * game and the app shows the cards of the game its switch is on. The same
+ * page title on two wikis is two cards, since the pages differ.
+ */
+export function moddingGuidesPage(gameNames: Record<string, string>): {
+  markdown: string;
+  cards: WikiCard[];
+  outro: string;
+} {
+  const ids = Object.keys(MODDING_GUIDES);
+  const sources = ids
+    .map((id) => `[${gameNames[id] ?? id} wiki](${MODDING_GUIDES[id].base}/Modding)`)
+    .join(", ");
+  const markdown = [
+    "# Modding Guides",
+    "",
+    "The game wiki's modding pages for the game the switch is on, grouped the way the wiki groups them. " +
+      "Every card opens the page in your browser; the line under the title says what the page covers.",
+    "",
+  ].join("\n");
+  const cards: WikiCard[] = CATEGORIES.flatMap((category) =>
+    ids.flatMap((id) =>
+      MODDING_GUIDES[id].pages
+        .filter((p) => p.category === category)
+        .map((p) => ({
+          title: p.title,
+          url: MODDING_GUIDES[id].base + p.path,
+          kind: category,
+          icon: CATEGORY_ICONS[category],
+          text: p.what,
+          games: [id],
+        }))
+    )
+  );
+  const outro = [
+    "## Missing a page?",
+    "",
+    "A wiki page you keep going back to and do not find here: tell me on [Discord](https://discord.gg/DfEJ2H9hj4) or [open an issue](https://github.com/JDeffner/paradox-modding-toolkit/issues).",
+    "",
+    `Sources: ${sources}.`,
+  ].join("\n");
+  return { markdown, cards, outro };
+}

--- a/packages/vscode/src/webviews/wiki/panel.ts
+++ b/packages/vscode/src/webviews/wiki/panel.ts
@@ -6,7 +6,8 @@
  * Tools).
  *
  * The sidebar carries a game switch, so a user can read another game's pages
- * without changing the workspace: articles that name a game (Modding Tools)
+ * without changing the workspace: articles that name a game (Modding Guides,
+ * Modding Tools)
  * show only for the selected one, and the switch starts on the workspace's
  * game.
  *
@@ -26,6 +27,7 @@ import type { GameMeta } from "@px-lsp/server/games/profile";
 import { creditsPage } from "../credits/credits";
 import { GAME_METAS } from "../../gameDetect";
 import { MODDING_TOOLS, moddingToolsPage } from "./moddingTools";
+import { moddingGuidesPage } from "./moddingGuides";
 import { wikiHtml } from "./html";
 import type { AppToHost, HostToApp, WikiArticle, WikiHubEntry } from "./messages";
 import { makeNonce } from "../nonce";
@@ -195,6 +197,12 @@ function hub(): WikiHubEntry[] {
       target: { page: STEAM_BBCODE_ARTICLE },
     },
     {
+      label: "Modding Guides",
+      icon: "bookOpen",
+      tip: "The game wiki's modding pages for the game you mod: events, map, sound, interface, compatibility, with what each covers.",
+      target: { page: MODDING_GUIDES_ARTICLE },
+    },
+    {
       label: "Modding Tools",
       icon: "wrench",
       tip: "Tools other modders built for the game you mod: map editors, translators, audio, history converters, with links.",
@@ -215,6 +223,7 @@ export const STEAM_BBCODE_ARTICLE = "steam-bbcode";
 export const CREDITS_ARTICLE = "credits";
 /** One page per game shares this id; the game switch picks which one shows. */
 export const MODDING_TOOLS_ARTICLE = "modding-tools";
+export const MODDING_GUIDES_ARTICLE = "modding-guides";
 
 /** `**Severity:** Error · **Source:** ...` opens every diagnostic page. */
 function severity(markdown: string): string | undefined {
@@ -271,6 +280,12 @@ function readArticles(context: vscode.ExtensionContext): WikiArticle[] {
     title: "Modding Tools",
     section: "Community",
     ...moddingToolsPage(gameNames),
+  });
+  articles.push({
+    id: MODDING_GUIDES_ARTICLE,
+    title: "Modding Guides",
+    section: "Community",
+    ...moddingGuidesPage(gameNames),
   });
 
   // Copied from docs/diagnostics by scripts/copy-docs.mjs. README.md is the

--- a/packages/vscode/src/webviews/workshop/app/main.ts
+++ b/packages/vscode/src/webviews/workshop/app/main.ts
@@ -38,6 +38,8 @@ installTips();
 // ---------------------------------------------------------------------------
 
 let mods: ModChoice[] = [];
+/** The menu value that opens the folder dialog instead of picking a mod. */
+const BROWSE = ":browse";
 let active: string | null = null;
 let info: WorkshopModInfo | null = null;
 let live: ItemDetails | null = null;
@@ -167,7 +169,6 @@ function renderToolbar(): void {
   const modBtn = $<HTMLButtonElement>("mod");
   const label = mods.find((m) => m.path === active)?.label ?? "(no mod)";
   modBtn.querySelector("span.px-truncate")!.textContent = label;
-  modBtn.style.display = mods.length > 1 ? "" : "none";
 
   // What Steam reported, not a verdict on the item: "live" read as if the
   // item were public, which it need not be.
@@ -1275,14 +1276,21 @@ window.addEventListener("message", (e: MessageEvent<HostToApp>) => {
 $("mod").addEventListener("click", () => {
   menu(
     $("mod"),
-    mods.map<MenuItem>((m) => ({ value: m.path, label: m.label, description: m.path })),
+    [
+      ...mods.map<MenuItem>((m) => ({ value: m.path, label: m.label, hint: m.hint, description: m.path })),
+      {
+        value: BROWSE,
+        label: "Browse for a mod folder…",
+        description: "Any mod on disk, in the workspace or not",
+      },
+    ],
     {
       value: active ?? undefined,
       width: 380,
       onPick: (path) => {
         if (path === active) return;
         flushSave();
-        send({ type: "selectMod", path });
+        send(path === BROWSE ? { type: "browseMod" } : { type: "selectMod", path });
       },
     }
   );

--- a/packages/vscode/src/webviews/workshop/app/main.ts
+++ b/packages/vscode/src/webviews/workshop/app/main.ts
@@ -1280,8 +1280,8 @@ $("mod").addEventListener("click", () => {
       ...mods.map<MenuItem>((m) => ({ value: m.path, label: m.label, hint: m.hint, description: m.path })),
       {
         value: BROWSE,
-        label: "Browse for a mod folder…",
-        description: "Any mod on disk, in the workspace or not",
+        label: "Upload a mod that is not in this workspace…",
+        description: "Pick its folder on disk; it joins this list for the session",
       },
     ],
     {

--- a/packages/vscode/src/webviews/workshop/messages.ts
+++ b/packages/vscode/src/webviews/workshop/messages.ts
@@ -26,6 +26,8 @@ export interface TranslationDraft {
 export interface ModChoice {
   label: string;
   path: string;
+  /** Where the mod comes from when it is not a workspace folder: the projects folder, the game's mod folder, a browsed folder. */
+  hint?: string;
 }
 
 /**
@@ -175,6 +177,8 @@ export type DlcSource = "game" | "steam" | "none";
 export type AppToHost =
   | { type: "ready" }
   | { type: "selectMod"; path: string }
+  /** Pick any mod folder on disk, in or out of the workspace; the host adds it to the choices. */
+  | { type: "browseMod" }
   /** Ask Steam for the item + these languages' text. */
   | { type: "refresh"; languages: string[] }
   /** Persist the local drafts into <configDir>/workshop.json. */

--- a/packages/vscode/src/webviews/workshop/messages.ts
+++ b/packages/vscode/src/webviews/workshop/messages.ts
@@ -26,7 +26,7 @@ export interface TranslationDraft {
 export interface ModChoice {
   label: string;
   path: string;
-  /** Where the mod comes from when it is not a workspace folder: the projects folder, the game's mod folder, a browsed folder. */
+  /** Said beside the name when the mod is not a workspace folder (picked through the Upload entry). */
   hint?: string;
 }
 

--- a/packages/vscode/src/webviews/workshop/panel.ts
+++ b/packages/vscode/src/webviews/workshop/panel.ts
@@ -502,14 +502,14 @@ export class WorkshopPanel {
           canSelectFiles: false,
           canSelectFolders: true,
           canSelectMany: false,
-          title: "Pick the mod folder to publish",
-          openLabel: "Manage This Mod",
+          title: "Pick a mod folder outside the workspace to upload",
+          openLabel: "Upload This Mod",
         });
         const dir = picked?.[0]?.fsPath;
         if (!dir) return;
         // A folder with no descriptor is taken too: the panel then offers to create one.
         if (!this.options.mods.some((m) => m.path === dir)) {
-          this.options.mods.push({ label: readModName(dir), path: dir, hint: "browsed" });
+          this.options.mods.push({ label: readModName(dir), path: dir, hint: "outside the workspace" });
         }
         this.active = dir;
         this.watchListing();

--- a/packages/vscode/src/webviews/workshop/panel.ts
+++ b/packages/vscode/src/webviews/workshop/panel.ts
@@ -40,7 +40,8 @@ import {
 } from "../../steam/workshopFiles";
 import { preflight } from "../../steam/preflight";
 import { readGameDlc } from "../../steam/gameDlc";
-import { detectGameVersion } from "../../descriptorMod";
+import { createDescriptorFile, detectGameVersion } from "../../descriptorMod";
+import { readModName } from "@px-lsp/protocol/modName";
 import { findSteamLibraries } from "../../steamDetect";
 import { declaredDependencies, dependencyCandidates } from "../../dependencyScan";
 import { changelogCandidates, DEFAULT_CHANGELOG } from "../../steam/workshopFiles";
@@ -483,7 +484,7 @@ export class WorkshopPanel {
   }
 
   private async onMessage(message: AppToHost): Promise<void> {
-    const { meta } = this.options;
+    const { meta, log } = this.options;
     const root = this.active;
     switch (message.type) {
       case "ready":
@@ -496,6 +497,25 @@ export class WorkshopPanel {
         this.watchListing();
         await this.postInfo();
         return;
+      case "browseMod": {
+        const picked = await vscode.window.showOpenDialog({
+          canSelectFiles: false,
+          canSelectFolders: true,
+          canSelectMany: false,
+          title: "Pick the mod folder to publish",
+          openLabel: "Manage This Mod",
+        });
+        const dir = picked?.[0]?.fsPath;
+        if (!dir) return;
+        // A folder with no descriptor is taken too: the panel then offers to create one.
+        if (!this.options.mods.some((m) => m.path === dir)) {
+          this.options.mods.push({ label: readModName(dir), path: dir, hint: "browsed" });
+        }
+        this.active = dir;
+        this.watchListing();
+        await this.postInit();
+        return;
+      }
       case "saveLocal": {
         if (!root) return;
         // The folder is the canonical store; workshop.json keeps only ids.
@@ -520,10 +540,14 @@ export class WorkshopPanel {
         void vscode.env.openExternal(vscode.Uri.parse(url));
         return;
       }
-      case "createDescriptor":
-        await vscode.commands.executeCommand("px.createDescriptor");
+      case "createDescriptor": {
+        // For the mod this panel is on, which need not be the focused one or in the workspace at all.
+        if (!root) return;
+        const file = createDescriptorFile(root, meta.id, this.options.gamePath, log);
         await this.postInfo();
+        await vscode.window.showTextDocument(await vscode.workspace.openTextDocument(vscode.Uri.file(file)));
         return;
+      }
       case "setField":
         await this.setField(message.field, message.value);
         return;

--- a/packages/vscode/test/moddingGuides.test.ts
+++ b/packages/vscode/test/moddingGuides.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { MODDING_GUIDES, moddingGuidesPage } from "../src/webviews/wiki/moddingGuides";
+
+describe("modding guides", () => {
+  it("builds one page with every game's wiki pages as cards", () => {
+    const page = moddingGuidesPage({ ck3: "CK3", vic3: "Vic3", eu5: "EU5" });
+    expect(Object.keys(MODDING_GUIDES)).toEqual(["ck3", "vic3", "eu5"]);
+    // Every card leads to its wiki, says what the page covers, and names its game.
+    for (const card of page.cards) {
+      expect(card.url, card.title).toMatch(/^https:\/\/(ck3|vic3|eu5)\.paradoxwikis\.com\/[A-Za-z0-9_.-]+$/);
+      expect(card.text, card.title).not.toBe("");
+      expect(card.games, card.title).toHaveLength(1);
+    }
+    // No wiki path listed twice for one game.
+    for (const [id, list] of Object.entries(MODDING_GUIDES)) {
+      expect(new Set(list.pages.map((p) => p.path)).size, id).toBe(list.pages.length);
+    }
+    // The pages this started from.
+    const ck3 = page.cards.filter((c) => c.games?.[0] === "ck3").map((c) => c.url);
+    for (const p of ["Modding", "Sound_modding", "Music_modding", "Mod_compatibility"]) {
+      expect(ck3).toContain(`https://ck3.paradoxwikis.com/${p}`);
+    }
+    expect(page.cards[0].kind).toBe("Basics");
+    expect(page.outro).toContain("Sources:");
+  });
+});


### PR DESCRIPTION
The 0.4.1 release: one editor feature people asked for, one wiki page, a Workshop panel fix, and the release edits.

## `@name` file constants are first-class

`@duration = 1825` at the top of a file, then `days = @duration` further down. The reader substitutes the text per file, so these were invisible to the toolkit (never indexed; the word pattern stops at the `@`). Now, in script and gui files of every game (`packages/server/src/features/atConstants.ts`, wired before the language-specific providers):

- hover: value, declaring line, in-file use count; the explanation of what a constant is only on the declaration and on an undeclared name
- F12 to the declaration, from a `@name` use or a bare operand inside `@[ ... ]`
- completion after `@` (new trigger character): the file's constants with their values, each item replacing from the `@`
- inlay hint `= 1825` beside every use
- inline math evaluated: `= @[base / 20] → 1`; all 575 such declarations in the CK3 buildings, men-at-arms, script_values and gui trees evaluate
- a constant standing for a script value shows that definition on the same card
- measured: hover on a constant in the 77,774-line `00_landed_titles.txt` takes 4 ms; when the cursor is not on a constant the extra cost is one regex on the line

## Wiki: Modding Guides page

One list per game (45 CK3, 55 Vic3, 52 EU5) from each wiki's Modding navbox, grouped into the wiki's own groups merged across games. Every card's one-line text was written from the page's actual lead paragraph. Same code path as Modding Tools.

## Workshop panel

- the mod menu lists the workspace mods and ends with "Upload a mod that is not in this workspace…", which adds a picked folder for the session; the menu shows even with one mod
- fix: Create Descriptor in the panel ran `px.createDescriptor`, which writes into the focused workspace mod whatever mod the panel showed; it now writes into the panel's mod via the shared `createDescriptorFile`

## Release edits

- extension and root 0.4.1, `@px-lsp/server` 0.3.2, `@px-lsp/protocol` 0.2.2; changelogs rolled; `docs/release/0.4.1.md`; README wiki bullets; README beta notes without a version
- PERFORMANCE.md row for 0.4.1 (two warm runs over cultivation.code-workspace: index 5.9 s, completion cold 150 ms, after save 138 ms, warm 7 ms, heap 268 MB, peak RSS 813 MB)
- the perf-history writer now reads and writes the `{ note, runs }` shape history.json has; it crashed after measuring on a bare-array assumption

## Checks

- `pnpm run typecheck`, `pnpm run lint`, `check-game-boundary` clean; full `vitest run`: 2140 passed, 7 skipped
- `lspSmoke` drives hover, completion, definition and inlay hints for constants over the real bundle; `stdioSmoke` green
- `px-toolkit-0.4.1.vsix` built per the runbook: PreRelease flag false, readme image URLs identical in shape to 0.4.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Expand editor support for file-local constants, add game-specific modding guides, and make Workshop uploads work with mods outside the workspace.

New Features:
- Add file-local `@name` constant support across script and GUI files, including hover information, completion, inlay values, inline-math evaluation, and go-to-definition.
- Add a per-game Modding Guides wiki page covering the modding pages published by each game's wiki.
- Allow the Workshop panel to browse for and upload mod folders outside the workspace.

Bug Fixes:
- Ensure Workshop descriptor creation writes to the mod currently shown by the panel rather than the focused workspace mod.

Enhancements:
- Expose file-local constants with a dedicated protocol symbol kind without indexing them across files.
- Keep the Workshop mod selector visible for single-mod workspaces and offer descriptor creation for selected folders without descriptors.

Build:
- Bump the extension, server, and protocol versions for the 0.4.1 release.

Documentation:
- Update the README and release documentation to describe Modding Guides, Workshop uploads, and the version-independent beta status.
- Add the 0.4.1 release notes and update documented performance history.

Tests:
- Add coverage for constant resolution, arithmetic, completion, hover, definitions, inlay hints, and LSP behavior.
- Add tests validating Modding Guides page generation.

Chores:
- Restructure performance history recording to store run metadata in the updated history format.