### PR TITLE
Unify README banners and make LSP developer guides easier to find

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ For Crusader Kings III, Victoria 3 and Europa Universalis V.
 
 </div>
 
-**Build with the language server:** [Editor setup](packages/server/README.md#install) · [Embed in an application](docs/EMBEDDING.md) · [Wire protocol](docs/PROTOCOL.md)
+**Build with the language server:** [Install the server](packages/server/README.md#install) · [Embed in an application](docs/EMBEDDING.md) · [Wire protocol](docs/PROTOCOL.md)
 
 > **Beta.** Young project, useful day to day, rough edges included.
 > Bug reports and missing-feature complaints are the point, not a nuisance:

--- a/README.md
+++ b/README.md
@@ -1,28 +1,24 @@
 <div align="center">
 
-<img src=".github/assets/github-banner.png" alt="Paradox Modding Toolkit: script completion, Steam Workshop uploads and visual editors for Crusader Kings III, Victoria 3 and Europa Universalis V." width="1200">
+<img src=".github/assets/github-banner.png" alt="Paradox Modding Toolkit" width="1200">
 
-# Paradox Modding Toolkit
+**Script editing, visual tools and Steam Workshop publishing for Paradox mods.**
 
-**A language workbench for Paradox mods.** Crusader Kings III, Victoria 3 and
-Europa Universalis V: a real script parser, scope-aware completion, instant
-diagnostics for the bugs the game swallows in silence, deep
-[tiger](https://github.com/amtep/tiger) integration, a visual GUI editor, an
-event graph laid out in firing order, a coat-of-arms Flag Builder, and a
-localization workflow no other tool has.
+For Crusader Kings III, Victoria 3 and Europa Universalis V.
 
 [![License: GPL-3.0-or-later](https://img.shields.io/badge/license-GPL--3.0--or--later-blue.svg)](LICENSE)
 ![Status: beta](https://img.shields.io/badge/status-beta-orange.svg)
 [![VS Code extension](https://img.shields.io/badge/VS%20Code-Paradox%20Modding%20Toolkit-007ACC.svg?logo=visualstudiocode)](https://marketplace.visualstudio.com/items?itemName=JDeffner.px-toolkit)
 [![npm @px-lsp/server](https://img.shields.io/npm/v/@px-lsp/server?logo=npm&label=%40px-lsp%2Fserver)](https://www.npmjs.com/package/@px-lsp/server)
-![Editor agnostic](https://img.shields.io/badge/also-any%20LSP%20client-brightgreen.svg)
 [![Discord](https://img.shields.io/badge/Discord-join-5865F2.svg?logo=discord&logoColor=white)](https://discord.gg/DfEJ2H9hj4)
 
 [Install](#install) · [What you get](#what-you-get) ·
-[Outside VS Code](#not-just-vs-code) · [Repo layout](#repo-layout) ·
+[Use the LSP](#use-the-language-server) · [Repo layout](#repo-layout) ·
 [Docs](https://github.com/JDeffner/paradox-modding-toolkit/wiki)
 
 </div>
+
+**Build with the language server:** [Editor setup](packages/server/README.md#install) · [Embed in an application](docs/EMBEDDING.md) · [Wire protocol](docs/PROTOCOL.md)
 
 > **Beta.** Young project, useful day to day, rough edges included.
 > Bug reports and missing-feature complaints are the point, not a nuisance:
@@ -153,7 +149,7 @@ CK3 is where the toolkit grew up and where every feature exists. The exact
 per-game limits, the detection ladder and the EU5 honesty note are on
 [Supported Games](https://github.com/JDeffner/paradox-modding-toolkit/wiki/Supported-Games).
 
-## Not just VS Code
+## Use the language server
 
 The language server is standard LSP over `--stdio` and runs from neovim, Zed,
 Helix or your own application. It is on npm:

--- a/packages/vscode/CHANGELOG.md
+++ b/packages/vscode/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Use the same banner in the GitHub and Marketplace READMEs, remove the repeated title and vague LSP badge, and link directly to editor setup, embedding and protocol guides.
+- Use the same banner in the GitHub and Marketplace READMEs, remove the repeated title and vague LSP badge, and link directly to server installation, embedding and protocol guides.
 
 ## 0.4.2 (beta) - graphics assets, DNA copying and section folding
 

--- a/packages/vscode/CHANGELOG.md
+++ b/packages/vscode/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Use the same banner in the GitHub and Marketplace READMEs, remove the repeated title and vague LSP badge, and link directly to editor setup, embedding and protocol guides.
+
 ## 0.4.2 (beta) - graphics assets, DNA copying and section folding
 
 - Fix `.asset` navigation and completion for mesh-local names, states, shader effects and CK3 accessory variations. Suggest graphics keywords from vanilla files and resolve engine shader paths.

--- a/packages/vscode/README.md
+++ b/packages/vscode/README.md
@@ -1,13 +1,19 @@
-<img src="media/icon.png" alt="PX TK" width="80" align="left">
+<div align="center">
 
-# Paradox Modding Toolkit
+<img src="https://raw.githubusercontent.com/JDeffner/paradox-modding-toolkit/main/.github/assets/github-banner.png" alt="Paradox Modding Toolkit" width="1200">
 
-Write, check and build mods for **Crusader Kings III**, **Victoria 3** and **Europa Universalis V** in VS Code.
+**Script editing, visual tools and Steam Workshop publishing for Paradox mods.**
+
+For Crusader Kings III, Victoria 3 and Europa Universalis V.
 
 [![License: GPL-3.0-or-later](https://img.shields.io/badge/license-GPL--3.0--or--later-blue.svg)](LICENSE)
 ![Status: beta](https://img.shields.io/badge/status-beta-orange.svg)
 ![VS Code](https://img.shields.io/badge/VS%20Code-%5E1.91-007ACC.svg?logo=visualstudiocode)
 [![Discord](https://img.shields.io/badge/Discord-join-5865F2.svg?logo=discord&logoColor=white)](https://discord.gg/DfEJ2H9hj4)
+
+</div>
+
+**Build with the language server:** [Editor setup](https://github.com/JDeffner/paradox-modding-toolkit/blob/main/packages/server/README.md#install) · [Embed in an application](https://github.com/JDeffner/paradox-modding-toolkit/blob/main/docs/EMBEDDING.md) · [Wire protocol](https://github.com/JDeffner/paradox-modding-toolkit/blob/main/docs/PROTOCOL.md)
 
 ## Start editing
 

--- a/packages/vscode/README.md
+++ b/packages/vscode/README.md
@@ -13,7 +13,7 @@ For Crusader Kings III, Victoria 3 and Europa Universalis V.
 
 </div>
 
-**Build with the language server:** [Editor setup](https://github.com/JDeffner/paradox-modding-toolkit/blob/main/packages/server/README.md#install) · [Embed in an application](https://github.com/JDeffner/paradox-modding-toolkit/blob/main/docs/EMBEDDING.md) · [Wire protocol](https://github.com/JDeffner/paradox-modding-toolkit/blob/main/docs/PROTOCOL.md)
+**Build with the language server:** [Install the server](https://github.com/JDeffner/paradox-modding-toolkit/blob/main/packages/server/README.md#install) · [Embed in an application](https://github.com/JDeffner/paradox-modding-toolkit/blob/main/docs/EMBEDDING.md) · [Wire protocol](https://github.com/JDeffner/paradox-modding-toolkit/blob/main/docs/PROTOCOL.md)
 
 ## Start editing
 


### PR DESCRIPTION
Use the existing GitHub banner in both READMEs and remove the duplicate text title. The image alt text supplies the title fallback. Replace the long summary with two short lines and remove the vague "also any LSP client" badge.

Put server installation, application embedding and protocol links near the top of both READMEs. The matching wiki navigation and outstanding post-audit protocol edits are committed locally as 29ab3e6 on docs/review-onboarding; wiki publication is separate.

Validation: GitHub Markdown rendering, guide/link checks and packaged README inspection passed. The test VSIX built and installed successfully. No runtime code changes.
