### PR TITLE
Release 0.4.2: graphics assets, DNA copying and section folding

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -215,6 +215,7 @@ record. Do not create notes under `docs/`.
 
 | Script | Output | What it does |
 |---|---|---|
+| `build-asset-vocabulary.ts [--game]` | `data/<id>/assetVocabulary.json` | Context-specific graphics properties and usage counts from vanilla `.asset` files; no binaries |
 | `build-structures-json.ts` | `data/ck3/structures.json` | Harvests every `_*.info` doc (CK3-only) |
 | `build-gui-schema.ts [--game]` | `data/<id>/guiSchema.json` | Widget types + property counts from vanilla `gui/` |
 | `build-freqs.ts [--game]` | `data/<id>/freqs.json` | Per-context usage counts. CK3 regen stays byte-identical modulo `meta.generated` unless the game patched |

--- a/README.md
+++ b/README.md
@@ -113,6 +113,9 @@ docs, image guidelines, diagnostics, mod report and credits.*
   editing, a coverage view, and scaffolding for entire translation mods.
 - **DDS tooling.** Inline texture previews on hover, a zoomable viewer with
   PNG export, image-to-DDS conversion, and measured size guidelines.
+- **Graphics assets** (CK3, Vic3). Index `.asset` files, complete graphics keywords, follow mesh and shader references, and preview textures. Toggle scanning with `px.indexAssets`.
+- **Comment sections.** Fold `### Title` headings through the next heading or the end of the file, across closing braces.
+- **Dynasty DNA** (CK3). Copy DNA for mod files or the game, resolve it across dependency mods, and paste portrait-editor DNA into the selected mod.
 - **Steam Workshop publishing.** Create or update your mod's Workshop item
   through the running Steam client, no Paradox launcher involved. New items
   start private and the id is written back into `descriptor.mod`. A Workshop

--- a/docs/EMBEDDING.md
+++ b/docs/EMBEDDING.md
@@ -166,6 +166,8 @@ concrete:
 - **`locLanguage`** selects the localization language for inlay previews and
   coverage.
 
+Set `indexAssets: false` to skip graphics `.asset` definition and reference indexing in all roots. It defaults to `true` for profiles that support `.asset` files. Send the changed settings through `paradox/configChanged` to rebuild the index without a restart. This does not disable open-file syntax features or on-demand texture previews.
+
 The remaining settings (`parentPaths`, `scopeInlayHints`, `diagnosticsIgnore`,
 `diagnosticsIgnorePatterns`, `diagnosticsVanilla`) are documented in
 `docs/PROTOCOL.md`. Push the whole settings object again as

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -82,6 +82,7 @@ interface ParadoxSettings {
   workspaceMods?: string[];    // mods being EDITED (reference indexing + diagnostics)
   locLanguage: string;         // "english", ...
   scopeInlayHints: boolean;
+  indexAssets?: boolean;      // default true; index .asset definitions and references
   hoverDetail?: "compact" | "standard" | "full"; // how much a hover shows; default "standard"
   calendar?: CalendarSetting;  // FALLBACK custom era calendar for date display (inlay hints + hover); absent = off.
                                //   A mod's own <mod>/.px-toolkit/calendar.json (same shape) wins for files under
@@ -95,6 +96,8 @@ interface ParadoxSettings {
   diagnosticsVanilla: boolean;         // false (default) = never diagnose game files
 }
 ```
+
+`indexAssets` defaults to `true`. Set it to `false` to skip `.asset` definition and reference indexing across workspace mods, dependency mods and vanilla, including on-demand reference searches. Changing it through `paradox/configChanged` rebuilds the index without a restart. Open-file syntax features and on-demand texture previews remain available. Support for `.asset` indexing comes from the active game profile.
 
 Every capability in `client` is independent and defaults to **off**, so a
 client declares exactly what it implements and the server tailors its output

--- a/docs/release/0.4.2.md
+++ b/docs/release/0.4.2.md
@@ -1,0 +1,9 @@
+# Paradox Modding Toolkit 0.4.2 (beta)
+
+- **Graphics assets:** index CK3 and Victoria 3 `.asset` files, complete graphics keywords, navigate mesh and shader references, and preview DDS textures. Toggle scanning with `px.indexAssets`.
+- **Dynasty DNA:** copy DNA for mod files or the game. Fix lookup across dependencies and unsaved files, and support pasting portrait-editor DNA.
+- **Section folding:** collapse `### Title` sections through the next heading or EOF. Closing braces no longer cut sections short.
+- **Editor fixes:** safer confirmation buttons, accessible keyboard focus, a corrected CK3 decision scaffold, and plain Markdown hovers for browser clients.
+- **Setup and presentation:** clearer onboarding and feature guides, a new GitHub banner and social preview, and compatibility checks for VS Code 1.91 and standalone Windows clients.
+
+Includes `@px-lsp/server` 0.3.3 and `@px-lsp/protocol` 0.2.3. Requires VS Code 1.91 or newer.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "px-lsp",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "private": true,
   "license": "GPL-3.0-or-later",
   "engines": {

--- a/packages/protocol/CHANGELOG.md
+++ b/packages/protocol/CHANGELOG.md
@@ -6,6 +6,14 @@ the shared helpers change. Before the split it moved inside the extension's
 version (up to 0.3.2); that history is in the extension changelog
 (`packages/vscode/CHANGELOG.md`).
 
+## Unreleased
+
+## 0.2.3
+
+Ships with the toolkit's 0.4.2 release.
+
+- Add optional `ParadoxSettings.indexAssets` (default `true`) to control graphics `.asset` definition and reference indexing, including live changes through `paradox/configChanged`.
+
 ## 0.2.2
 
 Ships with the toolkit's 0.4.1 release.

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@px-lsp/protocol",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "license": "GPL-3.0-or-later",
   "description": "Wire contract (custom LSP requests/notifications, settings types) and shared helpers for the px-lsp language server and its clients.",
   "keywords": [

--- a/packages/protocol/src/protocol.ts
+++ b/packages/protocol/src/protocol.ts
@@ -29,6 +29,8 @@ export interface ParadoxSettings {
    * reference diagnostics, on top of the parent definition scan. */
   workspaceMods?: string[];
   locLanguage: string;
+  /** Index .asset definitions and references across all roots. Default true. */
+  indexAssets?: boolean;
   /** Show inferred scope after scope-changing block openers (off by default). */
   scopeInlayHints: boolean;
   /**

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -8,6 +8,18 @@ changes. Before the split it moved inside the extension's version (up to
 
 ## Unreleased
 
+## 0.3.3
+
+Ships with the toolkit's 0.4.2 release.
+
+- Resolve graphics asset fields by context: mesh-local blend shapes and animations, entity states, shader effects and CK3 accessory variations. Harvest nested keyword completion from vanilla assets; keep binary shape names separate from script definitions.
+
+- Add `indexAssets` (default on) to toggle graphics `.asset` indexing across mods, dependencies and vanilla without restarting. Keep open-file features and texture previews available when indexing is off.
+
+- Fold comment sections headed by three or more `#` characters through the next heading or the end of the file, regardless of closing braces or indentation. Give sections priority over crossing brace folds.
+
+- Index named graphics blocks in CK3 and Victoria 3 `.asset` files, with file navigation, local filename completion and DDS hover previews. Meshes and animations stay unloaded during indexing.
+
 - Browser hovers use plain Markdown without VS Code commands, icons or HTML, while preserving completion snippets and restoring the enclosing host capabilities. Fix the CK3 decision scaffold's picture block from the current game documentation. Add packed npm consumer and Node 18 transport checks.
 
 ## 0.3.2

--- a/packages/server/data/ck3/assetVocabulary.json
+++ b/packages/server/data/ck3/assetVocabulary.json
@@ -1,0 +1,215 @@
+{
+  "": {
+    "arrowType": 18,
+    "entity": 3702,
+    "pdxmesh": 2964,
+    "skeletal_animation_set": 2
+  },
+  "arrowType": {
+    "effect": 18,
+    "effectname": 9,
+    "name": 18,
+    "size": 11,
+    "subdivisions": 11,
+    "texture": 18
+  },
+  "entity": {
+    "attach": 199,
+    "attribute": 8058,
+    "cull_radius": 14,
+    "default_state": 360,
+    "game_data": 1830,
+    "get_state_from_parent": 67,
+    "locator": 1037,
+    "meshsettings": 119,
+    "name": 3702,
+    "pdxmesh": 3574,
+    "scale": 115,
+    "state": 6859
+  },
+  "entity/attribute": {
+    "additive_animation": 127,
+    "blend_shape": 7931,
+    "default": 131,
+    "name": 8058
+  },
+  "entity/game_data": {
+    "court_entity_user_data": 12,
+    "portrait_entity_user_data": 1792,
+    "throne_entity_user_data": 27
+  },
+  "entity/game_data/court_entity_user_data": {
+    "coat_of_arms": 12
+  },
+  "entity/game_data/portrait_entity_user_data": {
+    "coa_mask": 69,
+    "coa_pattern": 4,
+    "color_mask_remap_interval": 302,
+    "portrait_accessory": 1482,
+    "portrait_decal": 6
+  },
+  "entity/game_data/portrait_entity_user_data/coa_pattern": {
+    "coa_pattern_scale": 4,
+    "coa_pattern_tile": 4,
+    "coa_shape_mask_channel": 4,
+    "coa_staggered_offset": 4
+  },
+  "entity/game_data/portrait_entity_user_data/color_mask_remap_interval": {
+    "interval": 302
+  },
+  "entity/game_data/portrait_entity_user_data/portrait_accessory": {
+    "pattern_mask": 1479,
+    "variation": 1479
+  },
+  "entity/game_data/portrait_entity_user_data/portrait_decal": {
+    "body_part": 6
+  },
+  "entity/game_data/throne_entity_user_data": {
+    "animation": 27,
+    "use_throne_transform": 27
+  },
+  "entity/locator": {
+    "name": 1037,
+    "position": 952,
+    "rotation": 761,
+    "scale": 719
+  },
+  "entity/meshsettings": {
+    "additional_shader_defines": 7,
+    "index": 119,
+    "name": 119,
+    "rasterizerstate": 3,
+    "shader": 109,
+    "shader_file": 109,
+    "texture": 13,
+    "texture_diffuse": 119,
+    "texture_normal": 109,
+    "texture_specular": 109
+  },
+  "entity/meshsettings/texture": {
+    "file": 13,
+    "index": 13
+  },
+  "entity/state": {
+    "animation": 6460,
+    "animation_blend_time": 418,
+    "animation_speed": 16,
+    "chance": 2176,
+    "event": 2312,
+    "looping": 5475,
+    "name": 6859,
+    "next_state": 5505,
+    "propagate_state": 120,
+    "start_event": 1657,
+    "state_time": 346,
+    "time_offset": 54
+  },
+  "entity/state/chance": {
+    "default": 8,
+    "if_current_state": 8
+  },
+  "entity/state/event": {
+    "attachment_id": 109,
+    "entity": 117,
+    "entity_fade_speed": 14,
+    "keep_entity": 3,
+    "keep_particle": 531,
+    "keep_sound": 2,
+    "life": 21,
+    "node": 707,
+    "particle": 603,
+    "remove_attachment": 27,
+    "skip_forward": 17,
+    "sound": 1567,
+    "soundparameter": 2055,
+    "time": 2223,
+    "trigger_once": 196,
+    "use_parent_nodes": 6
+  },
+  "entity/state/event/sound": {
+    "soundeffect": 1567,
+    "stop_on_state_change": 7
+  },
+  "entity/state/start_event": {
+    "attachment_id": 60,
+    "entity": 1180,
+    "entity_fade_speed": 36,
+    "keep_sound": 38,
+    "life": 40,
+    "light": 10,
+    "node": 1586,
+    "particle": 395,
+    "remove_attachment": 33,
+    "sound": 44,
+    "soundparameter": 6,
+    "state": 395,
+    "trigger_once": 45
+  },
+  "entity/state/start_event/sound": {
+    "soundeffect": 44
+  },
+  "pdxmesh": {
+    "additive_animation": 127,
+    "animation": 1882,
+    "blend_shape": 5241,
+    "cull_distance": 101,
+    "file": 2964,
+    "import": 6,
+    "lod_percentages": 853,
+    "meshsettings": 6787,
+    "name": 2964,
+    "scale": 283
+  },
+  "pdxmesh/additive_animation": {
+    "id": 127,
+    "type": 127
+  },
+  "pdxmesh/animation": {
+    "id": 1882,
+    "type": 1882
+  },
+  "pdxmesh/blend_shape": {
+    "data": 9,
+    "id": 5241,
+    "type": 5241
+  },
+  "pdxmesh/import": {
+    "name": 6,
+    "type": 6
+  },
+  "pdxmesh/lod_percentages": {
+    "lod": 1606
+  },
+  "pdxmesh/lod_percentages/lod": {
+    "index": 1606,
+    "percent": 1606
+  },
+  "pdxmesh/meshsettings": {
+    "additional_shader_defines": 631,
+    "index": 6775,
+    "name": 6777,
+    "rasterizerstate": 96,
+    "shader": 6791,
+    "shader_file": 6789,
+    "shadow_shader": 4,
+    "subpass": 709,
+    "texture": 1390,
+    "texture_diffuse": 6782,
+    "texture_normal": 6778,
+    "texture_specular": 6765
+  },
+  "pdxmesh/meshsettings/texture": {
+    "file": 1390,
+    "index": 1390,
+    "srgb": 53
+  },
+  "skeletal_animation_set": {
+    "animation": 1044,
+    "name": 2,
+    "reference_skeleton": 2
+  },
+  "skeletal_animation_set/animation": {
+    "id": 1044,
+    "type": 1044
+  }
+}

--- a/packages/server/data/vic3/assetVocabulary.json
+++ b/packages/server/data/vic3/assetVocabulary.json
@@ -1,0 +1,179 @@
+{
+  "": {
+    "arrowType": 6,
+    "entity": 2447,
+    "pdxmesh": 1683
+  },
+  "arrowType": {
+    "effect": 6,
+    "effectname": 6,
+    "line_smoothing": 6,
+    "name": 6,
+    "overlay": 4,
+    "size": 6,
+    "subdivisions": 6,
+    "texture": 6
+  },
+  "entity": {
+    "attach": 418,
+    "attribute": 3944,
+    "clone": 151,
+    "cull_radius": 94,
+    "default_state": 368,
+    "game_data": 996,
+    "get_state_from_parent": 16,
+    "group": 5,
+    "locator": 786,
+    "meshsettings": 1,
+    "name": 2447,
+    "pdxmesh": 2193,
+    "scale": 110,
+    "state": 1425
+  },
+  "entity/attribute": {
+    "additive_animation": 71,
+    "blend_shape": 3873,
+    "default": 71,
+    "name": 3944
+  },
+  "entity/game_data": {
+    "portrait_entity_user_data": 996
+  },
+  "entity/game_data/portrait_entity_user_data": {
+    "color_mask_remap_interval": 157,
+    "portrait_accessory": 844,
+    "portrait_decal": 4
+  },
+  "entity/game_data/portrait_entity_user_data/color_mask_remap_interval": {
+    "interval": 157
+  },
+  "entity/game_data/portrait_entity_user_data/portrait_accessory": {
+    "pattern_mask": 844,
+    "variation": 844
+  },
+  "entity/game_data/portrait_entity_user_data/portrait_decal": {
+    "body_part": 4
+  },
+  "entity/group": {
+    "attach": 18,
+    "name": 5
+  },
+  "entity/group/attach": {
+    "chance": 18
+  },
+  "entity/locator": {
+    "name": 786,
+    "position": 782,
+    "rotation": 482,
+    "scale": 185
+  },
+  "entity/meshsettings": {
+    "shader": 1,
+    "shader_file": 1,
+    "texture_diffuse": 1,
+    "texture_normal": 1,
+    "texture_specular": 1
+  },
+  "entity/state": {
+    "animation": 611,
+    "animation_blend_time": 10,
+    "animation_speed": 9,
+    "chance": 375,
+    "event": 1210,
+    "looping": 874,
+    "name": 1425,
+    "next_state": 180,
+    "propagate_state": 22,
+    "start_event": 523,
+    "state_time": 595,
+    "time_offset": 95
+  },
+  "entity/state/event": {
+    "attachment_id": 14,
+    "entity": 25,
+    "entity_fade_speed": 19,
+    "keep_entity": 3,
+    "keep_particle": 774,
+    "keep_sound": 646,
+    "life": 11,
+    "node": 679,
+    "particle": 825,
+    "remove_attachment": 7,
+    "skip_forward": 190,
+    "sound": 786,
+    "soundparameter": 60,
+    "time": 1121,
+    "trigger_once": 896,
+    "use_parent_nodes": 6
+  },
+  "entity/state/event/sound": {
+    "soundeffect": 786
+  },
+  "entity/state/start_event": {
+    "attachment_id": 6,
+    "entity": 39,
+    "entity_fade_speed": 3,
+    "keep_particle": 314,
+    "keep_sound": 136,
+    "light": 10,
+    "node": 361,
+    "particle": 331,
+    "remove_attachment": 3,
+    "skip_forward": 2,
+    "sound": 150,
+    "state": 6,
+    "time": 364,
+    "trigger_once": 370
+  },
+  "entity/state/start_event/sound": {
+    "soundeffect": 150
+  },
+  "pdxmesh": {
+    "additive_animation": 71,
+    "animation": 1676,
+    "blend_shape": 1867,
+    "cull_distance": 4,
+    "file": 1683,
+    "lod_percentages": 733,
+    "meshsettings": 7212,
+    "name": 1683,
+    "scale": 223
+  },
+  "pdxmesh/additive_animation": {
+    "id": 71,
+    "type": 71
+  },
+  "pdxmesh/animation": {
+    "id": 1676,
+    "type": 1676
+  },
+  "pdxmesh/blend_shape": {
+    "id": 1867,
+    "type": 1867
+  },
+  "pdxmesh/lod_percentages": {
+    "lod": 1883
+  },
+  "pdxmesh/lod_percentages/lod": {
+    "index": 1883,
+    "percent": 1883
+  },
+  "pdxmesh/meshsettings": {
+    "additional_shader_defines": 3783,
+    "index": 7198,
+    "name": 7206,
+    "shader": 7197,
+    "shader_file": 6976,
+    "shadow_shader": 32,
+    "subpass": 1891,
+    "texture": 2277,
+    "texture_diffuse": 6901,
+    "texture_normal": 6855,
+    "texture_specular": 6859
+  },
+  "pdxmesh/meshsettings/texture": {
+    "file": 2277,
+    "index": 2277,
+    "srgb": 252
+  }
+}

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@px-lsp/server",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "license": "GPL-3.0-or-later",
   "description": "Language server for Paradox script (Crusader Kings III first), usable over node-ipc or stdio from any LSP client.",
   "keywords": [

--- a/packages/server/src/features/assetLanguage.ts
+++ b/packages/server/src/features/assetLanguage.ts
@@ -1,0 +1,314 @@
+/** Context-sensitive graphics navigation. Only text definitions are read; binary
+ * shape names remain opaque. Game vocabulary and relationships live in profiles. */
+import * as fs from "fs";
+import { URI } from "vscode-uri";
+import { TextDocument } from "vscode-languageserver-textdocument";
+import { CompletionItemKind, type Position, type Location, type Hover } from "vscode-languageserver/node";
+import { getParse } from "../parseCache";
+import { parseScript, walkStatements, type AssignmentNode, type RootNode, type ScalarNode } from "../parser";
+import type { AssetField, SchemaEntry } from "../schema/types";
+import type { ServerData } from "../serverData";
+import type { ParadoxSettings } from "@px-lsp/protocol/protocol";
+import type { CompletionResult } from "./completion";
+import type { Definition } from "@px-lsp/protocol/types";
+import { provideAssetFileCompletion, resolveAssetPath } from "./assetPaths";
+
+function scalar(node: AssignmentNode, key: string): ScalarNode | null {
+  if (node.value?.kind !== "block") return null;
+  const field = node.value.statements.find((s) => s.kind === "assignment" && s.key.text === key);
+  return field?.kind === "assignment" && field.value?.kind === "scalar" ? field.value : null;
+}
+
+function contextAt(doc: TextDocument, pos: Position) {
+  const offset = doc.offsetAt(pos);
+  const { result } = getParse(doc);
+  let parents: AssignmentNode[] = [];
+  let hit: AssignmentNode | undefined;
+  let onKey = false;
+  walkStatements(result.root, (s, ancestors) => {
+    if (s.kind !== "assignment") return;
+    if (
+      s.value?.kind === "block" &&
+      offset > s.value.openBrace &&
+      offset <= (s.value.closeBrace ?? doc.getText().length)
+    ) {
+      parents = [...ancestors.filter((a): a is AssignmentNode => a.kind === "assignment"), s];
+    }
+    const keyHit = offset >= s.key.range.start && offset <= s.key.range.end;
+    const valueHit =
+      s.value?.kind === "scalar" && offset >= s.value.range.start && offset <= s.value.range.end;
+    if (keyHit || valueHit) {
+      hit = s;
+      onKey = keyHit;
+      parents = ancestors.filter((a): a is AssignmentNode => a.kind === "assignment");
+    }
+  });
+  return { parents, hit, onKey, path: parents.map((a) => a.key.text).join("/"), root: result.root };
+}
+
+export function assetField(entry: SchemaEntry, context: string, key: string): AssetField | undefined {
+  return entry.assetFields?.[`${context}/${key}`] ?? entry.assetFields?.[`${context}/*`];
+}
+
+interface Candidate {
+  name: string;
+  location: Location;
+}
+const namespaces = new WeakMap<
+  ServerData["index"],
+  { revision: number; entries: Map<string, Definition[]> }
+>();
+
+function namespace(data: ServerData, kind: string, block: string, name?: string): Definition[] {
+  const matches = (d: Definition) => d.kind === kind && d.container === block;
+  if (name !== undefined) {
+    const defs = data.index.lookupAll(name).filter(matches);
+    const source = ["mod", "parent", "vanilla"].find((s) => defs.some((d) => d.source === s));
+    return defs.filter((d) => d.source === source);
+  }
+  let cache = namespaces.get(data.index);
+  if (!cache || cache.revision !== data.index.revision) {
+    cache = { revision: data.index.revision, entries: new Map() };
+    namespaces.set(data.index, cache);
+  }
+  const key = `${kind}/${block}`;
+  let defs = cache.entries.get(key);
+  if (!defs) {
+    defs = data.index.allDefinitions().filter(matches);
+    cache.entries.set(key, defs);
+  }
+  return defs;
+}
+function candidate(doc: TextDocument, name: ScalarNode): Candidate {
+  return {
+    name: name.text,
+    location: {
+      uri: doc.uri,
+      range: { start: doc.positionAt(name.range.start), end: doc.positionAt(name.range.end) },
+    },
+  };
+}
+
+function namedBlocks(root: RootNode, block: string, name?: string): AssignmentNode[] {
+  return root.statements.filter(
+    (s): s is AssignmentNode =>
+      s.kind === "assignment" &&
+      s.key.text === block &&
+      s.value?.kind === "block" &&
+      (name === undefined || scalar(s, "name")?.text === name)
+  );
+}
+
+/** Use the open document for same-file edits; read other definitions only on demand. */
+function owners(
+  data: ServerData,
+  doc: TextDocument,
+  root: RootNode,
+  block: string,
+  name: string
+): Array<{ doc: TextDocument; node: AssignmentNode }> {
+  const result = namedBlocks(root, block, name).map((node) => ({ doc, node }));
+  if (result.length) return result;
+  for (const def of namespace(data, "asset", block, name)) {
+    if (URI.file(def.file).toString() === doc.uri) continue;
+    try {
+      const other = TextDocument.create(
+        URI.file(def.file).toString(),
+        "paradox",
+        0,
+        fs.readFileSync(def.file, "utf8")
+      );
+      for (const node of namedBlocks(parseScript(other.getText()).root, block, name))
+        result.push({ doc: other, node });
+    } catch {
+      /* missing definitions have no target */
+    }
+  }
+  return result;
+}
+
+function targets(
+  data: ServerData,
+  settings: ParadoxSettings,
+  doc: TextDocument,
+  ctx: ReturnType<typeof contextAt>,
+  rule: AssetField,
+  requestedName?: string
+): Candidate[] {
+  if (rule.shaderFile) {
+    const parent = ctx.parents[ctx.parents.length - 1];
+    const file = parent && scalar(parent, rule.shaderFile);
+    const resolved = file && resolveAssetPath(settings, doc.uri, file.text);
+    if (!resolved) return [];
+    try {
+      const text = fs.readFileSync(resolved.fsPath, "utf8");
+      const shaderDoc = TextDocument.create(URI.file(resolved.fsPath).toString(), "plaintext", 0, text);
+      // Preserve offsets while excluding comments in shader source.
+      const source = text.replace(/\/\*[\s\S]*?\*\/|\/\/[^\r\n]*|#[^\r\n]*/g, (s) =>
+        s.replace(/[^\r\n]/g, " ")
+      );
+      return [...source.matchAll(/^\s*Effect\s+([A-Za-z_][\w]*)\s*\{/gm)].map((m) => {
+        const start = m.index! + m[0].indexOf(m[1]);
+        return {
+          name: m[1],
+          location: {
+            uri: shaderDoc.uri,
+            range: { start: shaderDoc.positionAt(start), end: shaderDoc.positionAt(start + m[1].length) },
+          },
+        };
+      });
+    } catch {
+      return [];
+    }
+  }
+  const target = rule.target;
+  if (!target) return [];
+  if (!target.owner) {
+    const out = namespace(data, target.kind ?? "asset", target.block, requestedName)
+      .filter((d) => URI.file(d.file).toString() !== doc.uri)
+      .map((d) => ({
+        name: d.name,
+        location: {
+          uri: URI.file(d.file).toString(),
+          range: { start: { line: d.line, character: 0 }, end: { line: d.line, character: 0 } },
+        },
+      }));
+    for (const node of namedBlocks(ctx.root, target.block)) {
+      const name = scalar(node, "name");
+      if (name) out.unshift(candidate(doc, name));
+    }
+    return out;
+  }
+  let containers = ctx.parents.filter((p) => p.key.text === target.owner).map((node) => ({ doc, node }));
+  if (containers.length === 0 && target.via && ctx.parents[0]) {
+    const mesh = scalar(ctx.parents[0], target.via);
+    if (mesh) containers = owners(data, doc, ctx.root, target.owner, mesh.text);
+  }
+  const out: Candidate[] = [];
+  if (target.imports) {
+    const imports = target.imports;
+    const imported = containers.flatMap((owner) => {
+      if (owner.node.value?.kind !== "block") return [];
+      return owner.node.value.statements.flatMap((child) => {
+        if (child.kind !== "assignment" || child.key.text !== imports.block) return [];
+        const type = scalar(child, imports.typeKey)?.text;
+        const name = scalar(child, imports.nameKey)?.text;
+        return type === imports.type && name
+          ? owners(data, owner.doc, parseScript(owner.doc.getText()).root, type, name)
+          : [];
+      });
+    });
+    containers = [...containers, ...imported];
+  }
+  for (const owner of containers) {
+    if (owner.node.value?.kind !== "block") continue;
+    for (const child of owner.node.value.statements) {
+      if (child.kind !== "assignment" || child.key.text !== target.block) continue;
+      const name = scalar(child, target.key ?? "name");
+      if (name) out.push(candidate(owner.doc, name));
+    }
+  }
+  return out;
+}
+
+export function assetDefinitions(
+  data: ServerData,
+  settings: ParadoxSettings,
+  doc: TextDocument,
+  pos: Position,
+  entry: SchemaEntry
+): Location[] {
+  const ctx = contextAt(doc, pos);
+  if (!ctx.hit || ctx.onKey || ctx.hit.value?.kind !== "scalar") return [];
+  const rule = assetField(entry, ctx.path, ctx.hit.key.text);
+  if (!rule) return [];
+  if (rule.files) {
+    const found = resolveAssetPath(settings, doc.uri, ctx.hit.value.text);
+    return found
+      ? [
+          {
+            uri: URI.file(found.fsPath).toString(),
+            range: { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } },
+          },
+        ]
+      : [];
+  }
+  const name = ctx.hit.value.text;
+  return targets(data, settings, doc, ctx, rule, name)
+    .filter((c) => c.name === name)
+    .map((c) => c.location);
+}
+
+export function assetCompletion(
+  data: ServerData,
+  settings: ParadoxSettings,
+  doc: TextDocument,
+  pos: Position,
+  entry: SchemaEntry
+): CompletionResult {
+  const ctx = contextAt(doc, pos);
+  const offset = doc.offsetAt(pos);
+  if (getParse(doc).result.comments.some((c) => offset >= c.range.start && offset <= c.range.end))
+    return { isIncomplete: false, items: [] };
+  const line = doc.getText({ start: { line: pos.line, character: 0 }, end: pos });
+  const value = /"?([\w]+)"?\s*=\s*"?([\w.\-/]*)$/.exec(line);
+  if (value) {
+    const rule = assetField(entry, ctx.path, value[1]);
+    if (rule?.files)
+      return provideAssetFileCompletion(settings, doc, line, {
+        ...entry,
+        fileFields: { [value[1]]: rule.files },
+      });
+    if (!rule) return { isIncomplete: false, items: [] };
+    const seen = new Set<string>();
+    return {
+      isIncomplete: true,
+      items: targets(data, settings, doc, ctx, rule)
+        .filter(
+          (c) =>
+            c.name.toLowerCase().startsWith(value[2].toLowerCase()) && !seen.has(c.name) && !!seen.add(c.name)
+        )
+        .map((c) => ({ label: c.name, kind: CompletionItemKind.Reference, detail: rule.doc })),
+    };
+  }
+  if (line.trimStart().startsWith("#")) return { isIncomplete: false, items: [] };
+  const prefix = /[\w]*$/.exec(line)![0];
+  return {
+    isIncomplete: false,
+    items: Object.entries(entry.assetVocabulary?.[ctx.path] ?? {})
+      .filter(([key]) => key.startsWith(prefix))
+      .sort((a, b) => b[1] - a[1])
+      .map(([key, count]) => ({
+        label: key,
+        kind: CompletionItemKind.Property,
+        detail: `${ctx.path || "asset root"}; ${count} vanilla uses`,
+        documentation: assetField(entry, ctx.path, key)?.doc,
+        insertText: key,
+      })),
+  };
+}
+
+export function assetHover(
+  data: ServerData,
+  settings: ParadoxSettings,
+  doc: TextDocument,
+  pos: Position,
+  entry: SchemaEntry
+): Hover | null {
+  const ctx = contextAt(doc, pos);
+  if (!ctx.hit) return null;
+  const key = ctx.hit.key.text;
+  const rule = assetField(entry, ctx.path, key);
+  const count = entry.assetVocabulary?.[ctx.path]?.[key];
+  if (!rule && !count) return null;
+  const found = ctx.onKey ? [] : assetDefinitions(data, settings, doc, pos, entry);
+  const text = [
+    `**${key}** (${ctx.path || "asset root"})`,
+    rule?.doc ?? `Graphics property observed in ${count} vanilla declarations.`,
+  ];
+  if (found.length)
+    text.push(
+      `Resolved to ${found.length} declaration${found.length === 1 ? "" : "s"}. Use Go to Definition to open.`
+    );
+  return { contents: { kind: "markdown", value: text.join("\n\n") } };
+}

--- a/packages/server/src/features/assetPaths.ts
+++ b/packages/server/src/features/assetPaths.ts
@@ -12,6 +12,13 @@
 import { CompletionItemKind, type CompletionItem } from "vscode-languageserver/node";
 import * as fs from "fs";
 import * as path from "path";
+import { URI } from "vscode-uri";
+import type { TextDocument } from "vscode-languageserver-textdocument";
+import type { Position } from "vscode-languageserver/node";
+import { getParse } from "../parseCache";
+import { walkStatements } from "../parser";
+import { activeProfile } from "../games/active";
+import type { SchemaEntry } from "../schema/types";
 import type { ParadoxSettings } from "@px-lsp/protocol/protocol";
 import type { CompletionResult } from "./completion";
 
@@ -43,9 +50,110 @@ interface Root {
 export function assetRoots(settings: ParadoxSettings): Root[] {
   const roots: Root[] = [];
   if (settings.modPath) roots.push({ root: settings.modPath, label: "mod" });
-  for (const p of settings.parentPaths ?? []) roots.push({ root: p, label: "parent" });
+  for (const p of [...(settings.workspaceMods ?? [])]
+    .reverse()
+    .concat([...(settings.parentPaths ?? [])].reverse())) {
+    if (!roots.some((r) => r.root === p)) roots.push({ root: p, label: "parent" });
+  }
   if (settings.gamePath) roots.push({ root: settings.gamePath, label: "vanilla" });
+  if (settings.gamePath) {
+    for (const relative of activeProfile().schema.find((e) => e.assetEnginePaths)?.assetEnginePaths ?? []) {
+      roots.push({ root: path.resolve(settings.gamePath, relative), label: "engine" });
+    }
+  }
   return roots;
+}
+
+/** Directories corresponding to the document's folder, in content overlay order. */
+function localAssetRoots(settings: ParadoxSettings, documentUri: string): Root[] {
+  const docDir = path.dirname(URI.parse(documentUri).fsPath);
+  const roots = assetRoots(settings);
+  const owner = roots.find(({ root }) => {
+    const rel = path.relative(root, docDir);
+    return rel !== ".." && !rel.startsWith(`..${path.sep}`) && !path.isAbsolute(rel);
+  });
+  return owner
+    ? roots.map(({ root, label }) => ({ root: path.join(root, path.relative(owner.root, docDir)), label }))
+    : [{ root: docDir, label: "relative" }];
+}
+
+/** Resolve asset-local filenames through the same content overlay as root-relative paths. */
+export function resolveAssetPath(
+  settings: ParadoxSettings,
+  documentUri: string,
+  relative: string
+): { fsPath: string; label: string } | null {
+  const rel = relative.replace(/\\/g, "/");
+  if (path.isAbsolute(rel) || rel.split("/").includes("..")) return null;
+  const rooted = ASSET_ROOTS.has(rel.split("/")[0].toLowerCase());
+  const roots = rooted ? assetRoots(settings) : localAssetRoots(settings, documentUri);
+  for (const { root, label } of roots) {
+    const full = path.join(root, rel);
+    try {
+      if (fs.statSync(full).isFile()) return { fsPath: full, label };
+    } catch {
+      /* absent in this root */
+    }
+  }
+  return null;
+}
+
+/** Only filename-shaped scalar values qualify; comments never become links. */
+export function assetFileAt(document: TextDocument, position: Position): string | null {
+  const { result } = getParse(document);
+  const offset = document.offsetAt(position);
+  let hit: string | null = null;
+  walkStatements(result.root, (stmt) => {
+    if (stmt.kind !== "assignment" || stmt.value?.kind !== "scalar") return;
+    const value = stmt.value;
+    if (offset >= value.range.start && offset < value.range.end && /\.[a-z0-9]+$/i.test(value.text))
+      hit = value.text;
+  });
+  return hit;
+}
+
+/** Local filename completion reads one directory per content root, never the binary files. */
+export function provideAssetFileCompletion(
+  settings: ParadoxSettings,
+  document: TextDocument,
+  linePrefix: string,
+  entry: SchemaEntry
+): CompletionResult {
+  const rooted = assetDirContext(linePrefix);
+  if (rooted !== null && rooted.includes("/")) return provideAssetDirCompletion(settings, rooted);
+  const match = /([A-Za-z_][A-Za-z0-9_]*)\s*=\s*"?([A-Za-z0-9_.\-/]*)$/.exec(linePrefix);
+  const extensions = match ? entry.fileFields?.[match[1]] : null;
+  if (!match || !extensions)
+    return rooted !== null ? provideAssetDirCompletion(settings, rooted) : { isIncomplete: false, items: [] };
+  const prefix = match[2];
+  if (prefix.split("/").includes("..")) return { isIncomplete: false, items: [] };
+  const dirs = localAssetRoots(settings, document.uri);
+  const slash = prefix.lastIndexOf("/");
+  const partial = prefix.slice(slash + 1).toLowerCase();
+  const parent = slash >= 0 ? prefix.slice(0, slash) : "";
+  const items: CompletionItem[] = [];
+  const seen = new Set<string>();
+  for (const { root, label } of dirs) {
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(path.join(root, parent), { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const file of entries) {
+      const low = file.name.toLowerCase();
+      if (!low.startsWith(partial) || seen.has(low)) continue;
+      if (!file.isDirectory() && !extensions.includes(path.extname(low))) continue;
+      seen.add(low);
+      items.push({
+        label: file.name,
+        kind: file.isDirectory() ? CompletionItemKind.Folder : CompletionItemKind.File,
+        insertText: file.name + (file.isDirectory() ? "/" : ""),
+        detail: label,
+      });
+    }
+  }
+  return { isIncomplete: true, items };
 }
 
 /** Base dirs a bare `.dds` field resolves against, or null when the key is not mapped. */

--- a/packages/server/src/features/completion.ts
+++ b/packages/server/src/features/completion.ts
@@ -70,6 +70,7 @@ import { inferenceContextFor, variableTypes } from "../scopes/varTypes";
 import type { Scope } from "../scopes/model";
 import type { ParadoxSettings } from "@px-lsp/protocol/protocol";
 import { assetDirContext, provideAssetDirCompletion, provideBareNameCompletion } from "./assetPaths";
+import { assetCompletion } from "./assetLanguage";
 import { snippetSupport } from "../clientMode";
 import { blockTemplateFor } from "./blockSnippets";
 import { skeletonsAt } from "./definitionSkeletons";
@@ -338,6 +339,12 @@ export class CompletionFeature {
       start: { line: pos.line, character: 0 },
       end: { line: pos.line, character: pos.character },
     });
+
+    if (entry?.extraction === "named-block") {
+      return this.settings
+        ? assetCompletion(this.data, this.settings, document, pos, entry)
+        : { isIncomplete: false, items: [] };
+    }
 
     // `define:NS|CONST` (pipe form) → namespaces, then that namespace's constants.
     const defineMatch = DEFINE_POSITION.exec(linePrefix);

--- a/packages/server/src/features/folding.ts
+++ b/packages/server/src/features/folding.ts
@@ -1,6 +1,6 @@
 /**
  * Folding ranges from the CST: every `{}` block spanning multiple lines, plus
- * runs of consecutive comment lines. Serves every brace language the client
+ * runs of consecutive comment lines and sections headed by 3+ hashes. Serves every brace language the client
  * routes here (script, .gui, and the descriptor/format-doc languages). The
  * provider being registered means VS Code never falls back to indentation
  * folding, so returning [] for a routed language actively disables folding
@@ -21,7 +21,7 @@ function blockOf(stmt: Statement): BlockNode | null {
 }
 
 /** Comment banners: 2+ consecutive full-line comments fold as one region. */
-function commentRuns(lines: { line: number; atLineStart: boolean }[]): FoldingRange[] {
+function commentRuns(lines: { line: number; atLineStart: boolean; section?: boolean }[]): FoldingRange[] {
   const ranges: FoldingRange[] = [];
   let runStart = -1;
   let prevLine = -2;
@@ -33,6 +33,13 @@ function commentRuns(lines: { line: number; atLineStart: boolean }[]): FoldingRa
   };
   for (const c of lines) {
     if (!c.atLineStart) continue;
+    // A section owns the fold on its heading line. Comment-only folds must
+    // neither compete with it nor cross the next section heading.
+    if (c.section) {
+      flush(prevLine);
+      prevLine = c.line;
+      continue;
+    }
     if (c.line === prevLine + 1 && runStart >= 0) {
       prevLine = c.line;
       continue;
@@ -45,10 +52,50 @@ function commentRuns(lines: { line: number; atLineStart: boolean }[]): FoldingRa
   return ranges;
 }
 
+const SECTION_HEADING = /^#{3,}[ \t]*[^#\s]/;
+
+/** Headings are document-wide peers, regardless of indentation or hash count. */
+function sectionRanges(headings: { line: number }[], lastLine: number): FoldingRange[] {
+  return headings
+    .map((heading, i) => ({
+      startLine: heading.line,
+      endLine: headings[i + 1] ? headings[i + 1].line - 1 : lastLine,
+      kind: FoldingRangeKind.Region,
+    }))
+    .filter((r) => r.endLine > r.startLine);
+}
+
+/** Crossing folds cannot form an editor folding tree. Give explicit sections
+ * priority over brace/body folds that would otherwise cut them short. */
+function withSections(ranges: FoldingRange[], sections: FoldingRange[]): FoldingRange[] {
+  const containing = (line: number): FoldingRange | undefined => {
+    let low = 0;
+    let high = sections.length;
+    while (low < high) {
+      const mid = (low + high) >>> 1;
+      if (sections[mid].startLine <= line) low = mid + 1;
+      else high = mid;
+    }
+    const section = sections[low - 1];
+    return section && line <= section.endLine ? section : undefined;
+  };
+  return ranges
+    .filter((range) => {
+      const start = containing(range.startLine);
+      const end = containing(range.endLine);
+      return (
+        !(start && range.startLine > start.startLine && range.endLine > start.endLine) &&
+        !(end && range.startLine < end.startLine && range.endLine < end.endLine)
+      );
+    })
+    .concat(sections);
+}
+
 export function provideFoldingRanges(document: TextDocument): FoldingRange[] {
   if (document.languageId === "paradox-loc") return locFoldingRanges(document);
   const { result, lineIndex } = getParse(document);
   const ranges: FoldingRange[] = [];
+  const text = document.getText();
 
   walkStatements(result.root, (stmt) => {
     const block = blockOf(stmt);
@@ -64,16 +111,21 @@ export function provideFoldingRanges(document: TextDocument): FoldingRange[] {
     if (endLine > startLine) ranges.push({ startLine, endLine });
   });
 
-  ranges.push(
-    ...commentRuns(
-      result.comments.map((c) => ({
-        line: c.line,
-        atLineStart: lineIndex.positionAt(c.range.start).character === 0,
-      }))
+  const comments = result.comments.map((c) => ({
+    line: c.line,
+    atLineStart: /^[ \t\uFEFF]*$/.test(
+      text.slice(lineIndex.offsetAt({ line: c.line, character: 0 }), c.range.start)
+    ),
+    section: SECTION_HEADING.test(c.text),
+  }));
+  ranges.push(...commentRuns(comments));
+  return withSections(
+    ranges,
+    sectionRanges(
+      comments.filter((c) => c.atLineStart && c.section),
+      document.lineCount - 1
     )
   );
-
-  return ranges;
 }
 
 function locFoldingRanges(document: TextDocument): FoldingRange[] {
@@ -94,13 +146,20 @@ function locFoldingRanges(document: TextDocument): FoldingRange[] {
     .getText()
     .replace(/^\uFEFF/, "")
     .split("\n");
-  ranges.push(
-    ...commentRuns(
-      lines
-        .map((text, line) => ({ line, text }))
-        .filter(({ text }) => /^[ \t]*#/.test(text))
-        .map(({ line }) => ({ line, atLineStart: true }))
+  const comments = lines
+    .map((text, line) => ({ line, text: text.trimStart() }))
+    .filter(({ text }) => text.startsWith("#"))
+    .map(({ line, text }) => ({
+      line,
+      atLineStart: true,
+      section: SECTION_HEADING.test(text),
+    }));
+  ranges.push(...commentRuns(comments));
+  return withSections(
+    ranges,
+    sectionRanges(
+      comments.filter((c) => c.section),
+      lines.length - 1
     )
   );
-  return ranges;
 }

--- a/packages/server/src/features/rename.ts
+++ b/packages/server/src/features/rename.ts
@@ -46,6 +46,14 @@ function targetAt(data: ServerData, document: TextDocument, position: Position):
     );
   }
   const foreign = defs.find((d) => d.source !== "mod");
+  if (
+    defs.some((d) => activeProfile().schema.some((e) => e.extraction === "named-block" && e.kind === d.kind))
+  ) {
+    throw new ResponseError(
+      0,
+      "Asset rename is unavailable because not all graphics reference forms are indexed."
+    );
+  }
   if (foreign) {
     throw new ResponseError(
       0,

--- a/packages/server/src/features/semanticTokens.ts
+++ b/packages/server/src/features/semanticTokens.ts
@@ -127,6 +127,10 @@ export function provideSemanticTokens(
   };
 
   walkStatements(result.root, (stmt, ancestors) => {
+    if (entry?.extraction === "named-block") {
+      if (stmt.kind === "assignment" && !stmt.key.quoted) pushAs(stmt.key, "property", 0);
+      return;
+    }
     if (stmt.kind === "assignment") {
       pushScalar(stmt.key);
       if (stmt.value?.kind === "scalar") {

--- a/packages/server/src/features/symbols.ts
+++ b/packages/server/src/features/symbols.ts
@@ -11,6 +11,7 @@ import { DECL_MARKERS, SLOT_KEYS } from "../gui/declMarkers";
 import { PROPERTY_BLOCKS } from "../gui/layoutEngine";
 import { getLocParse, getParse } from "../parseCache";
 import { lspSymbolKind } from "./symbolKind";
+import { activeProfile } from "../games/active";
 
 function toLspRange(lines: LineIndex, range: Range): LspRange {
   return { start: lines.positionAt(range.start), end: lines.positionAt(range.end) };
@@ -176,6 +177,9 @@ function scriptSymbols(document: TextDocument, defKind: string | null): Document
   // so a breadcrumb and a hover badge on the same name draw the same picture.
   const fileKind = defKind ? lspSymbolKind(defKind) : null;
   const symbols: DocumentSymbol[] = [];
+  const namedBlocks = activeProfile().schema.some(
+    (e) => e.kind === defKind && e.extraction === "named-block"
+  );
   for (const stmt of result.root.statements) {
     if (stmt.kind !== "assignment" || stmt.key.quoted) continue;
     const name = stmt.key.text;
@@ -184,8 +188,8 @@ function scriptSymbols(document: TextDocument, defKind: string | null): Document
     const stmts = childBlockStatements(stmt);
     const detail = isEvent ? childScalar(stmts, "type") : childScalar(stmts, "name");
     symbols.push({
-      name,
-      detail: detail ? unquote(detail) : undefined,
+      name: namedBlocks && detail ? unquote(detail) : name,
+      detail: namedBlocks ? name : detail ? unquote(detail) : undefined,
       kind: fileKind ?? (isEvent ? EVENT_SYMBOL_KIND : SymbolKind.Function),
       range: toLspRange(lineIndex, stmt.range),
       selectionRange: toLspRange(lineIndex, stmt.key.range),

--- a/packages/server/src/features/textureHover.ts
+++ b/packages/server/src/features/textureHover.ts
@@ -12,7 +12,7 @@ import * as path from "path";
 import { ddsFormatInfo, ddsToPngDataUri } from "../dds";
 import { getLineText } from "../documents";
 import type { ParadoxSettings } from "@px-lsp/protocol/protocol";
-import { assetRoots, bareNameBaseDirs } from "./assetPaths";
+import { assetRoots, bareNameBaseDirs, resolveAssetPath, assetFileAt } from "./assetPaths";
 import { fileLink, renderHoverMarkdown, type CardInput } from "./hoverRender";
 
 const DDS_PATH = /[A-Za-z0-9_\-./\\]+\.dds/gi;
@@ -73,6 +73,8 @@ export function provideTextureHover(
   position: Position,
   entryKind?: string | null
 ): Hover | null {
+  const isAsset = document.uri.toLowerCase().endsWith(".asset");
+  if (isAsset && !assetFileAt(document, position)) return null;
   const lineText = getLineText(document, position.line);
   DDS_PATH.lastIndex = 0;
   let m: RegExpExecArray | null;
@@ -92,8 +94,12 @@ export function provideTextureHover(
     ...(settings.parentPaths ?? []).map((p) => ({ root: p as string | null, label: "parent" })),
     { root: settings.gamePath, label: "vanilla" },
   ];
-  let resolved: { fsPath: string; label: string } | null = null;
+  let resolved: { fsPath: string; label: string } | null = isAsset
+    ? resolveAssetPath(settings, document.uri, rel)
+    : null;
+  if (isAsset && !resolved) return null;
   for (const { root, label } of candidates) {
+    if (resolved) break;
     if (!root) continue;
     const full = path.join(root, ...rel.split("/"));
     if (fs.existsSync(full)) {

--- a/packages/server/src/games/ck3/schema.ts
+++ b/packages/server/src/games/ck3/schema.ts
@@ -16,7 +16,55 @@ import { JOMINI_VARIABLE_BLOCK_REFS } from "../jomini/variables";
 import { STRUCTURES } from "./structures";
 import { AMBIENT_SCOPES } from "./ambientScopes";
 
+import { ASSET_SCHEMA } from "../jomini/assets";
+import assetVocabulary from "../../../data/ck3/assetVocabulary.json";
+
 const CK3_SCHEMA_BASE: SchemaEntry[] = [
+  {
+    ...ASSET_SCHEMA,
+    assetVocabulary,
+    assetFields: {
+      ...ASSET_SCHEMA.assetFields,
+      // male_head/male_head.asset and female_head/female_head.asset share animation sets.
+      "pdxmesh/import/name": {
+        doc: "Shared skeletal animation set imported by this mesh.",
+        target: { block: "skeletal_animation_set" },
+      },
+      "pdxmesh/import/type": { doc: "Imported asset type, such as skeletal_animation_set." },
+      "skeletal_animation_set/reference_skeleton": {
+        doc: "Mesh used as the reference skeleton for this animation set.",
+        target: { block: "pdxmesh" },
+      },
+      "skeletal_animation_set/animation/type": {
+        doc: "Animation file for this shared animation ID.",
+        files: [".anim"],
+      },
+      "entity/state/animation": {
+        doc: "Animation ID declared by the entity's mesh or its imported skeletal animation set.",
+        target: {
+          owner: "pdxmesh",
+          via: "pdxmesh",
+          block: "animation",
+          key: "id",
+          imports: { block: "import", typeKey: "type", nameKey: "name", type: "skeletal_animation_set" },
+        },
+      },
+      "entity/game_data/portrait_entity_user_data/portrait_accessory/pattern_mask": {
+        doc: "Four-channel texture mask. Each channel selects a pattern from the variation block (vanilla portrait asset comments).",
+        files: [".dds"],
+      },
+      "entity/game_data/portrait_entity_user_data/portrait_accessory/variation": {
+        doc: "Named variation from gfx/portraits/accessory_variations (vanilla portrait asset comments).",
+        target: { kind: "accessory_variation", block: "variation" },
+      },
+    },
+  },
+  {
+    path: "gfx/portraits/accessory_variations",
+    kind: "accessory_variation",
+    extraction: "named-block",
+    completable: false,
+  },
   // --- Core script folders (already wired in v0.3; keep as-is) ---
   { path: "common/scripted_effects", kind: "scripted_effect" },
   { path: "common/scripted_triggers", kind: "scripted_trigger" },
@@ -375,7 +423,7 @@ export const CK3_SCHEMA: SchemaEntry[] = CK3_SCHEMA_BASE.map((entry) => {
 //    (867.1.1 = { ... }); the identity comes from the filename, so standard
 //    extraction would index garbage.
 //  - music/ (.asset format), dlc_metadata, reader_export, and the remaining
-//    gfx/ art-config folders (map styles, unit states, accessory_variations,
+//    gfx/ art-config folders (map styles, unit states,
 //    hud_skins, loading_screens): art/engine data, not script-referenced.
 //    (Full gap list: scripts/audit-schema-coverage.ts.)
 

--- a/packages/server/src/games/eu5/index.ts
+++ b/packages/server/src/games/eu5/index.ts
@@ -31,6 +31,7 @@ import { EU5_SCHEMA } from "./schema.generated";
  * `remove_trait`, which take a trait *scope* in EU5 (`scope[trait]`), not a
  * trait definition name, so wiring them would be a pure false-positive source.
  */
+// Asset indexing is not enabled until its file layout is verified against an install.
 const EU5_REF_FIELDS: RefField[] = [
   // Events & on_actions. Both trigger_event_* effects take either a bare event
   // id or a block (`{ id = X }` / `{ on_action = X }`); only the scalar form

--- a/packages/server/src/games/jomini/assets.ts
+++ b/packages/server/src/games/jomini/assets.ts
@@ -1,0 +1,89 @@
+import type { SchemaEntry, AssetField } from "../../schema/types";
+
+/** Relationships verified in both installed model corpora. Paths distinguish
+ * file-valued type from state/mesh identifiers and nested names. */
+const fields: Record<string, AssetField> = {
+  "pdxmesh/name": { doc: "Declares the mesh name referenced by entity.pdxmesh." },
+  "entity/name": { doc: "Declares an entity name." },
+  "pdxmesh/file": { doc: "Mesh file, relative to this asset or the content root.", files: [".mesh"] },
+  "entity/pdxmesh": {
+    doc: "References a pdxmesh declaration, not a mesh filename.",
+    target: { block: "pdxmesh" },
+  },
+  "entity/default_state": {
+    doc: "State name declared in this entity.",
+    target: { owner: "entity", block: "state" },
+  },
+  "entity/state/next_state": {
+    doc: "Next state declared in this entity.",
+    target: { owner: "entity", block: "state" },
+  },
+  "entity/state/animation": {
+    doc: "Animation ID declared by the entity's mesh.",
+    target: { owner: "pdxmesh", via: "pdxmesh", block: "animation", key: "id" },
+  },
+  "entity/attribute/blend_shape": {
+    doc: "Blend-shape ID declared by the entity's mesh.",
+    target: { owner: "pdxmesh", via: "pdxmesh", block: "blend_shape", key: "id" },
+  },
+  "entity/attribute/additive_animation": {
+    doc: "Additive-animation ID declared by the entity's mesh.",
+    target: { owner: "pdxmesh", via: "pdxmesh", block: "additive_animation", key: "id" },
+  },
+  "entity/attach/*": {
+    doc: "Entity attached at the locator named by this key.",
+    target: { block: "entity" },
+  },
+};
+for (const owner of ["pdxmesh", "entity"]) {
+  const context = `${owner}/meshsettings`;
+  fields[`${context}/name`] = {
+    doc: "Shape name inside the binary mesh. This is not a global script definition.",
+  };
+  fields[`${context}/shader`] = {
+    doc: "Effect declared in the sibling shader_file.",
+    shaderFile: "shader_file",
+  };
+  fields[`${context}/shader_file`] = {
+    doc: "Shader source, including the engine's jomini layer.",
+    files: [".shader"],
+  };
+  for (const key of ["texture_diffuse", "texture_normal", "texture_specular"]) {
+    fields[`${context}/${key}`] = { doc: "Texture file used by this mesh material.", files: [".dds"] };
+  }
+  fields[`${context}/texture/file`] = { doc: "Texture file for this material slot.", files: [".dds"] };
+}
+for (const block of ["animation", "additive_animation", "blend_shape"]) {
+  fields[`pdxmesh/${block}/id`] = { doc: `Declares a ${block} ID local to this mesh.` };
+  fields[`pdxmesh/${block}/type`] = {
+    doc: `Binary file for this ${block}.`,
+    files: [block === "blend_shape" ? ".mesh" : ".anim"],
+  };
+}
+for (const block of ["event", "start_event"]) {
+  fields[`entity/state/${block}/entity`] = {
+    doc: "Entity spawned by this state event.",
+    target: { block: "entity" },
+  };
+}
+
+/** Verified in the CK3 and Victoria 3 gfx/models .asset corpora (2026-09-08).
+ * Names come from the files; binary meshes, animations and textures are not scanned. */
+export const ASSET_SCHEMA: SchemaEntry = {
+  path: "gfx",
+  ext: ".asset",
+  kind: "asset",
+  extraction: "named-block",
+  assetFields: fields,
+  assetEnginePaths: ["../jomini"],
+  referenceKeys: ["entity", "pdxmesh"],
+  fileFields: {
+    file: [".mesh", ".anim"],
+    type: [".mesh", ".anim"],
+    texture_diffuse: [".dds"],
+    texture_normal: [".dds"],
+    texture_specular: [".dds"],
+    shader_file: [".shader"],
+  },
+  completable: false,
+};

--- a/packages/server/src/games/vic3/schema.ts
+++ b/packages/server/src/games/vic3/schema.ts
@@ -29,7 +29,11 @@
 import type { SchemaEntry, RefField } from "../../schema/types";
 import { JOMINI_VARIABLE_BLOCK_REFS } from "../jomini/variables";
 
+import { ASSET_SCHEMA } from "../jomini/assets";
+import assetVocabulary from "../../../data/vic3/assetVocabulary.json";
+
 export const VIC3_SCHEMA: SchemaEntry[] = [
+  { ...ASSET_SCHEMA, assetVocabulary },
   // --- Core script surfaces ---
   // Events use `namespace = x` declarations and ns.N ids like CK3. Root scope
   // varies by event type (country/state/character), so none is claimed.

--- a/packages/server/src/index/extract.ts
+++ b/packages/server/src/index/extract.ts
@@ -85,6 +85,17 @@ export function extractDefinitionsParsed(
   const modePrefix = entryModes?.length ? new RegExp(`^(${entryModes.join("|")}):`) : null;
 
   switch (extraction) {
+    case "named-block":
+      for (const stmt of root.statements) {
+        if (stmt.kind !== "assignment" || stmt.value?.kind !== "block") continue;
+        const name = stmt.value.statements.find(
+          (s) => s.kind === "assignment" && !s.key.quoted && s.key.text === "name"
+        );
+        if (name?.kind !== "assignment" || name.value?.kind !== "scalar") continue;
+        if (!DEF_NAME.test(name.value.text)) continue;
+        push(name.value.text, name.value.range.start, stmt.key.text);
+      }
+      break;
     case "top-level-key":
       for (const stmt of root.statements) {
         if (stmt.kind !== "assignment" || stmt.key.quoted) continue;

--- a/packages/server/src/index/fusedScan.ts
+++ b/packages/server/src/index/fusedScan.ts
@@ -177,8 +177,19 @@ export async function scanModRootFused(root: string, deps: FusedScanDeps): Promi
       for (let k = 0; k < batch.length; k++) {
         const content = contents[k];
         if (content === null) continue;
-        // Not `.txt`: nothing shares this parse, so the plain extractor.
-        pushAll(defsByEntry[index], extractDefinitions(content, entry, batch[k], deps.source));
+        if (entry.extraction === "named-block") {
+          const { root: cst } = parseScript(content);
+          const lines = new LineIndex(content);
+          pushAll(
+            defsByEntry[index],
+            extractDefinitionsParsed(content, cst, lines, entry, batch[k], deps.source)
+          );
+          const extracted = extractReferencesParsed(cst, lines, batch[k], deps.source, deps.schema);
+          deps.addReferences(extracted.references);
+          references += extracted.references.length;
+        } else {
+          pushAll(defsByEntry[index], extractDefinitions(content, entry, batch[k], deps.source));
+        }
       }
       done += batch.length;
       report(entry.path);

--- a/packages/server/src/index/indexer.ts
+++ b/packages/server/src/index/indexer.ts
@@ -269,7 +269,8 @@ export function scanRoot(root: string, source: DefSource, opts: ScanOptions): De
 // older caches lack them and must rebuild.
 // Bumped to 6 when event files started contributing inline
 // scripted_trigger/scripted_effect declarations (#5); older caches lack them.
-const INDEX_CACHE_FORMAT = 6;
+// Named .asset definitions are absent from older caches.
+const INDEX_CACHE_FORMAT = 8;
 
 /** Compact "absent" marker inside cache rows. */
 type Absent = 0;

--- a/packages/server/src/index/lazyRefs.ts
+++ b/packages/server/src/index/lazyRefs.ts
@@ -19,9 +19,11 @@
  * No `vscode` imports here: unit-tested in plain Node.
  */
 import * as fs from "fs";
+import * as path from "path";
 import type { DefSource, Reference } from "@px-lsp/protocol/types";
 import { listFiles } from "@px-lsp/protocol/fsWalk";
 import { isStructuralKeyword } from "../contextKeywords";
+import { activeProfile } from "../games/active";
 
 export interface LazyRefRoot {
   root: string;
@@ -44,13 +46,15 @@ const yieldNow = () => new Promise<void>((resolve) => setImmediate(resolve));
 
 export class LazyReferenceScanner {
   private roots: LazyRefRoot[] = [];
+  private indexAssets = true;
   private isEngineToken?: (name: string) => boolean;
   private fileLists = new Map<string, string[]>();
   private cache = new Map<string, Promise<Reference[]>>();
 
   /** Reconfigure (on reindex/settings change): drops all memoized results. */
-  setRoots(roots: LazyRefRoot[], isEngineToken?: (name: string) => boolean): void {
+  setRoots(roots: LazyRefRoot[], isEngineToken?: (name: string) => boolean, indexAssets = true): void {
     this.roots = roots;
+    this.indexAssets = indexAssets;
     this.isEngineToken = isEngineToken;
     this.fileLists.clear();
     this.cache.clear();
@@ -86,7 +90,16 @@ export class LazyReferenceScanner {
 
   private filesOf(root: string): string[] {
     let files = this.fileLists.get(root);
-    if (!files) this.fileLists.set(root, (files = listFiles(root, ".txt")));
+    if (!files) {
+      files = listFiles(root, ".txt");
+      for (const entry of activeProfile().schema) {
+        if (!this.indexAssets && entry.ext?.toLowerCase() === ".asset") continue;
+        if (entry.extraction === "named-block" && entry.ext && entry.ext !== ".txt") {
+          files.push(...listFiles(path.join(root, entry.path), entry.ext));
+        }
+      }
+      this.fileLists.set(root, files);
+    }
     return files;
   }
 

--- a/packages/server/src/index/references.ts
+++ b/packages/server/src/index/references.ts
@@ -106,6 +106,41 @@ export function extractReferencesParsed(
   const implicitDefs: Definition[] = [];
   const namespaces: string[] = [];
 
+  // Named asset blocks contain graphics properties, never script call sites.
+  const normalizedFile = file.replace(/\\/g, "/").toLowerCase();
+  const namedEntry = schema.entries.find(
+    (e) =>
+      e.extraction === "named-block" &&
+      normalizedFile.endsWith(e.ext ?? ".txt") &&
+      normalizedFile.includes(`/${e.path}/`)
+  );
+  if (namedEntry) {
+    walkStatements(root, (stmt, ancestors) => {
+      if (stmt.kind !== "assignment" || stmt.value?.kind !== "scalar") return;
+      const context = ancestors
+        .filter((a) => a.kind === "assignment")
+        .map((a) => a.key.text)
+        .join("/");
+      const rule =
+        namedEntry.assetFields?.[`${context}/${stmt.key.text}`] ?? namedEntry.assetFields?.[`${context}/*`];
+      if (!rule?.target || rule.target.owner) return;
+      const kinds = [rule.target.kind ?? namedEntry.kind];
+      const value = stmt.value;
+      if (!NAME_OK.test(value.text)) return;
+      const pos = lines.positionAt(value.range.start + (value.quoted ? 1 : 0));
+      references.push({
+        name: value.text,
+        kinds,
+        file,
+        line: pos.line,
+        startChar: pos.character,
+        endChar: pos.character + value.text.length,
+      });
+    });
+    shareReferenceStrings(references);
+    return { references, implicitDefs, namespaces };
+  }
+
   const pushRef = (name: string, kinds: string[], startOffset: number, call?: boolean, chain?: string) => {
     if (!NAME_OK.test(name) || NOT_A_NAME.has(name)) return;
     const pos = lines.positionAt(startOffset);

--- a/packages/server/src/schema/types.ts
+++ b/packages/server/src/schema/types.ts
@@ -15,6 +15,8 @@
 export type NameExtraction =
   /** One definition per top-level assignment key (`my_thing = { ... }`). */
   | "top-level-key"
+  /** Repeated top-level blocks whose identity is their direct `name` field. */
+  | "named-block"
   /** Event files: only `namespace.NNN` top-level keys are definitions. */
   | "event-id"
   /** Landed titles: keys matching /^[ekdcb]_/ at any nesting depth. */
@@ -94,6 +96,11 @@ export interface AmbientScope {
 }
 
 export interface SchemaEntry {
+  /** Graphics property vocabulary harvested from this game's .asset corpus. */
+  assetVocabulary?: Record<string, Record<string, number>>;
+  /** Context path + field -> graphics-specific meaning and target namespace. */
+  assetFields?: Record<string, AssetField>;
+  assetEnginePaths?: string[];
   /** Folder relative to the game/mod root, forward slashes, no trailing slash. */
   path: string;
   /** Definition kind, singular snake_case (e.g. "trait", "decision"). */
@@ -102,6 +109,10 @@ export interface SchemaEntry {
   ext?: string;
   /** Name extraction mode, default "top-level-key". */
   extraction?: NameExtraction;
+  /** Named-block fields that refer to another named block, rather than script calls. */
+  referenceKeys?: string[];
+  /** File-valued fields and allowed extensions, verified in the game's asset files. */
+  fileFields?: Record<string, string[]>;
   /**
    * Loc keys the game requires per definition; `$` is the definition name
    * (e.g. "trait_$", "$_desc"). Used for conservative missing-loc diagnostics
@@ -144,6 +155,22 @@ export interface SchemaEntry {
   structure?: StructureSpec;
   /** Engine-provided saved scopes for this kind (v1.1 §B3). Not yet overlayable (F5). */
   ambientScopes?: AmbientScope[];
+}
+
+export interface AssetField {
+  doc: string;
+  files?: string[];
+  target?: {
+    kind?: string;
+    block: string;
+    /** A declaration local to this owning block, reached via a named reference if needed. */
+    owner?: string;
+    via?: string;
+    key?: string;
+    imports?: { block: string; typeKey: string; nameKey: string; type: string };
+  };
+  /** Effect names are local to the shader file named by this sibling property. */
+  shaderFile?: string;
 }
 
 /** Form a cross-reference field takes. */

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -174,6 +174,7 @@ import { provideDateHover } from "./features/calendarDates";
 import { sanitizeCalendar, type CalendarSetting } from "@px-lsp/protocol/calendar";
 import { isCalendarFile, readCalendarFile } from "@px-lsp/protocol/calendarFile";
 import { provideTextureHover } from "./features/textureHover";
+import { assetDefinitions, assetHover } from "./features/assetLanguage";
 import { provideDefinition, provideLocDefinition } from "./features/definition";
 import {
   declaresConstants,
@@ -298,6 +299,7 @@ function defaultSettings(): ParadoxSettings {
     workspaceMods: [],
     locLanguage: "english",
     scopeInlayHints: false,
+    indexAssets: true,
     hoverDetail: "standard",
     diagnosticsIgnore: [],
     diagnosticsIgnorePatterns: [],
@@ -317,6 +319,8 @@ let indexing = false;
 let scanGeneration = 0;
 /** Bundled schema merged with the workspace overlay; reloaded on path changes. */
 let schema: SchemaData = loadSchema(null);
+/** Index selection is separate from the schema used by open-file features. */
+let indexSchema: SchemaData = schema;
 /** namespace declarations per mod file, folded into data.modNamespaces. */
 const namespacesByFile = new Map<string, string[]>();
 
@@ -342,7 +346,7 @@ function refreshLazyRefs(): void {
     source: "parent" as const,
   }));
   if (settings.gamePath) roots.push({ root: settings.gamePath, source: "vanilla" });
-  lazyRefs.setRoots(roots, isEngineToken);
+  lazyRefs.setRoots(roots, isEngineToken, settings.indexAssets !== false);
 }
 
 /** Bundled frequency tables: completion ranks with them, the Examples Wiki
@@ -1031,7 +1035,7 @@ async function scanRootChunked(
   const defs: Definition[] = [];
   const work: Array<{ entry: SchemaData["entries"][number]; files: string[] }> = [];
   let totalFiles = 0;
-  for (const entry of schema.entries) {
+  for (const entry of indexSchema.entries) {
     const dir = path.join(root, ...entry.path.split("/"));
     // The listing shares the read loop's yield budget below. It used to run to
     // completion first, and for its whole duration the server answered no
@@ -1090,7 +1094,7 @@ async function scanModRootBoth(root: string, generation: number): Promise<number
   if (faultScan) injectScanFault();
   const t0 = Date.now();
   const result = await scanModRootFused(root, {
-    schema,
+    schema: indexSchema,
     // Both callers are workspace mods; dependency parents never reach here.
     source: "mod",
     locLanguage: settings.locLanguage,
@@ -1157,6 +1161,10 @@ async function buildIndex(): Promise<void> {
   clearPathCaches();
   calendarByRoot.clear();
   schema = loadSchema([...(settings.modPath ? [settings.modPath] : []), ...workspaceModRoots()], log);
+  indexSchema =
+    settings.indexAssets === false
+      ? { ...schema, entries: schema.entries.filter((e) => e.ext?.toLowerCase() !== ".asset") }
+      : schema;
   data.completableKinds = new Set([
     ...schema.entries.filter((e) => e.completable !== false).map((e) => e.kind),
     "saved_scope",
@@ -1217,7 +1225,7 @@ async function buildIndex(): Promise<void> {
       const version = detectGameVersion(gamePath);
       const cacheFile = path.join(
         storageDir,
-        `vanillaIndex${activeProfile().cacheSuffix}-${settings.locLanguage}.json`
+        `vanillaIndex${activeProfile().cacheSuffix}-${settings.locLanguage}${settings.indexAssets === false ? "-no-assets" : ""}.json`
       );
       let defs = loadIndexCache(cacheFile, version);
       if (defs) {
@@ -1318,6 +1326,7 @@ function contentDigest(content: string | null): string {
 
 function rescanModFile(fsPath: string): void {
   const lower = fsPath.toLowerCase();
+  if (settings.indexAssets === false && lower.endsWith(".asset")) return;
   const wsRoot = workspaceRootOf(fsPath);
   const parentRoot = wsRoot ? null : parentRoots().find((r) => lower.startsWith(r.toLowerCase()));
   if (!wsRoot && !parentRoot) return;
@@ -1325,7 +1334,7 @@ function rescanModFile(fsPath: string): void {
   const source = wsRoot ? ("mod" as const) : ("parent" as const);
 
   const entry = classifyFile(root, fsPath, schema.entries);
-  const isScript = lower.endsWith(".txt");
+  const isScript = lower.endsWith(".txt") || entry?.extraction === "named-block";
   if (!entry && !isScript) return;
   if (entry?.kind === "loc_key" && !isWantedLocFile(path.relative(root, fsPath), settings.locLanguage))
     return;
@@ -1488,6 +1497,7 @@ connection.onInitialized(() => {
     void connection.client.register(DidChangeWatchedFilesNotification.type, {
       watchers: [
         { globPattern: "**/*.{txt,yml,gui,mod}" },
+        { globPattern: "**/gfx/**/*.asset" },
         { globPattern: "**/metadata.json" },
         { globPattern: "**/calendar.json" },
       ],
@@ -1531,6 +1541,7 @@ connection.onNotification(configChangedNotification, (incoming: ParadoxSettings)
     JSON.stringify(newSettings.diagnosticsIgnorePatterns) !==
       JSON.stringify(settings.diagnosticsIgnorePatterns) ||
     newSettings.diagnosticsVanilla !== settings.diagnosticsVanilla;
+  const assetIndexChanged = (newSettings.indexAssets !== false) !== (settings.indexAssets !== false);
   settings = newSettings;
   setHoverDetail(settings.hoverDetail ?? "standard");
   settings.calendar = sanitizeCalendar(settings.calendar);
@@ -1539,6 +1550,8 @@ connection.onNotification(configChangedNotification, (incoming: ParadoxSettings)
     log("paths changed; rebuilding data...");
     loadDocs(false);
     startIndexBuild("paths changed");
+  } else if (assetIndexChanged) {
+    startIndexBuild("asset indexing changed");
   }
   // Re-validate open documents so suppression/vanilla changes apply immediately.
   if (diagChanged || pathsChanged) {
@@ -2000,6 +2013,7 @@ connection.onHover((params) =>
     if (dateHover) return dateHover;
     const texture = provideTextureHover(settings, doc, params.position, entry?.kind);
     if (texture) return texture;
+    if (entry?.extraction === "named-block") return assetHover(data, settings, doc, params.position, entry);
     return provideHover(
       data,
       doc,
@@ -2046,6 +2060,9 @@ connection.onDefinition((params) =>
     if (!isScriptLanguage(doc.languageId) && doc.languageId !== "paradox-gui") return [];
     const constant = provideConstantDefinition(doc, params.position);
     if (constant) return constant;
+    const assetEntry = schemaEntryForFile(URI.parse(doc.uri).fsPath);
+    if (assetEntry?.extraction === "named-block")
+      return assetDefinitions(data, settings, doc, params.position, assetEntry);
     if (doc.languageId === "paradox-gui") {
       // Types, templates and blockoverride targets resolve through the FIOS
       // store first (what the game actually uses); loc keys etc. fall through.

--- a/packages/server/test/assetLanguage.test.ts
+++ b/packages/server/test/assetLanguage.test.ts
@@ -1,0 +1,214 @@
+import { afterAll, describe, expect, it } from "vitest";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { URI } from "vscode-uri";
+import { TextDocument } from "vscode-languageserver-textdocument";
+import type { ParadoxSettings } from "@px-lsp/protocol/protocol";
+import { ServerData } from "../src/serverData";
+import { ck3Profile } from "../src/games/ck3";
+import { extractDefinitions } from "../src/index/extract";
+import { assetCompletion, assetDefinitions, assetHover } from "../src/features/assetLanguage";
+import { devPath } from "../../../scripts/devPaths";
+
+const root = fs.mkdtempSync(path.join(os.tmpdir(), "px-asset-language-"));
+const game = path.join(root, "game");
+const mod = path.join(root, "mod");
+const entry = ck3Profile.schema.find((e) => e.ext === ".asset")!;
+const settings: ParadoxSettings = {
+  modPath: mod,
+  gamePath: game,
+  parentPaths: [],
+  logsPath: null,
+  locLanguage: "english",
+  scopeInlayHints: false,
+  diagnosticsIgnore: [],
+  diagnosticsIgnorePatterns: [],
+  diagnosticsVanilla: false,
+};
+afterAll(() => fs.rmSync(root, { recursive: true, force: true }));
+let version = 0;
+function document(marked: string, file = path.join(mod, "gfx/models/hat.asset")) {
+  const offset = marked.indexOf("|");
+  const doc = TextDocument.create(URI.file(file).toString(), "paradox", ++version, marked.replace("|", ""));
+  return { doc, pos: doc.positionAt(offset) };
+}
+function write(file: string, text: string) {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, text);
+  return file;
+}
+function definitions(marked: string, data = new ServerData()) {
+  const { doc, pos } = document(marked);
+  return assetDefinitions(data, settings, doc, pos, entry);
+}
+function complete(marked: string, data = new ServerData()) {
+  const { doc, pos } = document(marked);
+  return assetCompletion(data, settings, doc, pos, entry).items.map((i) => i.label);
+}
+
+describe("context-sensitive asset language", () => {
+  it("completes harvested keys at the root and at the screenshot's nested material", () => {
+    expect(complete("pdxm|")).toContain("pdxmesh");
+    expect(complete('pdxmesh = { name = "mesh" meshsettings = { texture_| } }')).toEqual(
+      expect.arrayContaining(["texture_diffuse", "texture_normal", "texture_specular"])
+    );
+    expect(
+      complete("entity = { game_data = { portrait_entity_user_data = { portrait_accessory = { var| } } } }")
+    ).toEqual(["variation"]);
+    expect(complete("entity = { default_| }")).toEqual(["default_state"]);
+  });
+
+  it("resolves mesh and blend-shape names in the open document, without indexing", () => {
+    const prefix = 'pdxmesh = { name = "mesh" blend_shape = { id = "fat" type = "fat.mesh" } }\n';
+    expect(definitions(prefix + 'entity = { pdxmesh = "me|sh" }')[0].range.start.line).toBe(0);
+    expect(
+      definitions(prefix + 'entity = { pdxmesh = "mesh" attribute = { blend_shape = "fa|t" } }')
+    ).toHaveLength(1);
+    expect(complete(prefix + 'entity = { pdxmesh = "mesh" attribute = { blend_shape = "f|" } }')).toEqual([
+      "fat",
+    ]);
+    expect(
+      definitions(prefix + 'entity = { pdxmesh = "different" attribute = { blend_shape = "fa|t" } }')
+    ).toEqual([]);
+  });
+
+  it("keeps state and animation identifiers local to their owners, including imported sets", () => {
+    const prefix = `skeletal_animation_set = { name = "shared" animation = { id = "idle_anim" type = "idle.anim" } }
+pdxmesh = { name = "mesh" import = { type = skeletal_animation_set name = "shared" } }
+entity = { name = "other" state = { name = "wrong" } }
+`;
+    expect(
+      complete(prefix + 'entity = { pdxmesh = "mesh" state = { name = "idle" animation = "idle_|" } }')
+    ).toEqual(["idle_anim"]);
+    expect(
+      definitions(prefix + 'entity = { pdxmesh = "mesh" state = { animation = "idle_an|im" } }')
+    ).toHaveLength(1);
+    expect(complete(prefix + 'entity = { default_state = "|" state = { name = "idle" } }')).toEqual(["idle"]);
+    expect(definitions(prefix + 'entity = { state = { name = "idle" next_state = "id|le" } }')).toHaveLength(
+      1
+    );
+  });
+
+  it("uses typed external definitions and refreshes completion after index changes", () => {
+    const data = new ServerData();
+    const file = write(
+      path.join(mod, "gfx/models/other.asset"),
+      'pdxmesh = { name = "external" blend_shape = { id = "fat" } }'
+    );
+    data.index.addAll(extractDefinitions(fs.readFileSync(file, "utf8"), entry, file, "mod"));
+    expect(definitions('entity = { pdxmesh = "ext|ernal" }', data)[0].uri).toBe(URI.file(file).toString());
+    expect(
+      definitions('entity = { pdxmesh = "external" attribute = { blend_shape = "fa|t" } }', data)[0].uri
+    ).toBe(URI.file(file).toString());
+    expect(complete('entity = { pdxmesh = "ext|" }', data)).toEqual(["external"]);
+    data.index.removeFile(file);
+    expect(complete('entity = { pdxmesh = "ext|" }', data)).toEqual([]);
+    data.index.addAll(extractDefinitions('entity = { name = "external" }', entry, file, "mod"));
+    expect(definitions('entity = { pdxmesh = "ext|ernal" }', data)).toEqual([]);
+    expect(definitions('entity = { attach = { "locator" = "ext|ernal" } }', data)).toHaveLength(1);
+    expect(complete('entity = { attach = { "locator" = "ext|" } }', data)).toEqual(["external"]);
+  });
+
+  it("resolves shader effects in the engine layer and ignores commented declarations", () => {
+    const shader = write(
+      path.join(root, "jomini/gfx/FX/jomini/portrait.shader"),
+      "/*\nEffect commented {}\n*/\n// Effect hidden {}\nEffect portrait_attachment_pattern\n{ }"
+    );
+    const marked =
+      'pdxmesh = { meshsettings = { shader = "portrait_attachment_pat|tern" shader_file = "gfx/FX/jomini/portrait.shader" } }';
+    const defs = definitions(marked);
+    expect(defs).toHaveLength(1);
+    expect(defs[0].uri).toBe(URI.file(shader).toString());
+    expect(defs[0].range.start.line).toBe(4);
+    expect(complete(marked.replace("portrait_attachment_pat|tern", "|"))).toEqual([
+      "portrait_attachment_pattern",
+    ]);
+  });
+
+  it("does not resolve mesh-local IDs from a shadowed vanilla mesh", () => {
+    const data = new ServerData();
+    for (const source of ["vanilla", "mod"] as const) {
+      const file = write(
+        path.join(source === "mod" ? mod : game, "gfx/models/override.asset"),
+        `pdxmesh = { name = "overridden" blend_shape = { id = "${source}_shape" } }`
+      );
+      data.index.addAll(extractDefinitions(fs.readFileSync(file, "utf8"), entry, file, source));
+    }
+    expect(
+      definitions('entity = { pdxmesh = "overridden" attribute = { blend_shape = "vanilla_sh|ape" } }', data)
+    ).toEqual([]);
+    expect(
+      definitions('entity = { pdxmesh = "overridden" attribute = { blend_shape = "mod_sh|ape" } }', data)
+    ).toHaveLength(1);
+  });
+
+  it("resolves accessory variations and root-relative masks from portrait game_data", () => {
+    const data = new ServerData();
+    const variationEntry = ck3Profile.schema.find((e) => e.kind === "accessory_variation")!;
+    const file = write(
+      path.join(game, "gfx/portraits/accessory_variations/example.txt"),
+      'variation = { name = "western_nobility" }'
+    );
+    data.index.addAll(extractDefinitions(fs.readFileSync(file, "utf8"), variationEntry, file, "vanilla"));
+    const prefix = "entity = { game_data = { portrait_entity_user_data = { portrait_accessory = { ";
+    expect(definitions(prefix + 'variation = "western_nob|ility" } } } }', data)[0].uri).toBe(
+      URI.file(file).toString()
+    );
+    const mask = write(path.join(mod, "gfx/models/masks.dds"), "");
+    expect(definitions(prefix + 'pattern_mask = "gfx/models/mas|ks.dds" } } } }')[0].uri).toBe(
+      URI.file(mask).toString()
+    );
+  });
+
+  it("does not confuse binary shape names, numeric properties or comments with script symbols", () => {
+    const data = new ServerData();
+    const prefix = 'pdxmesh = { name = "Shape" }\n';
+    expect(definitions(prefix + 'pdxmesh = { meshsettings = { name = "Sha|pe" } }', data)).toEqual([]);
+    expect(complete('entity = {\n # pdxmesh = "|\n}', data)).toEqual([]);
+    expect(complete('entity = { name = "a" # pdxmesh = "|\n}', data)).toEqual([]);
+    expect(complete("pdxmesh = { meshsettings = { index = | } }")).toEqual([]);
+    const { doc, pos } = document('pdxmesh = { blend_shape = { ty|pe = "fat.mesh" } }');
+    expect(JSON.stringify(assetHover(data, settings, doc, pos, entry))).toContain("Binary file");
+    expect(JSON.stringify(assetHover(data, settings, doc, pos, entry))).not.toContain("character_event");
+  });
+});
+
+const installedGame = devPath("gamePath");
+it.skipIf(!installedGame)(
+  "resolves the real CK3 portrait asset's mesh, blend shape, material files and variation",
+  () => {
+    const file = path.join(
+      installedGame!,
+      "gfx/models/portraits/f_headgear/sp3_western/western_nob_01/f_headgear_sec_sp3_western_hi_nob_01.asset"
+    );
+    const text = fs.readFileSync(file, "utf8");
+    const doc = TextDocument.create(URI.file(file).toString(), "paradox", 1, text);
+    const data = new ServerData();
+    const variationEntry = ck3Profile.schema.find((e) => e.kind === "accessory_variation")!;
+    const variation = path.join(installedGame!, "gfx/portraits/accessory_variations/sp3.txt");
+    data.index.addAll(
+      extractDefinitions(fs.readFileSync(variation, "utf8"), variationEntry, variation, "vanilla")
+    );
+    const realSettings = { ...settings, modPath: null, gamePath: installedGame };
+    for (const key of [
+      "file",
+      "texture_diffuse",
+      "texture_normal",
+      "texture_specular",
+      "shader",
+      "shader_file",
+      "pattern_mask",
+      "variation",
+      "pdxmesh",
+      "blend_shape",
+    ]) {
+      const match = new RegExp(`\\b${key}\\s*=\\s*"([^"]+)"`).exec(text)!;
+      expect(match, key).not.toBeNull();
+      const pos = doc.positionAt(match.index + match[0].indexOf('"') + 2);
+      const defs = assetDefinitions(data, realSettings, doc, pos, entry);
+      expect(defs.length, key).toBeGreaterThan(0);
+      expect(fs.existsSync(URI.parse(defs[0].uri).fsPath), key).toBe(true);
+    }
+  }
+);

--- a/packages/server/test/assets.test.ts
+++ b/packages/server/test/assets.test.ts
@@ -1,0 +1,159 @@
+import { afterAll, describe, expect, it } from "vitest";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { URI } from "vscode-uri";
+import { TextDocument } from "vscode-languageserver-textdocument";
+import type { ParadoxSettings } from "@px-lsp/protocol/protocol";
+import type { Reference } from "@px-lsp/protocol/types";
+import { scanModRootFused } from "../src/index/fusedScan";
+import { extractDefinitions } from "../src/index/extract";
+import { extractReferences } from "../src/index/references";
+import { loadSchema } from "../src/schema/loader";
+import { ASSET_SCHEMA } from "../src/games/jomini/assets";
+import { provideDocumentSymbols } from "../src/features/symbols";
+import { assetFileAt, provideAssetFileCompletion, resolveAssetPath } from "../src/features/assetPaths";
+import { provideTextureHover } from "../src/features/textureHover";
+import { LazyReferenceScanner } from "../src/index/lazyRefs";
+import { ck3Profile } from "../src/games/ck3";
+import { vic3Profile } from "../src/games/vic3";
+import { eu5Profile } from "../src/games/eu5";
+
+// The same named-block/meshsettings shape as the installed portrait assets.
+const text = `pdxmesh = {
+  name = "hat_mesh"
+  file = "hat.mesh"
+  meshsettings = { name = "Shape" texture_diffuse = "hat.dds" }
+}
+entity = {
+  name = "hat_entity"
+  pdxmesh = "hat_mesh"
+}
+entity = { name = "second_entity" pdxmesh = hat_mesh }
+`;
+const root = fs.mkdtempSync(path.join(os.tmpdir(), "px-assets-test-"));
+const mod = path.join(root, "mod");
+const game = path.join(root, "game");
+const parent = path.join(root, "parent");
+function write(base: string, rel: string, content: string | Buffer): string {
+  const file = path.join(base, rel);
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, content);
+  return file;
+}
+const asset = write(mod, "gfx/models/hat.asset", text);
+const doc = TextDocument.create(URI.file(asset).toString(), "paradox", 1, text);
+const schema = loadSchema(null);
+const settings: ParadoxSettings = {
+  modPath: mod,
+  gamePath: game,
+  parentPaths: [parent],
+  logsPath: null,
+  locLanguage: "english",
+  scopeInlayHints: false,
+  diagnosticsIgnore: [],
+  diagnosticsIgnorePatterns: [],
+  diagnosticsVanilla: false,
+};
+afterAll(() => fs.rmSync(root, { recursive: true, force: true }));
+
+describe("graphics assets", () => {
+  it("enables verified profiles and leaves the unverified game out", () => {
+    expect(ck3Profile.schema.find((e) => e.ext === ".asset")?.assetVocabulary).toBeDefined();
+    expect(vic3Profile.schema.find((e) => e.ext === ".asset")?.assetVocabulary).toBeDefined();
+    expect(eu5Profile.schema.some((e) => e.ext === ".asset")).toBe(false);
+  });
+
+  it("extracts direct names, preserves repeated block types and excludes meshsettings names", () => {
+    const defs = extractDefinitions(text, ASSET_SCHEMA, asset, "mod");
+    expect(defs.map((d) => [d.name, d.container, d.line])).toEqual([
+      ["hat_mesh", "pdxmesh", 1],
+      ["hat_entity", "entity", 6],
+      ["second_entity", "entity", 9],
+    ]);
+    expect(provideDocumentSymbols(doc, "asset").map((s) => s.name)).toEqual(defs.map((d) => d.name));
+  });
+
+  it("indexes quoted and bare references with exact ranges and no script calls", () => {
+    const result = extractReferences(text, asset, "mod", schema);
+    expect(result.references).toHaveLength(2);
+    for (const ref of result.references) {
+      expect(ref.name).toBe("hat_mesh");
+      expect(text.split("\n")[ref.line].slice(ref.startChar, ref.endChar)).toBe("hat_mesh");
+      expect(ref.call).toBeUndefined();
+    }
+    expect(result.implicitDefs).toEqual([]);
+  });
+
+  it("reads each asset once in the fused scan and never reads binary companions", async () => {
+    write(mod, "gfx/models/hat.mesh", Buffer.alloc(16));
+    const reads: string[] = [];
+    const refs: Reference[] = [];
+    const result = await scanModRootFused(mod, {
+      schema,
+      source: "mod",
+      locLanguage: "english",
+      readBatch: async (files) => {
+        reads.push(...files);
+        return files.map((f) => fs.readFileSync(f, "utf8"));
+      },
+      superseded: () => false,
+      yieldNow: async () => {},
+      addReferences: (r) => refs.push(...r),
+      setNamespaces: () => {},
+    });
+    expect(reads).toEqual([asset]);
+    expect(result?.defs).toHaveLength(3);
+    expect(refs).toHaveLength(2);
+  });
+
+  it("finds asset uses in dependency roots on demand", async () => {
+    write(parent, "gfx/models/parent.asset", 'entity = { name = "parent_hat" pdxmesh = "hat_mesh" }');
+    const scanner = new LazyReferenceScanner();
+    scanner.setRoots([{ root: parent, source: "parent" }]);
+    expect((await scanner.lookup("hat_mesh")).map((r) => r.name)).toEqual(["hat_mesh"]);
+    scanner.setRoots([{ root: parent, source: "parent" }], undefined, false);
+    expect(await scanner.lookup("hat_mesh")).toEqual([]);
+    scanner.setRoots([{ root: parent, source: "parent" }]);
+    expect(await scanner.lookup("hat_mesh")).toHaveLength(1);
+  });
+
+  it("resolves local and rooted paths through mod overlays and provides a real DDS preview", () => {
+    const dds = Buffer.alloc(132);
+    dds.write("DDS ");
+    dds.writeUInt32LE(124, 4);
+    dds.writeUInt32LE(1, 12);
+    dds.writeUInt32LE(1, 16);
+    dds.writeUInt32LE(32, 76);
+    dds.writeUInt32LE(0x41, 80);
+    dds.writeUInt32LE(32, 88);
+    dds.writeUInt32LE(0xff0000, 92);
+    dds.writeUInt32LE(0xff00, 96);
+    dds.writeUInt32LE(0xff, 100);
+    dds.writeUInt32LE(0xff000000, 104);
+    dds.writeUInt32LE(0xffff0000, 128);
+    const modTexture = write(mod, "gfx/models/hat.dds", dds);
+    write(game, "gfx/models/hat.dds", dds);
+    const vanillaUri = URI.file(path.join(game, "gfx/models/hat.asset")).toString();
+    expect(resolveAssetPath(settings, vanillaUri, "hat.dds")?.fsPath).toBe(modTexture);
+    expect(resolveAssetPath(settings, vanillaUri, "gfx/models/hat.dds")?.fsPath).toBe(modTexture);
+    expect(resolveAssetPath(settings, vanillaUri, "../secret.dds")).toBeNull();
+    const hoverDoc = TextDocument.create(vanillaUri, "paradox", 1, 'texture_diffuse = "hat.dds"');
+    const hover = provideTextureHover(
+      { ...settings, indexAssets: false },
+      hoverDoc,
+      { line: 0, character: 21 },
+      "asset"
+    );
+    expect((hover?.contents as { value: string }).value).toContain("data:image/png;base64,");
+    expect(assetFileAt(doc, { line: 2, character: 12 })).toBe("hat.mesh");
+  });
+
+  it("completes sibling files without suggesting unrelated script effects", () => {
+    write(mod, "gfx/models/f_hat.mesh", "");
+    write(game, "gfx/models/f_other.mesh", "");
+    write(mod, "gfx/models/f_notes.txt", "");
+    const result = provideAssetFileCompletion(settings, doc, 'file = "f_', ASSET_SCHEMA);
+    expect(result.items.map((i) => i.label)).toEqual(["f_hat.mesh", "f_other.mesh"]);
+  });
+});

--- a/packages/server/test/foldingSections.test.ts
+++ b/packages/server/test/foldingSections.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+import { TextDocument } from "vscode-languageserver-textdocument";
+import { provideFoldingRanges } from "../src/features/folding";
+
+let serial = 0;
+function fold(text: string, language = "paradox") {
+  return provideFoldingRanges(TextDocument.create(`file:///sections-${serial++}.txt`, language, 1, text));
+}
+function region(startLine: number, endLine: number) {
+  return { startLine, endLine, kind: "region" };
+}
+
+describe("comment section folding", () => {
+  it.each([
+    "paradox",
+    "paradox-ck3",
+    "paradox-vic3",
+    "paradox-eu5",
+    "paradox-gui",
+    "paradox-mod",
+    "paradox-info",
+  ])("folds short and long headings in %s, including multiple code blocks", (language) => {
+    const ranges = fold(
+      [
+        "### Gumagan",
+        "# travelers, 1 move",
+        "first = {",
+        " x = 1",
+        "}",
+        "second = { y = 2 }",
+        "",
+        "######## Makara",
+        "# diplomats, 1 move",
+        "third = { z = 3 }",
+      ].join("\n"),
+      language
+    );
+    expect(ranges).toContainEqual(region(0, 6));
+    expect(ranges).toContainEqual(region(7, 9));
+    expect(ranges).toContainEqual({ startLine: 2, endLine: 3 });
+    expect(ranges.filter((r) => r.startLine === 0)).toHaveLength(1);
+  });
+
+  it("ends at the next heading regardless of indentation or brace depth", () => {
+    const ranges = fold(
+      [
+        "### Outer",
+        "outer = {",
+        "  ### Inner one",
+        "  x = 1",
+        "  ######## Inner two",
+        "  y = 2",
+        "}",
+        "### Next",
+        "z = 3",
+      ].join("\n")
+    );
+    expect(ranges.filter((r) => r.kind === "region")).toEqual([
+      region(0, 1),
+      region(2, 3),
+      region(4, 6),
+      region(7, 8),
+    ]);
+    expect(ranges).not.toContainEqual({ startLine: 1, endLine: 5 });
+  });
+
+  it("crosses closing braces and sibling blocks until the next heading or EOF", () => {
+    const ranges = fold("a = {\n ### A\n x = 1\n}\nb = {\n ### B\n y = 2\n}");
+    expect(ranges).toEqual([region(1, 4), region(5, 7)]);
+  });
+
+  it("keeps compatible brace folds while giving sections priority over crossing folds", () => {
+    const ranges = fold("outer = {\n ### A\n inner = {\n  x = 1\n }\n}\nafter = 2");
+    expect(ranges).toContainEqual(region(1, 6));
+    expect(ranges).toContainEqual({ startLine: 2, endLine: 3 });
+    expect(ranges).not.toContainEqual({ startLine: 0, endLine: 4 });
+  });
+
+  it("ignores short comments, hash-only separators, inline comments and quoted hashes", () => {
+    const ranges = fold('# One\n## Two\n########\nx = "### String"\ny = 1 ### Inline\nz = 2');
+    expect(ranges.some((r) => r.kind === "region")).toBe(false);
+    expect(ranges).toContainEqual({ startLine: 0, endLine: 2, kind: "comment" });
+  });
+
+  it("handles a BOM, tabs, CRLF and a heading without a space", () => {
+    expect(
+      fold("\uFEFF\t###First\r\nx = 1\r\n\t######## Second\r\ny = 2").filter((r) => r.kind === "region")
+    ).toEqual([region(0, 1), region(2, 3)]);
+  });
+
+  it("does not let comment-only folds compete with or cross section headings", () => {
+    const ranges = fold("# Intro\n# Notes\n### A\n# Help\n# More help\nx = 1\n### B\ny = 2");
+    expect(ranges.filter((r) => r.kind === "comment")).toEqual([
+      { startLine: 0, endLine: 1, kind: "comment" },
+      { startLine: 3, endLine: 4, kind: "comment" },
+    ]);
+    expect(ranges).toContainEqual(region(2, 5));
+  });
+
+  it("omits empty sections and folds an unclosed block through EOF", () => {
+    expect(fold("### Empty\n######## Next\nx = 1").filter((r) => r.kind === "region")).toEqual([
+      region(1, 2),
+    ]);
+    expect(fold("a = {\n ### Open\n x = 1")).toContainEqual(region(1, 2));
+    expect(fold("### EOF")).toEqual([]);
+  });
+
+  it("folds localization sections while preserving the language-body fold", () => {
+    const ranges = fold(
+      '\uFEFFl_english:\n ### Names\n name:0 "Name"\n ######## Descriptions\n desc:0 "Description"',
+      "paradox-loc"
+    );
+    expect(ranges).toContainEqual({ startLine: 0, endLine: 4 });
+    expect(ranges.filter((r) => r.kind === "region")).toEqual([region(1, 2), region(3, 4)]);
+  });
+
+  it("extends localization sections through trailing comments to EOF", () => {
+    const ranges = fold('l_english:\n ### Names\n name:0 "Name"\n# Trailer\n# Notes', "paradox-loc");
+    expect(ranges).not.toContainEqual({ startLine: 0, endLine: 2 });
+    expect(ranges).toContainEqual(region(1, 4));
+  });
+});

--- a/packages/server/test/lspSmoke.test.ts
+++ b/packages/server/test/lspSmoke.test.ts
@@ -23,6 +23,7 @@ import {
 } from "vscode-jsonrpc/node";
 import {
   dependenciesRequest,
+  configChangedNotification,
   dynastyTreeRequest,
   type DynastyTreeParams,
   type DynastyTreeResult,
@@ -181,6 +182,16 @@ const GUI_TXT = `widget = {
 }
 `;
 
+const ASSET_TXT = `pdxmesh = {
+  name = "smoke_asset_mesh_a"
+  file = "smoke.mesh"
+}
+entity = {
+  name = "smoke_asset_entity"
+  pdxmesh = "smoke_asset_mesh_a"
+}
+`;
+
 // The one door .gui has into script, plus the loc keys a panel names: the
 // subject of paradox/guiDependencies and of `dependencies` with `guiUses`.
 const SGUI_TXT = `smoke_open_gui = {
@@ -283,6 +294,7 @@ describe.skipIf(!hasServer)("LSP smoke over node IPC (the client's transport)", 
   let child: ChildProcess;
   let conn: MessageConnection;
   let modDir: string;
+  let assetFile: string;
   let parentDir: string;
   let depDir: string;
   let eventsFile: string;
@@ -305,6 +317,8 @@ describe.skipIf(!hasServer)("LSP smoke over node IPC (the client's transport)", 
       return full;
     };
     const fx = (rel: string, content: string) => fxIn(modDir, rel, content);
+    assetFile = fx("gfx/models/smoke.asset", ASSET_TXT);
+    fx("gfx/models/smoke.mesh", "binary placeholder, never parsed");
     fxIn(parentDir, "common/scripted_effects/parent_effects.txt", PARENT_EFFECTS_TXT);
     fxIn(parentDir, "events/parent_events.txt", PARENT_EVENTS_TXT);
     fxIn(depDir, "data_binding/px_smoke_macros.txt", DEP_MACRO_TXT);
@@ -405,6 +419,132 @@ describe.skipIf(!hasServer)("LSP smoke over node IPC (the client's transport)", 
     expect(latest.tokens).toBeGreaterThan(500); // bundled wiki tokens loaded
     expect(latest.definitions).toBeGreaterThanOrEqual(5); // 2 effects + event + 2 loc keys
   });
+
+  it("indexes assets, navigates names and files, and handles standard watcher create/edit/delete", async () => {
+    const uri = toUri(assetFile);
+    await conn.sendNotification("textDocument/didOpen", {
+      textDocument: { uri, languageId: "paradox", version: 1, text: ASSET_TXT },
+    });
+    const request = (method: string, line: number, character: number) =>
+      conn.sendRequest(method, {
+        textDocument: { uri },
+        position: { line, character },
+        context: { includeDeclaration: false },
+      });
+    const defs = (await request("textDocument/definition", 6, 17)) as Array<{
+      uri: string;
+      range: { start: { line: number } };
+    }>;
+    expect(defs[0].range.start.line).toBe(1);
+    const mesh = (await request("textDocument/definition", 2, 13)) as Array<{ uri: string }>;
+    expect(mesh[0].uri).toContain("smoke.mesh");
+    const completion = (await request("textDocument/completion", 6, 8)) as {
+      items: Array<{ label: string }>;
+    };
+    expect(completion.items.map((i) => i.label)).toContain("pdxmesh");
+    const values = (await request("textDocument/completion", 6, 16)) as { items: Array<{ label: string }> };
+    expect(values.items.map((i) => i.label)).toContain("smoke_asset_mesh_a");
+    const hover = await request("textDocument/hover", 6, 5);
+    expect(JSON.stringify(hover)).toContain("References a pdxmesh declaration");
+    const refs = (await request("textDocument/references", 1, 14)) as unknown[];
+    expect(refs).toHaveLength(1);
+    const symbols = (await conn.sendRequest("textDocument/documentSymbol", {
+      textDocument: { uri },
+    })) as Array<{ name: string }>;
+    expect(symbols.map((s) => s.name)).toEqual(["smoke_asset_mesh_a", "smoke_asset_entity"]);
+
+    const extra = path.join(modDir, "gfx/models/extra.asset");
+    const extraUri = toUri(extra);
+    const notify = (type: number) =>
+      conn.sendNotification("workspace/didChangeWatchedFiles", { changes: [{ uri: extraUri, type }] });
+    const search = (query: string) => conn.sendRequest("workspace/symbol", { query }) as Promise<unknown[]>;
+    fs.writeFileSync(extra, 'entity = { name = "smoke_new_asset" pdxmesh = "smoke_asset_mesh_a" }');
+    await notify(1);
+    expect(await search("smoke_new_asset")).toHaveLength(1);
+    expect(await request("textDocument/references", 1, 14)).toHaveLength(2);
+    fs.writeFileSync(extra, 'entity = { name = "smoke_changed_asset" pdxmesh = "different_mesh" }');
+    await notify(2);
+    expect(await search("smoke_new_asset")).toHaveLength(0);
+    expect(await search("smoke_changed_asset")).toHaveLength(1);
+    expect(await request("textDocument/references", 1, 14)).toHaveLength(1);
+    fs.unlinkSync(extra);
+    await notify(3);
+    expect(await search("smoke_changed_asset")).toHaveLength(0);
+  });
+
+  it("toggles asset indexing live across roots, watcher updates and vanilla caches", async () => {
+    const game = path.join(depDir, "fake-game");
+    const files = [
+      path.join(parentDir, "gfx/models/workspace.asset"),
+      path.join(depDir, "gfx/models/dependency.asset"),
+      path.join(game, "gfx/models/vanilla.asset"),
+    ];
+    for (const [i, file] of files.entries()) {
+      fs.mkdirSync(path.dirname(file), { recursive: true });
+      fs.writeFileSync(file, `entity = { name = "toggle_asset_${i}" pdxmesh = "smoke_asset_mesh_a" }`);
+    }
+    const configure = async (indexAssets?: boolean, gamePath: string | null = game) => {
+      const start = statuses.length;
+      await conn.sendNotification(configChangedNotification, {
+        gamePath,
+        logsPath: null,
+        modPath: modDir,
+        parentPaths: [parentDir, depDir],
+        workspaceMods: [parentDir],
+        locLanguage: "english",
+        scopeInlayHints: false,
+        diagnosticsIgnore: [],
+        diagnosticsIgnorePatterns: [],
+        diagnosticsVanilla: false,
+        ...(indexAssets === undefined ? {} : { indexAssets }),
+      });
+      await expect
+        .poll(
+          () => {
+            const updates = statuses.slice(start);
+            const began = updates.findIndex((s) => s.indexing);
+            return began >= 0 && updates.slice(began + 1).some((s) => !s.indexing);
+          },
+          { timeout: 20_000 }
+        )
+        .toBe(true);
+    };
+    const symbols = (query: string) => conn.sendRequest("workspace/symbol", { query });
+    const references = () =>
+      conn.sendRequest("textDocument/references", {
+        textDocument: { uri: toUri(assetFile) },
+        position: { line: 1, character: 14 },
+        context: { includeDeclaration: false },
+      });
+    try {
+      // Enabled builds the vanilla cache and populates lazy reference results.
+      await configure(true);
+      expect(await symbols("toggle_asset_")).toHaveLength(3);
+      expect(await references()).toHaveLength(4);
+      await configure(false);
+      expect(await symbols("toggle_asset_")).toHaveLength(0);
+      expect(await symbols("smoke_asset_mesh_a")).toHaveLength(0);
+      expect(await references()).toHaveLength(0);
+      fs.writeFileSync(files[0], 'entity = { name = "toggle_asset_edited" pdxmesh = "smoke_asset_mesh_a" }');
+      await conn.sendNotification("workspace/didChangeWatchedFiles", {
+        changes: [{ uri: toUri(files[0]), type: 2 }],
+      });
+      expect(await symbols("toggle_asset_edited")).toHaveLength(0);
+      // Omitting the setting restores its default and reuses the enabled cache.
+      await configure();
+      expect(await symbols("toggle_asset_")).toHaveLength(3);
+      expect(await symbols("toggle_asset_edited")).toHaveLength(1);
+      expect(await references()).toHaveLength(4);
+      // Now reuse the disabled cache too; enabled definitions must not leak.
+      await configure(false);
+      expect(await symbols("toggle_asset_")).toHaveLength(0);
+      expect(await references()).toHaveLength(0);
+      expect(await symbols("my_smoke_effect")).toHaveLength(1);
+    } finally {
+      for (const file of files) fs.unlinkSync(file);
+      await configure(undefined, null);
+    }
+  }, 60_000);
 
   it("completion inside immediate: CompletionList with the mod effect and engine effects", async () => {
     // Position: inside the immediate block (line 5 = "\t\tmy_smoke_effect = yes"; use start of line 6 area).

--- a/packages/server/test/perf/history.json
+++ b/packages/server/test/perf/history.json
@@ -1,5 +1,5 @@
 {
-  "note": "One row per profileWorkspace.ts run (pnpm run perf:history) over cultivation.code-workspace: the CK3 install plus five workspace mods, Agent Courier excluded by px.excludedMods. Warm file cache, two runs per version, UV_THREADPOOL_SIZE=16, heap ceiling 4096 MB. Add a row for every release; docs/PERFORMANCE.md carries the medians.",
+  "note": "Release rows use cultivation.code-workspace: the CK3 install plus five workspace mods, Agent Courier excluded by px.excludedMods. Warm file cache, two runs per version, UV_THREADPOOL_SIZE=16, heap ceiling 4096 MB. The asset-* comparison rows use assets.code-workspace: CK3 plus Cultivation only, before and after graphics asset indexing. The first asset-before run includes uncontrolled disk-cache warmup; compare asset-before3/4 with asset-after1/2. Add a row for every release; docs/PERFORMANCE.md carries the release medians.",
   "runs": [
     {
       "version": "0.3.0",
@@ -391,6 +391,373 @@
         "internedIdentifiers": 551751,
         "peakRssMb": 816,
         "rssSamples": 16
+      }
+    },
+    {
+      "version": "asset-before",
+      "recordedAt": "2026-09-08",
+      "workspace": "assets.code-workspace",
+      "roots": 2,
+      "build": "working tree dist/server.js",
+      "machine": {
+        "cpu": "AMD Ryzen 7 5800X 8-Core Processor             ",
+        "totalMemGb": 32,
+        "node": "v24.12.0"
+      },
+      "results": {
+        "timeToIndexedMs": 25564,
+        "definitions": 467986,
+        "completionCold": 201,
+        "completionWarm": 9,
+        "semanticTokens": 2,
+        "hover": 4,
+        "documentSymbol": 1,
+        "completionAfterSave": 149,
+        "tokensAfterSave": 1,
+        "heapMb": 252,
+        "rssAtBuildMb": 717,
+        "internedIdentifiers": 536777,
+        "peakRssMb": 817,
+        "rssSamples": 49
+      }
+    },
+    {
+      "version": "asset-before",
+      "recordedAt": "2026-09-08",
+      "workspace": "assets.code-workspace",
+      "roots": 2,
+      "build": "working tree dist/server.js",
+      "machine": {
+        "cpu": "AMD Ryzen 7 5800X 8-Core Processor             ",
+        "totalMemGb": 32,
+        "node": "v24.12.0"
+      },
+      "results": {
+        "timeToIndexedMs": 7733,
+        "definitions": 467986,
+        "completionCold": 187,
+        "completionWarm": 8,
+        "semanticTokens": 2,
+        "hover": 4,
+        "documentSymbol": 1,
+        "completionAfterSave": 180,
+        "tokensAfterSave": 1,
+        "heapMb": 252,
+        "rssAtBuildMb": 648,
+        "internedIdentifiers": 536777,
+        "peakRssMb": 704,
+        "rssSamples": 16
+      }
+    },
+    {
+      "version": "asset-before3",
+      "recordedAt": "2026-09-08",
+      "workspace": "assets.code-workspace",
+      "roots": 2,
+      "build": "working tree dist/server.js",
+      "machine": {
+        "cpu": "AMD Ryzen 7 5800X 8-Core Processor             ",
+        "totalMemGb": 32,
+        "node": "v24.12.0"
+      },
+      "results": {
+        "timeToIndexedMs": 9928,
+        "definitions": 467986,
+        "completionCold": 128,
+        "completionWarm": 6,
+        "semanticTokens": 1,
+        "hover": 3,
+        "documentSymbol": 1,
+        "completionAfterSave": 178,
+        "tokensAfterSave": 1,
+        "heapMb": 252,
+        "rssAtBuildMb": 718,
+        "internedIdentifiers": 536777,
+        "peakRssMb": 810,
+        "rssSamples": 20
+      }
+    },
+    {
+      "version": "asset-after1",
+      "recordedAt": "2026-09-08",
+      "workspace": "assets.code-workspace",
+      "roots": 2,
+      "build": "working tree dist/server.js",
+      "machine": {
+        "cpu": "AMD Ryzen 7 5800X 8-Core Processor             ",
+        "totalMemGb": 32,
+        "node": "v24.12.0"
+      },
+      "results": {
+        "timeToIndexedMs": 7811,
+        "definitions": 474700,
+        "completionCold": 166,
+        "completionWarm": 7,
+        "semanticTokens": 1,
+        "hover": 3,
+        "documentSymbol": 1,
+        "completionAfterSave": 144,
+        "tokensAfterSave": 1,
+        "heapMb": 255,
+        "rssAtBuildMb": 719,
+        "internedIdentifiers": 543495,
+        "peakRssMb": 809,
+        "rssSamples": 17
+      }
+    },
+    {
+      "version": "asset-before4",
+      "recordedAt": "2026-09-08",
+      "workspace": "assets.code-workspace",
+      "roots": 2,
+      "build": "working tree dist/server.js",
+      "machine": {
+        "cpu": "AMD Ryzen 7 5800X 8-Core Processor             ",
+        "totalMemGb": 32,
+        "node": "v24.12.0"
+      },
+      "results": {
+        "timeToIndexedMs": 7797,
+        "definitions": 467986,
+        "completionCold": 224,
+        "completionWarm": 12,
+        "semanticTokens": 2,
+        "hover": 5,
+        "documentSymbol": 1,
+        "completionAfterSave": 231,
+        "tokensAfterSave": 1,
+        "heapMb": 252,
+        "rssAtBuildMb": 646,
+        "internedIdentifiers": 536777,
+        "peakRssMb": 715,
+        "rssSamples": 16
+      }
+    },
+    {
+      "version": "asset-after2",
+      "recordedAt": "2026-09-08",
+      "workspace": "assets.code-workspace",
+      "roots": 2,
+      "build": "working tree dist/server.js",
+      "machine": {
+        "cpu": "AMD Ryzen 7 5800X 8-Core Processor             ",
+        "totalMemGb": 32,
+        "node": "v24.12.0"
+      },
+      "results": {
+        "timeToIndexedMs": 11707,
+        "definitions": 474700,
+        "completionCold": 260,
+        "completionWarm": 10,
+        "semanticTokens": 2,
+        "hover": 3,
+        "documentSymbol": 1,
+        "completionAfterSave": 282,
+        "tokensAfterSave": 1,
+        "heapMb": 255,
+        "rssAtBuildMb": 705,
+        "internedIdentifiers": 543495,
+        "peakRssMb": 800,
+        "rssSamples": 20
+      }
+    },
+    {
+      "version": "asset-toggle-before",
+      "recordedAt": "2026-09-08",
+      "workspace": "assets.code-workspace",
+      "roots": 2,
+      "build": "working tree dist/server.js",
+      "machine": {
+        "cpu": "AMD Ryzen 7 5800X 8-Core Processor             ",
+        "totalMemGb": 32,
+        "node": "v24.12.0"
+      },
+      "results": {
+        "timeToIndexedMs": 11092,
+        "definitions": 474700,
+        "completionCold": 239,
+        "completionWarm": 8,
+        "semanticTokens": 1,
+        "hover": 4,
+        "documentSymbol": 1,
+        "completionAfterSave": 196,
+        "tokensAfterSave": 1,
+        "heapMb": 255,
+        "rssAtBuildMb": 706,
+        "internedIdentifiers": 543495,
+        "peakRssMb": 804,
+        "rssSamples": 22
+      }
+    },
+    {
+      "version": "asset-toggle-off",
+      "note": "Indexing disabled. Tests and lint ran concurrently; use the isolated runs for comparison.",
+      "recordedAt": "2026-09-08",
+      "workspace": "assets-off.code-workspace",
+      "roots": 2,
+      "build": "working tree dist/server.js",
+      "machine": {
+        "cpu": "AMD Ryzen 7 5800X 8-Core Processor             ",
+        "totalMemGb": 32,
+        "node": "v24.12.0"
+      },
+      "results": {
+        "timeToIndexedMs": 10169,
+        "definitions": 467986,
+        "completionCold": 248,
+        "completionWarm": 11,
+        "semanticTokens": 2,
+        "hover": 4,
+        "documentSymbol": 1,
+        "completionAfterSave": 166,
+        "tokensAfterSave": 1,
+        "heapMb": 252,
+        "rssAtBuildMb": 712,
+        "internedIdentifiers": 536777,
+        "peakRssMb": 805,
+        "rssSamples": 19
+      }
+    },
+    {
+      "version": "asset-toggle-off-isolated",
+      "note": "Same CK3 plus Cultivation roots as assets.code-workspace, with px.indexAssets=false. Single run; startup timings vary with disk activity.",
+      "recordedAt": "2026-09-08",
+      "workspace": "assets-off.code-workspace",
+      "roots": 2,
+      "build": "working tree dist/server.js",
+      "machine": {
+        "cpu": "AMD Ryzen 7 5800X 8-Core Processor             ",
+        "totalMemGb": 32,
+        "node": "v24.12.0"
+      },
+      "results": {
+        "timeToIndexedMs": 10552,
+        "definitions": 467986,
+        "completionCold": 226,
+        "completionWarm": 8,
+        "semanticTokens": 1,
+        "hover": 3,
+        "documentSymbol": 1,
+        "completionAfterSave": 185,
+        "tokensAfterSave": 1,
+        "heapMb": 252,
+        "rssAtBuildMb": 647,
+        "internedIdentifiers": 536777,
+        "peakRssMb": 716,
+        "rssSamples": 20
+      }
+    },
+    {
+      "version": "asset-toggle-on-isolated",
+      "note": "Same build and roots as asset-toggle-off-isolated, with asset indexing enabled by default. Single run; warm completion 8 ms in both modes, retained heap 255 MB enabled versus 252 MB disabled.",
+      "recordedAt": "2026-09-08",
+      "workspace": "assets.code-workspace",
+      "roots": 2,
+      "build": "working tree dist/server.js",
+      "machine": {
+        "cpu": "AMD Ryzen 7 5800X 8-Core Processor             ",
+        "totalMemGb": 32,
+        "node": "v24.12.0"
+      },
+      "results": {
+        "timeToIndexedMs": 8781,
+        "definitions": 474700,
+        "completionCold": 204,
+        "completionWarm": 8,
+        "semanticTokens": 2,
+        "hover": 4,
+        "documentSymbol": 1,
+        "completionAfterSave": 165,
+        "tokensAfterSave": 1,
+        "heapMb": 255,
+        "rssAtBuildMb": 716,
+        "internedIdentifiers": 543495,
+        "peakRssMb": 809,
+        "rssSamples": 18
+      }
+    },
+    {
+      "version": "asset-language-before",
+      "recordedAt": "2026-09-08",
+      "workspace": "assets.code-workspace",
+      "roots": 2,
+      "build": "working tree dist/server.js",
+      "machine": {
+        "cpu": "AMD Ryzen 7 5800X 8-Core Processor             ",
+        "totalMemGb": 32,
+        "node": "v24.12.0"
+      },
+      "results": {
+        "timeToIndexedMs": 8366,
+        "definitions": 474700,
+        "completionCold": 155,
+        "completionWarm": 5,
+        "semanticTokens": 1,
+        "hover": 3,
+        "documentSymbol": 1,
+        "completionAfterSave": 113,
+        "tokensAfterSave": 1,
+        "heapMb": 255,
+        "rssAtBuildMb": 721,
+        "internedIdentifiers": 543495,
+        "peakRssMb": 833,
+        "rssSamples": 21
+      }
+    },
+    {
+      "version": "asset-language-after",
+      "recordedAt": "2026-09-08",
+      "workspace": "assets.code-workspace",
+      "roots": 2,
+      "build": "working tree dist/server.js",
+      "machine": {
+        "cpu": "AMD Ryzen 7 5800X 8-Core Processor             ",
+        "totalMemGb": 32,
+        "node": "v24.12.0"
+      },
+      "results": {
+        "timeToIndexedMs": 7073,
+        "definitions": 476065,
+        "completionCold": 153,
+        "completionWarm": 7,
+        "semanticTokens": 2,
+        "hover": 3,
+        "documentSymbol": 1,
+        "completionAfterSave": 120,
+        "tokensAfterSave": 1,
+        "heapMb": 255,
+        "rssAtBuildMb": 713,
+        "internedIdentifiers": 544587,
+        "peakRssMb": 798,
+        "rssSamples": 16
+      }
+    },
+    {
+      "version": "0.4.2",
+      "recordedAt": "2026-09-08",
+      "workspace": "release-0.4.2.code-workspace",
+      "roots": 2,
+      "build": "working tree dist/server.js",
+      "machine": {
+        "cpu": "AMD Ryzen 7 5800X 8-Core Processor             ",
+        "totalMemGb": 32,
+        "node": "v24.12.0"
+      },
+      "results": {
+        "timeToIndexedMs": 7290,
+        "definitions": 481227,
+        "completionCold": 137,
+        "completionWarm": 5,
+        "semanticTokens": 1,
+        "hover": 3,
+        "documentSymbol": 1,
+        "completionAfterSave": 128,
+        "tokensAfterSave": 0,
+        "heapMb": 259,
+        "rssAtBuildMb": 726,
+        "internedIdentifiers": 551461,
+        "peakRssMb": 787,
+        "rssSamples": 17
       }
     }
   ]

--- a/packages/server/test/perf/profileWorkspace.ts
+++ b/packages/server/test/perf/profileWorkspace.ts
@@ -136,6 +136,7 @@ const settings = {
   workspaceMods: [...modRoots],
   locLanguage: "english",
   scopeInlayHints: false,
+  indexAssets: ws.settings?.["px.indexAssets"] !== false,
   diagnosticsIgnore: [],
   diagnosticsIgnorePatterns: [],
   diagnosticsVanilla: false,

--- a/packages/vscode/CHANGELOG.md
+++ b/packages/vscode/CHANGELOG.md
@@ -2,7 +2,21 @@
 
 ## Unreleased
 
+## 0.4.2 (beta) - graphics assets, DNA copying and section folding
+
+- Fix `.asset` navigation and completion for mesh-local names, states, shader effects and CK3 accessory variations. Suggest graphics keywords from vanilla files and resolve engine shader paths.
+
+- Add separate Dynasty Tree DNA copy actions for mod blocks and CK3's Ruler Designer or portrait editor, with persistent-DNA paste support. Fix dependency, nested-folder and unsaved-file lookup, respect overrides, keep the clipboard unchanged when DNA is missing, and paste into the selected mod.
+
+- Add the `px.indexAssets` setting to turn graphics `.asset` indexing on or off. Changes rebuild the index automatically; highlighting, folding and on-demand texture previews remain available.
+
+- Collapse script, GUI, asset and localization sections headed by `### Title` or longer hash headings. Sections end before the next heading or at the end of the file, regardless of closing braces or indentation.
+
+- Recognize graphics `.asset` files, index their named blocks and update them on save. Add navigation to referenced files, local filename completion and DDS previews with mod texture overrides.
+
 - Confirmation prompts keep Cancel safe when Enter is pressed, shared menus expose keyboard focus to screen readers, and the GUI save/undo controls have a separate module. Require VS Code 1.91, check the minimum editor and Windows launcher, fix the CK3 decision scaffold's picture block, and refresh onboarding and the feature guide.
+
+- Update the GitHub banner and social preview to show the toolkit's editing and publishing workflows.
 
 ## 0.4.1 (beta) - file constants and modding guides
 

--- a/packages/vscode/README.md
+++ b/packages/vscode/README.md
@@ -23,6 +23,8 @@ This is a beta. Check generated content in the game before publishing it. After 
 
 - **Completion and navigation:** scope-aware ranking, definitions, references, rename, symbols and block skeletons. Items outside the inferred scope are annotated rather than hidden.
 - **Documentation from the game:** hover descriptions, scope information, localized text and texture previews, plus searchable vanilla examples.
+- **Graphics assets:** CK3 and Victoria 3 `.asset` indexing, context-specific completion, reference navigation and DDS previews. Use `px.indexAssets` to toggle scanning.
+- **Section folding:** `### Title` or longer hash headings fold through the next heading or the end of the file, across closing braces.
 - **Validation:** instant structural checks for malformed files, encodings and folder mistakes. CK3 and Victoria 3 also integrate tiger for deeper validation.
 - **Localization:** coverage, inlay hints, quick fixes and workflows for adding languages or making a translation mod.
 
@@ -35,6 +37,8 @@ The **Event Simulator** walks an event and its options beside the source. The **
 The **GUI Editor** lets you select, move and resize widgets, inspect inherited properties and save source-preserving edits. Its preview models supported layout rules; runtime bindings still need an in-game check. CK3 also has forms for traits, cultures, traditions, legacies, dynasties and coats of arms. Victoria 3 and EU5 have the Flag Builder.
 
 ![CK3 Trait Creator with editable values, a game-style preview and generated script](media/screenshots/trait-creator.png)
+
+The **Dynasty Tree** supports copying DNA for mod files or the game, including lookup in dependency mods and pasting portrait-editor DNA.
 
 The Project panel also opens DDS conversion, game launch options, custom calendars, multi-mod indexing and the **Steam Workshop Panel**. Workshop uploads use your running Steam client and show the parts being uploaded before confirmation.
 

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "px-toolkit",
   "displayName": "Paradox Modding Toolkit",
   "description": "Modding toolkit for Paradox games (Crusader Kings III, Victoria 3, Europa Universalis V): completion, go-to-definition, hover docs, tiger diagnostics, inline localization, event graph and a visual GUI editor.",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "publisher": "JDeffner",
   "author": {
     "name": "Joël Deffner"
@@ -980,6 +980,12 @@
             "default": false,
             "order": 1,
             "markdownDescription": "Show the inferred scope (e.g. `character`) after scope-changing block openers like `every_vassal = {`. Best-effort inference; display only."
+          },
+          "px.indexAssets": {
+            "type": "boolean",
+            "default": true,
+            "scope": "window",
+            "markdownDescription": "Index definitions and references in graphics `.asset` files for supported games, across mods, dependencies and vanilla. Disable to reduce indexing time and memory. Changing this rebuilds the index automatically. Syntax highlighting, folding and on-demand texture previews remain available."
           },
           "px.calendar": {
             "type": "object",

--- a/packages/vscode/src/config.ts
+++ b/packages/vscode/src/config.ts
@@ -36,6 +36,7 @@ export interface PxConfig {
   /** `px.excludedMods`: workspace mod roots skipped entirely (sanitized). */
   excludedMods: string[];
   locLanguage: string;
+  indexAssets: boolean;
   scopeInlayHints: boolean;
   hoverDetail: "compact" | "standard" | "full";
   /** `px.calendar`: custom era calendar for date display, or undefined. */
@@ -310,6 +311,7 @@ export function readConfig(): PxConfig {
     excludedMods,
     locLanguage: (cfg.get<string>("locLanguage") ?? "english").trim().toLowerCase() || "english",
     scopeInlayHints: cfg.get<boolean>("scopeInlayHints") ?? false,
+    indexAssets: cfg.get<boolean>("indexAssets") ?? true,
     hoverDetail: cfg.get<"compact" | "standard" | "full">("hover.detail") ?? "standard",
     calendar: sanitizeCalendar(cfg.get("calendar")),
     tigerRunOn,

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -190,6 +190,7 @@ function toSettings(c: PxConfig): ParadoxSettings {
     parentPaths: c.parentPaths,
     workspaceMods: c.workspaceMods,
     locLanguage: c.locLanguage,
+    indexAssets: c.indexAssets,
     scopeInlayHints: c.scopeInlayHints,
     calendar: c.calendar,
     diagnosticsIgnore: c.diagnosticsIgnore,
@@ -619,7 +620,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       // .mod included so origin labels (descriptor name= in hovers) stay fresh.
       // calendar.json: the mod's display calendar (.px-toolkit/calendar.json),
       // which the server caches per mod until the file changes.
-      for (const glob of ["**/*.{txt,yml,gui,mod}", "**/calendar.json"]) {
+      for (const glob of ["**/*.{txt,yml,gui,mod}", "**/gfx/**/*.asset", "**/calendar.json"]) {
         const w = vscode.workspace.createFileSystemWatcher(
           new vscode.RelativePattern(vscode.Uri.file(root), glob)
         );

--- a/packages/vscode/src/languageMode.ts
+++ b/packages/vscode/src/languageMode.ts
@@ -28,6 +28,7 @@ export async function ensureFileAssociations(cfg: PxConfig): Promise<void> {
   const script = scriptLangFor(cfg.gameId);
   const wanted: Record<string, string> = {
     "*.txt": script,
+    "**/gfx/**/*.asset": script,
     "*.gui": "paradox-gui",
     "*.mod": "paradox-mod",
     "**/localization/**/*.yml": "paradox-loc",
@@ -72,7 +73,7 @@ export function wireLanguageDetection(
       // persisted association from an older version (or from a workspace for a
       // different game) leaves behind on the open editors.
       if (
-        lower.endsWith(".txt") &&
+        (lower.endsWith(".txt") || (lower.endsWith(".asset") && /[\\/]gfx[\\/]/.test(lower))) &&
         (doc.languageId === "plaintext" || (isScriptLang(doc.languageId) && doc.languageId !== script))
       ) {
         await vscode.languages.setTextDocumentLanguage(doc, script);

--- a/packages/vscode/src/webviews/dynastyTree/app/main.ts
+++ b/packages/vscode/src/webviews/dynastyTree/app/main.ts
@@ -1143,17 +1143,20 @@ function renderCharacter(root: HTMLElement, char: DynastyCharacter): void {
   // DNA is the one fact with a way out of the panel: the name points at a
   // block in common/dna_data, which the buttons open or copy whole. A line
   // that only printed the name left the modder asking where the DNA was.
-  const dnaRow = node("div", "px-row");
+  const dnaRow = node("div", "px-row dna-row");
   if (char.dna) {
     const key = char.dna;
     dnaRow.append(node("code", "px-mono px-sm", key));
     const open = button("Open", "folderOpen", "ghost");
     open.dataset.tip = "Open this DNA's block in common/dna_data";
     open.addEventListener("click", () => post({ type: "dnaOpen", key }));
-    const copy = button("Copy", "copy", "ghost");
+    const copy = button("Copy block", "copy", "ghost");
     copy.dataset.tip = "Copy the whole DNA block, to paste into another character";
     copy.addEventListener("click", () => post({ type: "dnaCopy", key }));
-    dnaRow.append(open, copy);
+    const gameCopy = button("Copy for game", "copy", "ghost");
+    gameCopy.dataset.tip = "Copy DNA for CK3's Ruler Designer or portrait editor";
+    gameCopy.addEventListener("click", () => post({ type: "dnaCopyGame", key, female: char.female }));
+    dnaRow.append(open, copy, gameCopy);
   } else {
     dnaRow.append(node("span", "px-sm px-muted", "none; Edit pastes one from the portrait editor"));
   }
@@ -1435,7 +1438,7 @@ function renderForm(root: HTMLElement, form: CharacterForm): void {
   // it points at is opened, copied whole, or written into the mod from the
   // clipboard, because "dna = eadgar_dna" without that block is a portrait
   // nobody else can see.
-  const dnaRow = node("div", "px-row");
+  const dnaRow = node("div", "px-row dna-row");
   const dna = textInput(form.dna ?? "", (v) => (form.dna = v.trim() || undefined));
   dna.placeholder = "from the portrait editor";
   const dnaButton = (label: string, glyph: IconName, tip: string, run: () => void): HTMLButtonElement => {
@@ -1451,6 +1454,11 @@ function renderForm(root: HTMLElement, form: CharacterForm): void {
     if (key) run(key);
     else toast("This character has no DNA name yet.");
   };
+  const copyForGame = button("Copy for game", "copy", "ghost");
+  copyForGame.addEventListener(
+    "click",
+    named((key) => post({ type: "dnaCopyGame", key, female: form.female }))
+  );
   dnaRow.append(
     dna,
     dnaButton(
@@ -1465,6 +1473,7 @@ function renderForm(root: HTMLElement, form: CharacterForm): void {
       "Copy this DNA's whole block",
       named((key) => post({ type: "dnaCopy", key }))
     ),
+    copyForGame,
     dnaButton("Paste DNA", "paste", "Take a DNA off the clipboard", () =>
       post({ type: "dnaPaste", character: form.id })
     )

--- a/packages/vscode/src/webviews/dynastyTree/dna.ts
+++ b/packages/vscode/src/webviews/dynastyTree/dna.ts
@@ -1,0 +1,65 @@
+import * as path from "path";
+import { listFiles } from "@px-lsp/protocol/fsWalk";
+import { parseScript } from "@px-lsp/server/parser";
+
+/** common/dna_data/_dna_data.info defines the portrait_info and DNA-string
+ * alternatives. Game-generated common/bookmark_portraits and saved .ck3ruler
+ * portrait_info blocks use the same direct genes/type shape for persistent DNA. */
+export function gameDnaCopy(
+  text: string,
+  female: boolean
+): { text: string; format: "persistent" | "string" } | null {
+  const parsed = parseScript(text);
+  if (parsed.errors.length) return null;
+  const outer = parsed.root.statements[0];
+  if (outer?.kind !== "assignment" || outer.value?.kind !== "block") return null;
+  const fields = outer.value.statements;
+  const portrait = fields.find((s) => s.kind === "assignment" && s.key.text === "portrait_info");
+  if (portrait?.kind === "assignment" && portrait.value?.kind === "block") {
+    const block = portrait.value;
+    if (
+      !block.statements.some(
+        (s) => s.kind === "assignment" && s.key.text === "genes" && s.value?.kind === "block"
+      )
+    )
+      return null;
+    const type = block.statements.find((s) => s.kind === "assignment" && s.key.text === "type");
+    let body = text.slice(block.range.start, block.range.end);
+    const sex = female ? "female" : "male";
+    if (type?.kind === "assignment" && type.value?.kind === "scalar") {
+      const start = type.value.range.start - block.range.start;
+      const end = type.value.range.end - block.range.start;
+      body = body.slice(0, start) + sex + body.slice(end);
+    } else {
+      body = `{\n\ttype=${sex}\n${body.slice(1)}`;
+    }
+    return { text: `${outer.key.text}=${body}`, format: "persistent" };
+  }
+  const dna = fields.find((s) => s.kind === "assignment" && s.key.text === "dna");
+  return dna?.kind === "assignment" && dna.value?.kind === "scalar" && dna.value.text
+    ? { text: dna.value.text, format: "string" }
+    : null;
+}
+
+/** Roots are in load order, base first. Later files and definitions win.
+ * Same-path overrides hide the entire earlier file, even keys they omit. */
+export function dnaFiles(roots: string[], folder: string, openFiles: string[] = []): string[] {
+  const effective = new Map<string, { file: string; order: number }>();
+  for (const [order, root] of roots.filter((r, i) => roots.lastIndexOf(r) === i).entries()) {
+    const dir = path.join(root, folder);
+    const files = new Set(listFiles(dir, ".txt"));
+    for (const file of openFiles) {
+      const rel = path.relative(dir, file);
+      if (rel && !rel.startsWith("..") && !path.isAbsolute(rel) && file.toLowerCase().endsWith(".txt")) {
+        files.add(file);
+      }
+    }
+    for (const file of [...files].sort()) {
+      const relative = path.relative(dir, file).replace(/\\/g, "/");
+      effective.set(process.platform === "win32" ? relative.toLowerCase() : relative, { file, order });
+    }
+  }
+  return [...effective.values()]
+    .sort((a, b) => b.order - a.order || (a.file < b.file ? 1 : a.file > b.file ? -1 : 0))
+    .map(({ file }) => file);
+}

--- a/packages/vscode/src/webviews/dynastyTree/html.ts
+++ b/packages/vscode/src/webviews/dynastyTree/html.ts
@@ -38,6 +38,8 @@ ${uiCss}
   #picker > .px-panel-title:first-child { padding-top: 4px; }
   #picker .px-item { align-items: center; gap: 8px; }
   #picker .dname { flex: 0 0 auto; font-weight: 500; }
+  .dna-row { flex-wrap: wrap; }
+  .dna-row > code, .dna-row > input { flex: 1 0 100%; min-width: 0; overflow-wrap: anywhere; }
   #picker .dkey { flex: 1 1 auto; min-width: 0; color: var(--px-muted-fg); font-family: var(--px-font-mono);
     font-size: var(--px-text-xs); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
   #picker .dcount { flex: 0 0 auto; color: var(--px-muted-fg); font-size: var(--px-text-xs); }

--- a/packages/vscode/src/webviews/dynastyTree/messages.ts
+++ b/packages/vscode/src/webviews/dynastyTree/messages.ts
@@ -174,6 +174,8 @@ export type AppToHost =
   | { type: "dnaOpen"; key: string }
   /** Copy that block's whole text, so it can be pasted into another mod. */
   | { type: "dnaCopy"; key: string }
+  /** Copy persistent DNA for CK3, or the encoded string for its portrait editor. */
+  | { type: "dnaCopyGame"; key: string; female: boolean }
   /**
    * Take a DNA off the clipboard: a whole block or a bare `portrait_info` is
    * written into the mod's own `common/dna_data`, under a key derived from

--- a/packages/vscode/src/webviews/dynastyTree/panel.ts
+++ b/packages/vscode/src/webviews/dynastyTree/panel.ts
@@ -53,6 +53,7 @@ import { characterBlock, dynastyBlock, houseBlock, unquotableValue } from "./blo
 import { dynastyTreeHtml } from "./html";
 import { WriteJournal } from "./journal";
 import { dnaPasteBlock, parseDnaPaste, scanBlocks, uniqueKey, type ScriptBlock } from "./scan";
+import { dnaFiles, gameDnaCopy } from "./dna";
 import type { AppToHost, HostToApp, ModTarget, OptionSets, TraitStats, TraitTip } from "./messages";
 import { plainLoc, type PreviewModifier } from "../traitCreator/app/preview";
 import { GuiTextureCache } from "../guiEditor/textureCache";
@@ -288,6 +289,9 @@ export class DynastyTreePanel {
         return;
       case "dnaCopy":
         await this.copyDna(msg.key);
+        return;
+      case "dnaCopyGame":
+        await this.copyDna(msg.key, msg.female);
         return;
       case "dnaPaste":
         await this.pasteDna(msg.character);
@@ -587,6 +591,10 @@ export class DynastyTreePanel {
    * row can show what a trait does without a request per row.
    */
   private fileBlocks(file: string): Map<string, ScriptBlock> {
+    const open = vscode.workspace.textDocuments.find(
+      (doc) => doc.uri.scheme === "file" && samePath(doc.uri.fsPath, file)
+    );
+    if (open) return scanBlocks(open.getText());
     let mtimeMs: number;
     try {
       mtimeMs = fs.statSync(file).mtimeMs;
@@ -744,10 +752,19 @@ export class DynastyTreePanel {
   }
 
   /** Every DNA file the workspace can see, the mods' own first (they win). */
-  private dnaFiles(): string[] {
-    const roots = this.options.mods.map((m) => m.path);
-    if (this.options.cfg.gamePath) roots.push(this.options.cfg.gamePath);
-    return roots.flatMap((root) => listScripts(this.dnaDir(root)));
+  private dnaFiles(roots?: string[]): string[] {
+    const { cfg } = this.options;
+    return dnaFiles(
+      roots ?? [
+        ...(cfg.gamePath ? [cfg.gamePath] : []),
+        ...cfg.parentPaths,
+        ...cfg.workspaceMods,
+        ...this.options.mods.map((m) => m.path).reverse(),
+        ...(cfg.modPath ? [cfg.modPath] : []),
+      ],
+      this.dnaFolder(),
+      vscode.workspace.textDocuments.filter((doc) => doc.uri.scheme === "file").map((doc) => doc.uri.fsPath)
+    );
   }
 
   private findDna(key: string): { file: string; block: ScriptBlock } | null {
@@ -769,17 +786,35 @@ export class DynastyTreePanel {
 
   /**
    * The whole block, so it can be pasted into another mod or another
-   * character. A name nothing defines still copies as a name: that is what the
-   * field holds, and refusing to copy it would help nobody.
+   * character. An unresolved name is not DNA and must not replace the clipboard.
    */
-  private async copyDna(key: string): Promise<void> {
+  private async copyDna(key: string, gameFemale?: boolean): Promise<void> {
     const found = this.findDna(key);
-    await vscode.env.clipboard.writeText(found ? found.block.text : key);
+    if (!found) {
+      this.post({
+        type: "toast",
+        message: `DNA ${key} was not found in ${this.dnaFolder()}. Check the game and dependency mod paths. Clipboard unchanged.`,
+        variant: "destructive",
+      });
+      return;
+    }
+    const gameCopy = gameFemale === undefined ? null : gameDnaCopy(found.block.text, gameFemale);
+    if (gameFemale !== undefined && !gameCopy) {
+      this.post({
+        type: "toast",
+        message: `DNA ${key} has no complete portrait or DNA string to copy. Clipboard unchanged.`,
+        variant: "destructive",
+      });
+      return;
+    }
+    await vscode.env.clipboard.writeText(gameCopy?.text ?? found.block.text);
     this.post({
       type: "toast",
-      message: found
-        ? `Copied ${key} from ${path.basename(found.file)}.`
-        : `No ${key} in ${this.dnaFolder()}, so only the name was copied.`,
+      message: gameCopy
+        ? gameCopy.format === "persistent"
+          ? "Copied persistent DNA. Use Paste DNA in Ruler Designer or Paste Persistent DNA in the portrait editor."
+          : "Copied DNA string. Use Paste DNA in the portrait editor, then Copy Persistent DNA for Ruler Designer."
+        : `Copied ${key} from ${path.basename(found.file)}.`,
     });
   }
 
@@ -804,14 +839,14 @@ export class DynastyTreePanel {
       this.post({ type: "pasted", field: "dna", text: paste.name });
       return;
     }
-    const modPath = this.options.mods[0]?.path ?? this.options.cfg.modPath;
+    const modPath = this.targetChoice()?.modPath ?? this.options.mods[0]?.path ?? this.options.cfg.modPath;
     if (!modPath) {
       this.post({ type: "toast", message: "No mod to write the DNA into.", variant: "destructive" });
       return;
     }
 
     const dir = this.dnaDir(modPath);
-    const mine = listScripts(dir);
+    const mine = this.dnaFiles([modPath]);
     const taken = new Set<string>();
     for (const file of mine) for (const key of this.fileBlocks(file).keys()) taken.add(key);
     const key = uniqueKey(paste.kind === "block" ? paste.key : `${character}_dna`, taken);
@@ -1165,19 +1200,6 @@ export function readTraitBlock(
     }
   }
   return out;
-}
-
-/** The `.txt` files of one folder, sorted, or none when it is not there. */
-function listScripts(dir: string): string[] {
-  try {
-    return fs
-      .readdirSync(dir)
-      .filter((name) => name.toLowerCase().endsWith(".txt"))
-      .sort()
-      .map((name) => path.join(dir, name));
-  } catch {
-    return [];
-  }
 }
 
 /** A mod folder's name as a file name may spell it. */

--- a/packages/vscode/src/webviews/dynastyTree/scan.ts
+++ b/packages/vscode/src/webviews/dynastyTree/scan.ts
@@ -14,6 +14,8 @@
  * No `vscode` imports: unit-tested in plain Node (test/dynastyScan.test.ts).
  */
 
+import { parseScript } from "@px-lsp/server/parser";
+
 /** One top-level `key = { … }`, with the offsets it occupies in the text. */
 export interface ScriptBlock {
   key: string;
@@ -126,7 +128,15 @@ export function parseDnaPaste(clipboard: string): DnaPaste | null {
   // A whole definition: the one that carries a portrait, else the first, so a
   // block written in a shape this panel has not seen is still pasted verbatim.
   const block = blocks.find((b) => b.text.includes("portrait_info")) ?? blocks[0];
-  return { kind: "block", key: block.key, body: braces(block.text) };
+  const body = braces(block.text);
+  // CK3's persistent clipboard format has genes directly under its root;
+  // common/dna_data requires those portrait fields inside portrait_info.
+  const fields = scanBlocks(body.slice(1, -1));
+  return {
+    kind: "block",
+    key: block.key,
+    body: fields.has("genes") && !fields.has("portrait_info") ? `{\n\tportrait_info = ${body}\n}` : body,
+  };
 }
 
 /** `key = { … }` reduced to its `{ … }`. */
@@ -136,18 +146,38 @@ function braces(block: string): string {
 }
 
 /**
- * The script a paste writes, under the key it was given. A whole block keeps
- * its own body verbatim; a bare `portrait_info` is wrapped in one. `enabled =
+ * The script a paste writes, under the key it was given. Gene text is kept
+ * verbatim; clipboard-only metadata is removed and bare `portrait_info` wrapped.
+ * `enabled =
  * yes` is NOT added: 296 of the 431 vanilla `common/dna_data` blocks write it
  * and 135 do not (measured, CK3 1.19), so it is optional and inventing it
  * would be writing game knowledge nobody asked for.
  */
 export function dnaPasteBlock(key: string, paste: DnaPaste): string | null {
   if (paste.kind === "name") return null;
-  if (paste.kind === "block") return `${key} = ${paste.body}`;
-  const body = paste.body
-    .split(/\r?\n/)
-    .map((line) => (line.trim() === "" ? line : `\t${line}`))
-    .join("\n");
-  return `${key} = {\n${body}\n}`;
+  const body =
+    paste.kind === "block"
+      ? paste.body
+      : `{\n${paste.body
+          .split(/\r?\n/)
+          .map((line) => (line.trim() === "" ? line : `\t${line}`))
+          .join("\n")}\n}`;
+  let text = `${key} = ${body}`;
+  // These clipboard fields are absent from vanilla common/dna_data and are
+  // rejected there by CK3 1.19 tiger. Keep all genes and portrait overrides.
+  const metadata = new Set(["type", "id", "random_seed", "age"]);
+  const outer = parseScript(text).root.statements[0];
+  if (outer?.kind === "assignment" && outer.value?.kind === "block") {
+    const portrait = outer.value.statements.find(
+      (s) => s.kind === "assignment" && s.key.text === "portrait_info"
+    );
+    if (portrait?.kind === "assignment" && portrait.value?.kind === "block") {
+      for (const s of [...portrait.value.statements].reverse()) {
+        if (s.kind === "assignment" && metadata.has(s.key.text)) {
+          text = text.slice(0, s.range.start) + text.slice(s.range.end);
+        }
+      }
+    }
+  }
+  return text;
 }

--- a/packages/vscode/test/dynastyDna.test.ts
+++ b/packages/vscode/test/dynastyDna.test.ts
@@ -1,0 +1,77 @@
+import { afterAll, describe, expect, it } from "vitest";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { dnaFiles, gameDnaCopy } from "../src/webviews/dynastyTree/dna";
+import { scanBlocks, parseDnaPaste, dnaPasteBlock } from "../src/webviews/dynastyTree/scan";
+import { parseScript } from "@px-lsp/server/parser";
+
+const scratch = fs.mkdtempSync(path.join(os.tmpdir(), "px-dynasty-dna-"));
+const folder = "common/dna_data";
+afterAll(() => fs.rmSync(scratch, { recursive: true, force: true }));
+function write(root: string, file: string, text: string): string {
+  const full = path.join(root, folder, file);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  fs.writeFileSync(full, text);
+  return full;
+}
+
+describe("dynasty DNA lookup", () => {
+  it("exports persistent DNA and imports it back with every gene and override intact", () => {
+    const portrait =
+      "genes={ hair_color={ 14 244 25 255 } }\nportrait_modifier_overrides={ custom_hair=example_hair }";
+    const copied = gameDnaCopy(`test_dna={ portrait_info={ ${portrait} } enabled=yes }`, true);
+    expect(copied?.format).toBe("persistent");
+    expect(copied?.text).toContain("type=female");
+    expect(copied?.text).toContain(portrait);
+    expect(copied?.text).not.toContain("portrait_info");
+    expect(copied?.text).not.toContain("enabled");
+    const pasted = dnaPasteBlock("another_dna", parseDnaPaste(copied!.text)!);
+    expect(pasted).toContain("portrait_info");
+    expect(pasted).toContain(portrait);
+    expect(parseScript(pasted!).errors).toEqual([]);
+    expect(pasted).not.toContain("type=");
+    expect(gameDnaCopy(pasted!, true)?.text).toContain(portrait);
+  });
+
+  it("uses the character's sex without losing stored portrait metadata", () => {
+    const copied = gameDnaCopy("test={portrait_info={type=male age=0.3 random_seed=42 genes={}}}", true);
+    expect(copied?.text).toBe("test={type=female age=0.3 random_seed=42 genes={}}");
+    const pasted = dnaPasteBlock("new_dna", parseDnaPaste(copied!.text)!);
+    expect(pasted).not.toMatch(/type=|age=|random_seed=/);
+    expect(pasted).toContain("genes={}");
+  });
+
+  it("copies stored DNA strings and refuses incomplete or unrelated blocks", () => {
+    expect(gameDnaCopy('test={dna="abc+/123="}', false)).toEqual({ text: "abc+/123=", format: "string" });
+    expect(gameDnaCopy("test={portrait_info={genes={}", false)).toBeNull();
+    expect(gameDnaCopy("test={trait=brave}", false)).toBeNull();
+  });
+
+  it("finds nested dependency DNA and applies file and definition overrides", () => {
+    const game = path.join(scratch, "game");
+    const parent = path.join(scratch, "parent");
+    const mod = path.join(scratch, "mod");
+    const vanilla = write(game, "shared.txt", "hidden = { dna = vanilla }");
+    const overridden = write(parent, "a.txt", "portrait = { dna = earlier }");
+    const winner = write(parent, "portraits/z.txt", "portrait = { dna = later }");
+    const replacement = write(mod, "shared.txt", "replacement = { dna = mod }");
+    const files = dnaFiles([game, parent, mod], folder);
+    expect(files).toEqual([replacement, winner, overridden]);
+    expect(files).not.toContain(vanilla);
+    const found = files.map((f) => scanBlocks(fs.readFileSync(f, "utf8")).get("portrait")).find(Boolean);
+    expect(found?.text).toBe("portrait = { dna = later }");
+  });
+
+  it("includes a new unsaved DNA file while excluding other folders and file types", () => {
+    const mod = path.join(scratch, "new-mod");
+    const unsaved = path.join(mod, folder, "portraits/new.txt");
+    expect(
+      dnaFiles([mod], folder, [
+        unsaved,
+        path.join(mod, "events/event.txt"),
+        path.join(mod, folder, "image.dds"),
+      ])
+    ).toEqual([unsaved]);
+  });
+});

--- a/packages/vscode/test/dynastyTreeApp.test.ts
+++ b/packages/vscode/test/dynastyTreeApp.test.ts
@@ -395,8 +395,16 @@ describe("the Dynasty Tree app", () => {
     click(app, card(app, "3"));
     expect(side.textContent).toContain("3_smokelet");
     expect(side.textContent).toContain("martial 7");
+    sideButton(app, "Copy block").click();
+    expect(app.posted).toContainEqual({ type: "dnaCopy", key: "3_smokelet" });
+    sideButton(app, "Copy for game").click();
+    expect(app.posted).toContainEqual({ type: "dnaCopyGame", key: "3_smokelet", female: false });
 
     click(app, card(app, "3").querySelector('.cact[data-act="edit"]')!);
+    side.querySelector<HTMLButtonElement>('button[aria-label="Copy DNA"]')!.click();
+    expect(app.posted.filter((m) => m.type === "dnaCopy")).toHaveLength(2);
+    sideButton(app, "Copy for game").click();
+    expect(app.posted.filter((m) => m.type === "dnaCopyGame")).toHaveLength(2);
     const prowess = [...side.querySelectorAll(".skills .px-field")].find(
       (f) => f.querySelector(".px-label")?.textContent === "prowess"
     )!;

--- a/scripts/build-asset-vocabulary.ts
+++ b/scripts/build-asset-vocabulary.ts
@@ -1,0 +1,35 @@
+/** Harvest graphics property paths from vanilla .asset files. No binaries are read.
+ * Run the bundled script with --game <id>; paths come from dev-paths.json. */
+import * as fs from "fs";
+import * as path from "path";
+import { listFiles } from "../packages/protocol/src/fsWalk";
+import { parseScript, walkStatements } from "../packages/server/src/parser";
+import { parseGameArg, requireDevPath } from "./devPaths";
+
+const { gameId } = parseGameArg(process.argv.slice(2));
+const game = requireDevPath("gamePath", "build-asset-vocabulary", gameId);
+const contexts: Record<string, Record<string, number>> = {};
+const files = listFiles(path.join(game, "gfx"), ".asset").sort();
+for (const file of files) {
+  walkStatements(parseScript(fs.readFileSync(file, "utf8")).root, (s, ancestors) => {
+    if (s.kind !== "assignment" || s.key.quoted || !/^[a-zA-Z_][\w]*$/.test(s.key.text)) return;
+    const chain = ancestors.filter((a) => a.kind === "assignment").map((a) => a.key.text);
+    if (chain.some((key) => !/^[a-zA-Z_][\w]*$/.test(key))) return;
+    const context = chain.join("/");
+    // These blocks use dynamic locator/attachment names as keys.
+    if (context === "entity/attach" || context === "entity/state/propagate_state") return;
+    const keys = (contexts[context] ??= {});
+    keys[s.key.text] = (keys[s.key.text] ?? 0) + 1;
+  });
+}
+const output = Object.fromEntries(
+  Object.keys(contexts)
+    .sort()
+    .map((key) => [
+      key,
+      Object.fromEntries(Object.entries(contexts[key]).sort(([a], [b]) => a.localeCompare(b))),
+    ])
+);
+const target = path.join("packages/server/data", gameId, "assetVocabulary.json");
+fs.writeFileSync(target, JSON.stringify(output, null, 2) + "\n");
+console.log(`${gameId}: ${files.length} assets, ${Object.keys(output).length} contexts -> ${target}`);


### PR DESCRIPTION
Prepare 0.4.2 with graphics asset support, reliable Dynasty Tree DNA copy/paste, and `###` sections that end at the next heading or EOF, including localization, GUI and asset files.

- Add context-aware asset completion/navigation, DDS previews and the `px.indexAssets` toggle.
- Copy DNA for mod files or the game, with dependency and unsaved-file lookup.
- Include all three package changelogs, concise release notes and README updates. Versions: toolkit 0.4.2, server 0.3.3, protocol 0.2.3. Based on the latest main, including the banner update.

Validation: 2,188 tests passed after one corpus timeout passed on an isolated rerun; 7 skipped. Typecheck, lint, game boundary, packaged npm consumer, standalone tarball, bundled Windows launcher and Neovim checks passed. Test VSIX installed and verified for the normal Marketplace channel.

Performance: unchanged CK3 rankings across 1,400 sampled positions. The release workspace indexed 481,227 definitions in 7.29 s, using 259 MB post-GC heap; warm completion took 5 ms. Performance history is included. Binary meshes and animations are not decoded during indexing.

Release artifacts are built locally. This PR does not tag or publish the release; squash merge remains the maintainer's step.

## Summary by Sourcery

Release the toolkit's graphics asset language support, reliable Dynasty DNA workflows, and heading-based section folding improvements.

New Features:
- Add graphics asset indexing, context-aware completion and navigation, asset file completion, shader references, and DDS previews for CK3 and Victoria 3.
- Add Dynasty Tree DNA copying for mods and game editors, including dependency and unsaved-file lookup and paste support.
- Add document-wide folding for `###` sections through the next heading or end of file.

Bug Fixes:
- Improve DNA resolution across dependency, nested, overridden, and unsaved files while preserving the clipboard when DNA is unavailable.
- Prevent graphics asset indexing and references from treating binary mesh data or incomplete asset values as script definitions.

Enhancements:
- Add the `px.indexAssets` setting with live index rebuilding while retaining open-file syntax features and on-demand previews.
- Update asset schemas, profiles, language-server capabilities, editor integration, and watcher support for graphics assets.
- Release toolkit version 0.4.2 with server 0.3.3 and protocol 0.2.3.

Build:
- Add asset vocabulary generation and checked-in CK3 and Victoria 3 asset vocabulary data.

Documentation:
- Update README, embedding and protocol documentation, changelogs, and release notes for graphics assets, DNA workflows, section folding, and configuration.

Tests:
- Add coverage for asset extraction, references, completion, navigation, previews, indexing toggles, section folding, DNA conversion, lookup, and Dynasty Tree UI behavior.

Chores:
- Refresh performance history and release presentation assets.