### PR TITLE
Add a Compatch Workspace for cross-file mod comparisons

### DIFF
--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -8,6 +8,8 @@ changes. Before the split it moved inside the extension's version (up to
 
 ## Unreleased
 
+- Declare verified CK3 event and localization folders for the client's Compatch Workspace; other game profiles explicitly use file comparisons only.
+
 ## 0.3.3
 
 Ships with the toolkit's 0.4.2 release.

--- a/packages/server/src/games/ck3/meta.ts
+++ b/packages/server/src/games/ck3/meta.ts
@@ -19,6 +19,8 @@ export const ck3Meta: GameMeta = {
   // Verified on the 1.19 install: dlc_001.dds .. dlc_029.dds.
   dlcIconDir: "gfx/interface/icons/dlc",
   eventNamespaces: true,
+  // Same folders and top-level event IDs as the installed events/_events.info and schema.
+  compatch: { events: "events", localization: "localization" },
   // The engine's own default metrics: they were measured on this game's font,
   // and the layout engine reuses them for games whose probe has not run.
   uiFont: "fonts/Gitan/GitanLatin-Regular.otf",

--- a/packages/server/src/games/eu5/meta.ts
+++ b/packages/server/src/games/eu5/meta.ts
@@ -10,6 +10,7 @@ import { EU5_SCAFFOLDS } from "./scaffolds";
 
 export const eu5Meta: GameMeta = {
   id: "eu5",
+  compatch: null,
   name: "Europa Universalis V",
   shortName: "EU5",
   engine: "jomini",

--- a/packages/server/src/games/profile.ts
+++ b/packages/server/src/games/profile.ts
@@ -98,6 +98,8 @@ export interface GameMeta {
   dlcIconDir?: string;
   /** Whether event files declare `namespace = x` and use `ns.N` event ids. */
   eventNamespaces: boolean;
+  /** Verified identity matching for the client compatch browser. Null = file diffs only. */
+  compatch: { events: string; localization: string } | null;
   /**
    * Subfolder of docsFolderName the ENGINE writes error.log into. Absent =
    * "logs", which is where both live installs checked (2026-08-12) write it.

--- a/packages/server/src/games/vic3/meta.ts
+++ b/packages/server/src/games/vic3/meta.ts
@@ -7,6 +7,7 @@ import { VIC3_SCAFFOLDS } from "./scaffolds";
 
 export const vic3Meta: GameMeta = {
   id: "vic3",
+  compatch: null,
   name: "Victoria 3",
   shortName: "Vic3",
   engine: "jomini",

--- a/packages/vscode/CHANGELOG.md
+++ b/packages/vscode/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add a Compatch Workspace with cross-file CK3 event and localization comparisons, file diffs for all games, an optional base, editable result files, and saved reviews that flag source updates. Event output uses full files; localization output checks vanilla ownership before choosing its folder.
+
 - Use the same banner in the GitHub and Marketplace READMEs, remove the repeated title and vague LSP badge, and link directly to server installation, embedding and protocol guides.
 
 ## 0.4.2 (beta) - graphics assets, DNA copying and section folding

--- a/packages/vscode/media/walkthrough/overview.md
+++ b/packages/vscode/media/walkthrough/overview.md
@@ -16,3 +16,11 @@ Below it, collapsed until you need them:
 - **Dependencies** — impact view for the definition at the cursor
 
 **Show Mod Report** (the checklist button above the Mod Overview list) collects all of it into one page.
+
+**Compatch Workspace** opens from Project or the command palette. Choose source A, source B, an optional common base, and a separate result mod folder. CK3 events match by ID across files; localization matches by language and key across ordinary and replace folders. Other content uses relative file paths. Victoria 3 and EU5 currently offer file comparisons only.
+
+Select a Compatch row to compare read-only sources. Its action button opens full source files, compares a source with an editable result, and records reviews. For existing filenames, choose **Choose existing result file**. Event creation copies the full source file at its original relative path. Localization creation checks the installed game's keys, routes vanilla overrides to `localization/replace`, and puts new keys in ordinary localization. An existing result is opened without overwriting it; copy the changes you want in the diff editor. Add the result mod to your workspace for the usual language features, and configure its parent mods and playset before testing it.
+
+Localization uses the workspace language by default. **Choose Compatch Localization Language** switches languages and rescans; saved reviews for other languages stay available when you switch back. Lists show 200 entries per page. Use **Filter Compatch Entries** to find an ID, key, path or status. **Show Compatch Scan Notes** lists source paths, parse issues, skipped links, files over 8 MiB and files that are not UTF-8 text. One review session is saved per VS Code workspace.
+
+**Mark reviewed** and **Skip for now** save source snapshots. Use **Refresh Compatch Sources** after saving source edits or updating a mod. Changed sources reopen the review; **Compare last reviewed** shows what changed. Your result files stay intact. These are text comparisons, not proof of gameplay compatibility or load-order resolution. A missing entry is not an instruction to delete it. Single-event override generation and GUI template matching are not included yet.

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -721,6 +721,59 @@
         "category": "Paradox",
         "title": "Extension Settings",
         "icon": "$(settings-gear)"
+      },
+      {
+        "command": "px.openCompatch",
+        "title": "Open Compatch Workspace",
+        "category": "Paradox",
+        "icon": "$(git-compare)"
+      },
+      {
+        "command": "px.newCompatch",
+        "title": "New Compatch Workspace",
+        "category": "Paradox",
+        "icon": "$(add)"
+      },
+      {
+        "command": "px.refreshCompatch",
+        "title": "Refresh Compatch Sources",
+        "category": "Paradox",
+        "icon": "$(refresh)"
+      },
+      {
+        "command": "px.filterCompatch",
+        "title": "Filter Compatch Entries",
+        "category": "Paradox",
+        "icon": "$(filter)"
+      },
+      {
+        "command": "px.compatchActions",
+        "title": "Compatch Entry Actions",
+        "category": "Paradox",
+        "icon": "$(diff)"
+      },
+      {
+        "command": "px.compareCompatch",
+        "title": "Compare Compatch Entry",
+        "category": "Paradox"
+      },
+      {
+        "command": "px.compatchScanNotes",
+        "title": "Show Compatch Scan Notes",
+        "category": "Paradox",
+        "icon": "$(output)"
+      },
+      {
+        "command": "px.compatchLanguage",
+        "title": "Choose Compatch Localization Language",
+        "category": "Paradox",
+        "icon": "$(globe)",
+        "enablement": "px.compatchSemanticSupported"
+      },
+      {
+        "command": "px.compatchPage",
+        "title": "Change Compatch Page",
+        "category": "Paradox"
       }
     ],
     "customEditors": [
@@ -1146,6 +1199,13 @@
           "icon": "media/px-view.svg",
           "visibility": "collapsed",
           "when": "px.isCk3Workspace"
+        },
+        {
+          "id": "px.compatch",
+          "name": "Compatch",
+          "icon": "media/px-view.svg",
+          "visibility": "collapsed",
+          "when": "px.isCk3Workspace"
         }
       ]
     },
@@ -1466,6 +1526,42 @@
         {
           "command": "px.openSettings",
           "when": "px.isCk3Workspace"
+        },
+        {
+          "command": "px.openCompatch",
+          "when": "px.isCk3Workspace"
+        },
+        {
+          "command": "px.newCompatch",
+          "when": "px.isCk3Workspace"
+        },
+        {
+          "command": "px.refreshCompatch",
+          "when": "px.isCk3Workspace"
+        },
+        {
+          "command": "px.filterCompatch",
+          "when": "px.isCk3Workspace"
+        },
+        {
+          "command": "px.compatchActions",
+          "when": "false"
+        },
+        {
+          "command": "px.compareCompatch",
+          "when": "false"
+        },
+        {
+          "command": "px.compatchScanNotes",
+          "when": "px.isCk3Workspace"
+        },
+        {
+          "command": "px.compatchLanguage",
+          "when": "px.isCk3Workspace && px.compatchSemanticSupported"
+        },
+        {
+          "command": "px.compatchPage",
+          "when": "false"
         }
       ],
       "view/title": [
@@ -1543,6 +1639,31 @@
           "command": "px.customizeSidebar",
           "when": "view == px.tools",
           "group": "1_configure@2"
+        },
+        {
+          "command": "px.newCompatch",
+          "when": "view == px.compatch",
+          "group": "navigation"
+        },
+        {
+          "command": "px.refreshCompatch",
+          "when": "view == px.compatch",
+          "group": "navigation"
+        },
+        {
+          "command": "px.filterCompatch",
+          "when": "view == px.compatch",
+          "group": "navigation"
+        },
+        {
+          "command": "px.compatchScanNotes",
+          "when": "view == px.compatch",
+          "group": "2_notes"
+        },
+        {
+          "command": "px.compatchLanguage",
+          "when": "view == px.compatch && px.compatchSemanticSupported",
+          "group": "2_language"
         }
       ],
       "view/item/context": [
@@ -1605,6 +1726,11 @@
           "command": "px.nextProblemInFile",
           "when": "view == px.problems && viewItem == px.problemFile",
           "group": "1_navigate@2"
+        },
+        {
+          "command": "px.compatchActions",
+          "when": "view == px.compatch && viewItem == px.compatchEntry",
+          "group": "inline"
         }
       ],
       "editor/context": [
@@ -1900,6 +2026,17 @@
         "command": "px.insertSnippet",
         "key": "ctrl+alt+i",
         "when": "editorTextFocus && editorLangId =~ /^paradox(-(ck3|vic3|eu5))?$/"
+      },
+      {
+        "command": "px.openCompatch",
+        "key": "ctrl+alt+m",
+        "when": "px.isCk3Workspace && !inputFocus"
+      }
+    ],
+    "viewsWelcome": [
+      {
+        "view": "px.compatch",
+        "contents": "Compare mods or game versions and edit a separate result mod.\n[Open Compatch Workspace](command:px.openCompatch)"
       }
     ]
   },

--- a/packages/vscode/src/compatch/core.ts
+++ b/packages/vscode/src/compatch/core.ts
@@ -1,0 +1,311 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { createHash } from "node:crypto";
+import { parseScript, parseLoc } from "@px-lsp/server/parser";
+import type { GameMeta } from "@px-lsp/server/games/profile";
+
+export type Side = "A" | "B" | "base";
+export type Kind = "event" | "localization" | "file";
+export interface Site {
+  path: string;
+  line: number;
+  text: string;
+}
+export interface Entry {
+  id: string;
+  name: string;
+  kind: Kind;
+  sites: Record<Side, Site[]>;
+}
+export interface Review {
+  status: "reviewed" | "skipped";
+  fingerprint: string;
+  sites: Entry["sites"];
+}
+export interface Session {
+  version: 1;
+  gameId: string;
+  localizationLanguage: string;
+  roots: Record<Side, string | null>;
+  output: string;
+  protectedRoots: string[];
+  reviews: Record<string, Review>;
+  results: Record<string, string>;
+}
+export interface Inventory {
+  entries: Map<string, Entry>;
+  files: Record<Side, Map<string, string>>;
+  issues: string[];
+}
+
+const textExtensions = new Set([
+  ".txt",
+  ".gui",
+  ".yml",
+  ".yaml",
+  ".asset",
+  ".gfx",
+  ".mod",
+  ".json",
+  ".lua",
+  ".shader",
+  ".fx",
+  ".fxh",
+  ".csv",
+  ".info",
+  ".settings",
+  ".map",
+  ".md",
+]);
+const normalize = (text: string) => text.replace(/^\uFEFF/, "").replace(/\r\n?/g, "\n");
+
+export function fingerprint(entry: Entry): string {
+  return createHash("sha256").update(JSON.stringify(entry.sites)).digest("hex");
+}
+
+export function status(entry: Entry, review?: Review): string {
+  if (review) return review.fingerprint === fingerprint(entry) ? review.status : "sources changed";
+  if (Object.values(entry.sites).some((sites) => sites.length > 1)) return "multiple definitions";
+  const { A, B } = entry.sites;
+  if (!A.length && !B.length) return "absent from A and B";
+  if (!A.length) return "B only";
+  if (!B.length) return "A only";
+  return normalize(A[0].text) === normalize(B[0].text) ? "same" : "different";
+}
+
+/** Index source sites without resolving winners. File identity and definition identity coexist. */
+export function addFile(
+  inventory: Inventory,
+  side: Side,
+  relative: string,
+  text: string,
+  support: GameMeta["compatch"],
+  languageFilter?: string
+): void {
+  inventory.files[side].set(relative, text);
+  function add(kind: Kind, name: string, content: string, line: number) {
+    const id = JSON.stringify([kind, name]);
+    let entry = inventory.entries.get(id);
+    if (!entry) {
+      entry = { id, kind, name, sites: { A: [], B: [], base: [] } };
+      inventory.entries.set(id, entry);
+    }
+    entry.sites[side].push({ path: relative, line, text: content });
+  }
+  add("file", relative, text, 1);
+  if (!support) return;
+  if (relative.startsWith(`${support.events}/`) && relative.endsWith(".txt")) {
+    const parsed = parseScript(text);
+    if (parsed.errors.length)
+      inventory.issues.push(`${side}: ${relative}: script parse errors; inspect the full file.`);
+    // File constants and namespace declarations stay in the full-file view.
+    const context = parsed.root.statements
+      .filter((s) => s.kind === "assignment" && (s.key.text === "namespace" || s.key.text.startsWith("@")))
+      .map((s) => text.slice(s.range.start, s.range.end))
+      .join("\n");
+    for (const statement of parsed.root.statements) {
+      if (
+        statement.kind !== "assignment" ||
+        statement.value?.kind !== "block" ||
+        !statement.key.text.includes(".")
+      )
+        continue;
+      const line = text.slice(0, statement.range.start).split(/\r\n|\r|\n/).length;
+      add(
+        "event",
+        statement.key.text,
+        `${context}\n\n${text.slice(statement.range.start, statement.range.end)}\n`,
+        line
+      );
+    }
+  }
+  if (relative.startsWith(`${support.localization}/`) && relative.endsWith(".yml")) {
+    const parsed = parseLoc(text);
+    if (parsed.errors.length)
+      inventory.issues.push(`${side}: ${relative}: localization parse errors; inspect the full file.`);
+    if (!parsed.language) return;
+    if (languageFilter && parsed.language !== languageFilter) return;
+    const lines = text.split(/\r\n|\r|\n/);
+    for (const entry of parsed.entries) {
+      add(
+        "localization",
+        `${parsed.language}:${entry.key}`,
+        `l_${parsed.language}:\n${lines[entry.line]}\n`,
+        entry.line + 1
+      );
+    }
+  }
+}
+
+export function emptyInventory(): Inventory {
+  return { entries: new Map(), files: { A: new Map(), B: new Map(), base: new Map() }, issues: [] };
+}
+
+/** Links are skipped, so a selected source cannot silently scan a different mod. */
+export async function scan(
+  session: Session,
+  support: GameMeta["compatch"],
+  report: (file: string) => void,
+  cancelled: () => boolean
+): Promise<Inventory> {
+  const inventory = emptyInventory();
+  for (const side of ["A", "B", "base"] as const) {
+    const root = session.roots[side];
+    if (!root) continue;
+    async function walk(directory: string): Promise<void> {
+      const children = await fs.readdir(directory, { withFileTypes: true });
+      children.sort((a, b) => a.name.localeCompare(b.name));
+      for (const child of children) {
+        if (cancelled()) throw new Error("Compatch scan cancelled. The previous comparison is unchanged.");
+        if ((child.name.startsWith(".") && child.name !== ".metadata") || child.name === "node_modules")
+          continue;
+        const filename = path.join(directory, child.name);
+        const relative = path.relative(root!, filename).split(path.sep).join("/");
+        const language = /_l_([A-Za-z_]+)\.yml$/.exec(relative)?.[1];
+        if (
+          support &&
+          relative.startsWith(`${support.localization}/`) &&
+          language &&
+          language !== session.localizationLanguage
+        )
+          continue;
+        if (child.isSymbolicLink()) {
+          inventory.issues.push(`${side}: ${relative}: symbolic link skipped.`);
+        } else if (child.isDirectory()) {
+          await walk(filename);
+        } else if (child.isFile() && textExtensions.has(path.extname(child.name).toLowerCase())) {
+          report(`${side}: ${relative}`);
+          const stat = await fs.stat(filename);
+          if (stat.size > 8 * 1024 * 1024) {
+            inventory.issues.push(`${side}: ${relative}: exceeds 8 MiB; skipped.`);
+            continue;
+          }
+          const bytes = await fs.readFile(filename);
+          let text: string;
+          try {
+            text = new TextDecoder("utf-8", { fatal: true, ignoreBOM: true }).decode(bytes);
+            if (text.includes("\0")) throw new Error("binary");
+          } catch {
+            inventory.issues.push(`${side}: ${relative}: not UTF-8 text; skipped.`);
+            continue;
+          }
+          addFile(inventory, side, relative, text, support, session.localizationLanguage);
+        }
+      }
+    }
+    await walk(root);
+  }
+  // Keep reviewed definitions that disappear so an upstream removal remains reviewable.
+  for (const id of Object.keys(session.reviews)) {
+    if (!inventory.entries.has(id)) {
+      const [kind, name] = JSON.parse(id) as [Kind, string];
+      if (kind === "localization" && !name.startsWith(`${session.localizationLanguage}:`)) continue;
+      const language = /_l_([A-Za-z_]+)\.yml$/.exec(name)?.[1];
+      if (
+        kind === "file" &&
+        support &&
+        name.startsWith(`${support.localization}/`) &&
+        language &&
+        language !== session.localizationLanguage
+      )
+        continue;
+      inventory.entries.set(id, { id, kind, name, sites: { A: [], B: [], base: [] } });
+    }
+  }
+  return inventory;
+}
+
+export function contains(root: string, target: string): boolean {
+  const relative = path.relative(root, target);
+  return (
+    relative === "" ||
+    (!relative.startsWith(`..${path.sep}`) && relative !== ".." && !path.isAbsolute(relative))
+  );
+}
+
+export async function validateRoots(session: Session): Promise<void> {
+  const output = await fs.realpath(session.output);
+  for (const root of [...Object.values(session.roots), ...session.protectedRoots]) {
+    if (!root) continue;
+    const source = await fs.realpath(root);
+    if (contains(source, output) || contains(output, source)) {
+      throw new Error(
+        "Choose a separate result folder outside all source folders. Sources cannot be inside the result folder either."
+      );
+    }
+  }
+}
+
+/** Checks existing ancestors too: a junction in the output tree must not lead into a source. */
+export async function resultPath(session: Session, relative: string): Promise<string> {
+  await validateRoots(session);
+  const root = await fs.realpath(session.output);
+  const target = path.resolve(root, relative);
+  if (!relative || path.isAbsolute(relative) || !contains(root, target) || target === root)
+    throw new Error("Use a relative file path inside the result folder.");
+  let existing = target;
+  while (true) {
+    try {
+      const real = await fs.realpath(existing);
+      if (!contains(root, real)) throw new Error("The result path follows a link outside the result folder.");
+      break;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+      existing = path.dirname(existing);
+    }
+  }
+  return target;
+}
+
+export async function createResult(session: Session, relative: string, text: string): Promise<string> {
+  const target = await resultPath(session, relative);
+  await fs.mkdir(path.dirname(target), { recursive: true });
+  await fs.writeFile(target, text, { encoding: "utf8", flag: "wx" });
+  return target;
+}
+
+/** Full event files are the supported replacement unit until single-event priority rules ship. */
+export function seedFile(relative: string, text: string, support: GameMeta["compatch"]): string {
+  let content = text.replace(/^\uFEFF/, "");
+  if (support && relative.startsWith(`${support.events}/`) && relative.endsWith(".txt")) {
+    const parsed = parseScript(content);
+    if (parsed.errors.length)
+      throw new Error("Fix the source file's script errors before creating a result from it.");
+    const headers = parsed.root.statements.filter(
+      (s) => s.kind === "assignment" && s.key.text === "namespace" && s.value?.kind === "scalar"
+    );
+    if (!headers.length)
+      throw new Error("The source event file has no namespace. Create or repair the result manually.");
+    const prefix = headers.map((s) => content.slice(s.range.start, s.range.end)).join("\n");
+    for (const header of [...headers].reverse())
+      content = content.slice(0, header.range.start) + content.slice(header.range.end);
+    content = `${prefix}\n${content}`;
+  }
+  return /\.(txt|yml)$/i.test(relative) ? `\uFEFF${content}` : text;
+}
+
+/** Verify against this install, never infer vanilla ownership from a mod's replace folder. */
+export async function hasVanillaLoc(directory: string, language: string, key: string): Promise<boolean> {
+  for (const child of await fs.readdir(directory, { withFileTypes: true })) {
+    const filename = path.join(directory, child.name);
+    if (child.isSymbolicLink()) throw new Error("Cannot verify vanilla localization through symbolic links.");
+    if (child.isDirectory() && (await hasVanillaLoc(filename, language, key))) return true;
+    if (child.isFile() && child.name.endsWith(`_l_${language}.yml`)) {
+      const parsed = parseLoc(await fs.readFile(filename, "utf8"));
+      if (parsed.language === language && parsed.entries.some((entry) => entry.key === key)) return true;
+    }
+  }
+  return false;
+}
+
+export function localizationSeed(
+  text: string,
+  folder: string,
+  vanilla: boolean
+): { relative: string; text: string } {
+  const parsed = parseLoc(text);
+  if (!parsed.language || parsed.errors.length || parsed.entries.length !== 1)
+    throw new Error("Select a single valid localization entry.");
+  const relative = `${folder}/${vanilla ? "replace" : parsed.language}/px_compatch_l_${parsed.language}.yml`;
+  return { relative, text: `\uFEFF${text.replace(/^\uFEFF/, "")}` };
+}

--- a/packages/vscode/src/compatch/view.ts
+++ b/packages/vscode/src/compatch/view.ts
@@ -1,0 +1,619 @@
+import * as vscode from "vscode";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { randomUUID } from "node:crypto";
+import { parseLoc } from "@px-lsp/server/parser";
+import type { PxConfig } from "../config";
+import { metaFor } from "../meta";
+import { locTargetFile } from "../locCommands";
+import {
+  type Entry,
+  type Inventory,
+  type Kind,
+  type Session,
+  type Side,
+  type Site,
+  emptyInventory,
+  scan,
+  status,
+  fingerprint,
+  validateRoots,
+  resultPath,
+  createResult,
+  seedFile,
+  hasVanillaLoc,
+  localizationSeed,
+} from "./core";
+
+type Row = { group: Kind } | { entry: Entry } | { page: Kind; direction: number };
+const PAGE_SIZE = 200;
+const labels: Record<Kind, string> = {
+  event: "Events by ID",
+  localization: "Localization by language and key",
+  file: "Files by path",
+};
+
+class CompatchView implements vscode.TreeDataProvider<Row>, vscode.TextDocumentContentProvider {
+  private readonly changes = new vscode.EventEmitter<void>();
+  readonly onDidChangeTreeData = this.changes.event;
+  private readonly snapshots = new Map<string, string>();
+  private inventory: Inventory = emptyInventory();
+  private session: Session | undefined;
+  private busy = false;
+  private saveQueue: Promise<void> = Promise.resolve();
+  private filter = "";
+  private pages: Record<Kind, number> = { event: 0, localization: 0, file: 0 };
+  private rows: Partial<Record<Kind, Entry[]>> = {};
+  private readonly view: vscode.TreeView<Row>;
+  private readonly log = vscode.window.createOutputChannel("Paradox Compatch");
+  private readonly stateFile: string | undefined;
+
+  constructor(
+    context: vscode.ExtensionContext,
+    private readonly getCfg: () => PxConfig
+  ) {
+    this.stateFile = context.storageUri && path.join(context.storageUri.fsPath, "compatch.json");
+    this.view = vscode.window.createTreeView("px.compatch", {
+      treeDataProvider: this,
+      showCollapseAll: true,
+    });
+    this.view.message = "Open Compatch Workspace to choose two sources and a separate result mod.";
+    context.subscriptions.push(
+      this.view,
+      this.changes,
+      this.log,
+      vscode.workspace.registerTextDocumentContentProvider("px-compatch", this),
+      vscode.workspace.onDidCloseTextDocument((document) => {
+        if (document.uri.scheme === "px-compatch")
+          setTimeout(() => {
+            if (
+              !vscode.workspace.textDocuments.some((open) => open.uri.toString() === document.uri.toString())
+            )
+              this.snapshots.delete(document.uri.toString());
+          }, 0);
+      })
+    );
+    const commands: Record<string, (row?: Row) => Promise<unknown>> = {
+      "px.openCompatch": () => this.open(),
+      "px.newCompatch": () => this.setup(),
+      "px.refreshCompatch": () => this.refresh(),
+      "px.filterCompatch": () => this.setFilter(),
+      "px.compatchLanguage": async () => {
+        if (!this.session || this.busy) return;
+        if (!metaFor(this.session.gameId).compatch) return;
+        const language = await vscode.window.showInputBox({
+          title: "Compatch localization language",
+          value: this.session.localizationLanguage,
+          prompt:
+            "Language name from l_<language>, such as english, french or german. Rescans sources; reviews for other languages are retained.",
+          validateInput: (value) =>
+            /^[a-z_]+$/.test(value)
+              ? undefined
+              : "Use a language name with lowercase letters and underscores.",
+        });
+        if (language) await this.refresh({ ...this.session, localizationLanguage: language });
+      },
+      "px.compatchPage": async (row) => {
+        if (row && "page" in row) {
+          this.pages[row.page] = Math.max(0, this.pages[row.page] + row.direction);
+          this.changes.fire();
+        }
+      },
+      "px.compatchActions": (row) => this.actions(row),
+      "px.compareCompatch": async (row) => {
+        if (row && "entry" in row && this.session && !this.busy) await this.compare(row.entry, "A", "B");
+      },
+      "px.compatchScanNotes": async () => {
+        this.log.show(true);
+      },
+    };
+    for (const [id, action] of Object.entries(commands)) {
+      context.subscriptions.push(
+        vscode.commands.registerCommand(id, async (row?: Row) => {
+          try {
+            if (this.session && id !== "px.newCompatch" && this.session.gameId !== this.getCfg().gameId)
+              throw new Error("The active game changed. Use New Compatch Workspace.");
+            if (this.session && this.getCfg().gamePath)
+              this.session.protectedRoots = [this.getCfg().gamePath!];
+            await action(row);
+          } catch (error) {
+            void vscode.window.showErrorMessage(
+              `Compatch: ${error instanceof Error ? error.message : String(error)}`
+            );
+          }
+        })
+      );
+    }
+  }
+
+  provideTextDocumentContent(uri: vscode.Uri): string {
+    return (
+      this.snapshots.get(uri.toString()) ?? "Snapshot closed. Reopen the comparison from the Compatch view."
+    );
+  }
+
+  private async snapshot(text: string, label: string, filename: string): Promise<vscode.Uri> {
+    const uri = vscode.Uri.from({
+      scheme: "px-compatch",
+      path: `/${label}/${randomUUID()}/${path.basename(filename)}`,
+    });
+    this.snapshots.set(uri.toString(), text);
+    const doc = await vscode.workspace.openTextDocument(uri);
+    const language = filename.endsWith(".yml")
+      ? "paradox-loc"
+      : filename.endsWith(".gui")
+        ? "paradox-gui"
+        : filename.endsWith(".txt")
+          ? `paradox-${this.session!.gameId}`
+          : "plaintext";
+    await vscode.languages.setTextDocumentLanguage(doc, language);
+    return uri;
+  }
+
+  getTreeItem(row: Row): vscode.TreeItem {
+    if ("group" in row) {
+      const item = new vscode.TreeItem(labels[row.group], vscode.TreeItemCollapsibleState.Collapsed);
+      item.description = String(this.entries(row.group).length);
+      return item;
+    }
+    if ("page" in row) {
+      const item = new vscode.TreeItem(row.direction > 0 ? "Next 200 entries" : "Previous 200 entries");
+      item.iconPath = new vscode.ThemeIcon(row.direction > 0 ? "arrow-right" : "arrow-left");
+      item.command = { command: "px.compatchPage", title: "Change page", arguments: [row] };
+      return item;
+    }
+    const entry = row.entry;
+    const state = status(entry, this.session?.reviews[entry.id]);
+    const item = new vscode.TreeItem(entry.name);
+    item.id = entry.id;
+    item.contextValue = "px.compatchEntry";
+    item.description = state;
+    item.iconPath = new vscode.ThemeIcon(
+      state === "reviewed"
+        ? "check"
+        : state === "skipped"
+          ? "debug-step-over"
+          : state === "same"
+            ? "dash"
+            : "diff"
+    );
+    item.tooltip = [
+      state,
+      ...(["A", "B", "base"] as const).flatMap((side) =>
+        entry.sites[side].map((site) => `${side}: ${site.path}:${site.line}`)
+      ),
+      "Select to compare. Use the row actions to edit a result or record your review.",
+    ].join("\n");
+    item.command = { command: "px.compareCompatch", title: "Compare A and B", arguments: [row] };
+    return item;
+  }
+
+  private entries(kind: Kind): Entry[] {
+    return (this.rows[kind] ??= [...this.inventory.entries.values()]
+      .filter(
+        (entry) =>
+          entry.kind === kind &&
+          (!this.filter ||
+            `${entry.name} ${status(entry, this.session?.reviews[entry.id])} ${Object.values(entry.sites)
+              .flat()
+              .map((s) => s.path)
+              .join(" ")}`
+              .toLowerCase()
+              .includes(this.filter.toLowerCase()))
+      )
+      .sort((a, b) => a.name.localeCompare(b.name)));
+  }
+
+  getChildren(row?: Row): Row[] {
+    if (!this.session) return [];
+    if (!row)
+      return (["event", "localization", "file"] as const)
+        .filter((kind) => this.entries(kind).length)
+        .map((group) => ({ group }));
+    if (!("group" in row)) return [];
+    const entries = this.entries(row.group);
+    const page = Math.min(this.pages[row.group], Math.max(0, Math.ceil(entries.length / PAGE_SIZE) - 1));
+    this.pages[row.group] = page;
+    const result: Row[] = entries.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE).map((entry) => ({ entry }));
+    if (page > 0) result.unshift({ page: row.group, direction: -1 });
+    if ((page + 1) * PAGE_SIZE < entries.length) result.push({ page: row.group, direction: 1 });
+    return result;
+  }
+
+  private changed(): void {
+    this.rows = {};
+    this.changes.fire();
+  }
+
+  private async persist(): Promise<void> {
+    if (!this.stateFile || !this.session) return;
+    const filename = this.stateFile;
+    const text = JSON.stringify(this.session);
+    const save = async () => {
+      await fs.mkdir(path.dirname(filename), { recursive: true });
+      const temporary = `${filename}.tmp`;
+      await fs.writeFile(temporary, text, "utf8");
+      await fs.rename(temporary, filename);
+    };
+    this.saveQueue = this.saveQueue.then(save, save);
+    await this.saveQueue;
+  }
+
+  private async folder(title: string): Promise<string | undefined> {
+    const pick = await vscode.window.showOpenDialog({
+      title,
+      canSelectFolders: true,
+      canSelectFiles: false,
+      canSelectMany: false,
+      openLabel: "Use folder",
+    });
+    if (!pick?.[0]) return;
+    if (pick[0].scheme !== "file") throw new Error("Choose a folder on the local filesystem.");
+    return fs.realpath(pick[0].fsPath);
+  }
+
+  private async open(): Promise<void> {
+    if (!this.session && this.stateFile) {
+      try {
+        const saved = JSON.parse(await fs.readFile(this.stateFile, "utf8")) as Session;
+        if (saved.version !== 1 || saved.gameId !== this.getCfg().gameId)
+          throw new Error("Saved comparison belongs to another game. Use New Compatch Workspace.");
+        await this.refresh(saved);
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+      }
+    }
+    if (!this.session) await this.setup();
+    await vscode.commands.executeCommand("px.compatch.focus");
+  }
+
+  private async setup(): Promise<void> {
+    if (this.busy) return;
+    if (this.session && Object.keys(this.session.reviews).length) {
+      const choice = await vscode.window.showWarningMessage(
+        "A new comparison replaces this workspace's saved review session. Result files stay on disk.",
+        "Start new comparison"
+      );
+      if (!choice) return;
+    }
+    const A = await this.folder("Source A: mod folder or game data folder");
+    if (!A) return;
+    const B = await this.folder("Source B: other mod or new game data folder");
+    if (!B) return;
+    const baseChoice = await vscode.window.showQuickPick(["Compare without a base", "Choose a base folder"], {
+      title: "Compatch: optional common base",
+      placeHolder: "For a game update, the base is the old game data folder.",
+    });
+    if (!baseChoice) return;
+    const base =
+      baseChoice === "Choose a base folder"
+        ? await this.folder("Base: shared starting version, such as the old game data folder")
+        : null;
+    if (base === undefined) return;
+    const output = await this.folder(
+      "Result: a separate mod folder (create it with New Mod first if needed)"
+    );
+    if (!output) return;
+    const session: Session = {
+      version: 1,
+      gameId: this.getCfg().gameId,
+      localizationLanguage: this.getCfg().locLanguage,
+      roots: { A, B, base },
+      output,
+      protectedRoots: this.getCfg().gamePath ? [this.getCfg().gamePath!] : [],
+      reviews: {},
+      results: {},
+    };
+    await this.refresh(session);
+    await vscode.commands.executeCommand("px.compatch.focus");
+  }
+
+  private async refresh(candidate = this.session): Promise<void> {
+    if (this.busy) return;
+    if (!candidate) {
+      await this.open();
+      return;
+    }
+    if (candidate.gameId !== this.getCfg().gameId)
+      throw new Error("The active game changed. Start a new comparison for this game.");
+    this.busy = true;
+    try {
+      candidate.protectedRoots = this.getCfg().gamePath ? [this.getCfg().gamePath!] : [];
+      await validateRoots(candidate);
+      let lastReport = 0;
+      const inventory = await vscode.window.withProgress(
+        {
+          location: vscode.ProgressLocation.Notification,
+          title: "Scanning compatch sources",
+          cancellable: true,
+        },
+        (progress, token) =>
+          scan(
+            candidate,
+            metaFor(candidate.gameId).compatch,
+            (message) => {
+              if (Date.now() - lastReport > 100) {
+                progress.report({ message });
+                lastReport = Date.now();
+              }
+            },
+            () => token.isCancellationRequested
+          )
+      );
+      this.inventory = inventory;
+      this.pages = { event: 0, localization: 0, file: 0 };
+      this.session = candidate;
+      await this.persist();
+      this.log.clear();
+      for (const [side, root] of Object.entries(candidate.roots))
+        if (root) this.log.appendLine(`${side}: ${root}`);
+      this.log.appendLine(`Result: ${candidate.output}`);
+      if (metaFor(candidate.gameId).compatch)
+        this.log.appendLine(
+          `Localization: ${candidate.localizationLanguage}. Other named localization languages are excluded from this scan.`
+        );
+      this.log.appendLine(
+        "Compares saved UTF-8 text. No load-order winner or gameplay compatibility is inferred. Missing content is not a deletion instruction."
+      );
+      for (const issue of inventory.issues) this.log.appendLine(issue);
+      this.view.message = `A: ${path.basename(candidate.roots.A!)} | B: ${path.basename(candidate.roots.B!)} | Result: ${path.basename(candidate.output)}. ${metaFor(candidate.gameId).compatch ? `Localization: ${candidate.localizationLanguage}. ` : "This game supports file comparisons only. "}Saved files; Refresh after source edits. ${inventory.issues.length ? `${inventory.issues.length} scan notes in Paradox Compatch output.` : ""}`;
+      this.changed();
+      if (inventory.issues.length) {
+        const choice = await vscode.window.showWarningMessage(
+          `Compatch scan has ${inventory.issues.length} notes. Some files may be incomplete or skipped.`,
+          "Show scan notes"
+        );
+        if (choice) this.log.show(true);
+      }
+    } finally {
+      this.busy = false;
+    }
+  }
+
+  private async setFilter(): Promise<void> {
+    const filter = await vscode.window.showInputBox({
+      title: "Filter compatch entries",
+      prompt: "Match an ID, key, path or status, such as different or sources changed. Empty shows all.",
+      value: this.filter,
+    });
+    if (filter !== undefined) {
+      this.filter = filter;
+      this.pages = { event: 0, localization: 0, file: 0 };
+      this.view.description = filter ? `Filter: ${filter}` : undefined;
+      this.changed();
+    }
+  }
+
+  private async chooseSite(entry: Entry, side: Side, sites = entry.sites[side]): Promise<Site | undefined> {
+    if (sites.length <= 1) return sites[0];
+    const pick = await vscode.window.showQuickPick(
+      sites.map((site) => ({ label: site.path, description: `Line ${site.line}`, site })),
+      {
+        title: `${side}: ${entry.name}`,
+        placeHolder: "Multiple definitions found. Choose a source; no winner is assumed.",
+      }
+    );
+    return pick?.site;
+  }
+
+  private async compare(entry: Entry, left: Side, right: Side): Promise<void> {
+    const a = await this.chooseSite(entry, left);
+    if (!a && entry.sites[left].length) return;
+    const b = await this.chooseSite(entry, right);
+    if (!b && entry.sites[right].length) return;
+    const filename = a?.path ?? b?.path ?? "missing.txt";
+    const leftUri = await this.snapshot(a?.text ?? "", left, filename);
+    const rightUri = await this.snapshot(b?.text ?? "", right, b?.path ?? filename);
+    await vscode.commands.executeCommand(
+      "vscode.diff",
+      leftUri,
+      rightUri,
+      `${entry.name}: ${left} (${a?.path ?? "absent"}) ↔ ${right} (${b?.path ?? "absent"})`
+    );
+  }
+
+  private async source(entry: Entry, side: Side): Promise<void> {
+    const site = await this.chooseSite(entry, side);
+    if (!site) return;
+    const text = this.inventory.files[side].get(site.path)!;
+    const uri = await this.snapshot(text, `${side}-full-file`, site.path);
+    const editor = await vscode.window.showTextDocument(uri);
+    const position = new vscode.Position(site.line - 1, 0);
+    editor.selection = new vscode.Selection(position, position);
+    editor.revealRange(new vscode.Range(position, position), vscode.TextEditorRevealType.InCenter);
+  }
+
+  private async linkResult(entry: Entry): Promise<void> {
+    const session = this.session!;
+    const picked = await vscode.window.showOpenDialog({
+      title: "Choose the result file to edit",
+      defaultUri: vscode.Uri.file(session.output),
+      canSelectMany: false,
+      canSelectFiles: true,
+    });
+    if (!picked?.[0]) return;
+    if (picked[0].scheme !== "file") throw new Error("Choose a local result file.");
+    const relative = path.relative(session.output, picked[0].fsPath);
+    await resultPath(session, relative);
+    session.results[entry.id] = relative;
+    await this.persist();
+    await this.editResult(entry);
+  }
+
+  private async editResult(entry: Entry, side?: Side): Promise<void> {
+    const session = this.session!;
+    const relative = session.results[entry.id];
+    if (!relative) {
+      await this.linkResult(entry);
+      if (session.results[entry.id] && side) await this.editResult(entry, side);
+      return;
+    }
+    const target = vscode.Uri.file(await resultPath(session, relative));
+    if (!side) {
+      await vscode.window.showTextDocument(target);
+      return;
+    }
+    const site = await this.chooseSite(entry, side);
+    if (!site) return;
+    const source = await this.snapshot(site.text, side, site.path);
+    await vscode.commands.executeCommand(
+      "vscode.diff",
+      source,
+      target,
+      `${entry.name}: ${side} → Result (editable)`
+    );
+  }
+
+  private async createLocalization(entry: Entry, side: Side): Promise<void> {
+    const site = await this.chooseSite(entry, side);
+    if (!site) return;
+    const session = this.session!;
+    const game = this.getCfg().gamePath;
+    const support = metaFor(session.gameId).compatch;
+    if (!game || !support)
+      throw new Error("Set the game data path first so vanilla localization ownership can be checked.");
+    const parsed = parseLoc(site.text);
+    if (!parsed.language || parsed.entries.length !== 1 || parsed.errors.length)
+      throw new Error("Select a valid localization entry.");
+    const vanilla = await vscode.window.withProgress(
+      { location: vscode.ProgressLocation.Notification, title: "Checking vanilla localization" },
+      () => hasVanillaLoc(path.join(game, support.localization), parsed.language!, parsed.entries[0].key)
+    );
+    const seed = localizationSeed(site.text, support.localization, vanilla);
+    if (!vanilla) {
+      const target = await locTargetFile(
+        { ...this.getCfg(), modPath: session.output, locLanguage: parsed.language },
+        async () => [],
+        parsed.entries[0].key
+      );
+      seed.relative = path.relative(session.output, target!);
+    }
+    try {
+      await createResult(session, seed.relative, seed.text);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+    }
+    session.results[entry.id] = seed.relative;
+    await this.persist();
+    await this.editResult(entry, side);
+  }
+
+  private async create(entry: Entry, side: Side): Promise<void> {
+    const site = await this.chooseSite(entry, side);
+    if (!site) return;
+    const session = this.session!;
+    const sourceText = this.inventory.files[side].get(site.path)!;
+    const text = seedFile(site.path, sourceText, metaFor(session.gameId).compatch);
+    try {
+      await createResult(session, site.path, text);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+    }
+    session.results[entry.id] = site.path;
+    await this.persist();
+    await this.editResult(entry);
+  }
+
+  private async previous(entry: Entry, side: Side): Promise<void> {
+    const saved = this.session!.reviews[entry.id];
+    if (!saved) return;
+    const old = await this.chooseSite(entry, side, saved.sites[side]);
+    if (!old && saved.sites[side].length) return;
+    const current = await this.chooseSite(entry, side);
+    if (!current && entry.sites[side].length) return;
+    const filename = current?.path ?? old?.path ?? "missing.txt";
+    await vscode.commands.executeCommand(
+      "vscode.diff",
+      await this.snapshot(old?.text ?? "", `${side}-last-reviewed`, filename),
+      await this.snapshot(current?.text ?? "", `${side}-current`, filename),
+      `${entry.name}: last reviewed ${side} → current ${side}`
+    );
+  }
+
+  private async actions(row?: Row): Promise<void> {
+    if (!row || !("entry" in row) || !this.session || this.busy) return;
+    const entry = row.entry;
+    const choices: { label: string; description?: string; run: () => Promise<unknown> }[] = [
+      {
+        label: "Compare A ↔ B",
+        description: "Read-only snapshots; an absent side is empty",
+        run: () => this.compare(entry, "A", "B"),
+      },
+    ];
+    for (const side of ["A", "B"] as const) {
+      if (this.session.roots.base)
+        choices.push({ label: `Compare base ↔ ${side}`, run: () => this.compare(entry, "base", side) });
+      if (entry.sites[side].length) {
+        choices.push({
+          label: `Open full ${side} file`,
+          description: "Read-only source snapshot",
+          run: () => this.source(entry, side),
+        });
+        choices.push({
+          label: `Compare ${side} → result`,
+          description: "Edit the result on the right",
+          run: () => this.editResult(entry, side),
+        });
+        if (entry.kind !== "localization" && !entry.name.endsWith(".yml"))
+          choices.push({
+            label: `Create result from full ${side} file`,
+            description:
+              "Keeps the source path and every definition; opens existing results without overwriting",
+            run: () => this.create(entry, side),
+          });
+        if (entry.kind === "localization")
+          choices.push({
+            label: `Create localization result from ${side}`,
+            description: "Checks vanilla ownership; opens existing result files without overwriting",
+            run: () => this.createLocalization(entry, side),
+          });
+      }
+    }
+    choices.push({ label: "Choose existing result file", run: () => this.linkResult(entry) });
+    if (this.session.results[entry.id])
+      choices.push({
+        label: "Open result",
+        description: this.session.results[entry.id],
+        run: () => this.editResult(entry),
+      });
+    for (const state of ["reviewed", "skipped"] as const)
+      choices.push({
+        label: state === "reviewed" ? "Mark reviewed" : "Skip for now",
+        description: "Records source snapshots; does not certify game compatibility",
+        run: async () => {
+          this.session!.reviews[entry.id] = {
+            status: state,
+            fingerprint: fingerprint(entry),
+            sites: structuredClone(entry.sites),
+          };
+          await this.persist();
+          this.changed();
+        },
+      });
+    if (this.session.reviews[entry.id]) {
+      for (const side of ["A", "B", "base"] as const)
+        if (this.session.roots[side])
+          choices.push({
+            label: `Compare last reviewed ${side} → current ${side}`,
+            run: () => this.previous(entry, side),
+          });
+      choices.push({
+        label: "Reopen review",
+        run: async () => {
+          delete this.session!.reviews[entry.id];
+          await this.persist();
+          this.changed();
+        },
+      });
+    }
+    const pick = await vscode.window.showQuickPick(choices, {
+      title: `${entry.name} · ${status(entry, this.session.reviews[entry.id])}`,
+      matchOnDescription: true,
+    });
+    if (pick) await pick.run();
+  }
+}
+
+export function registerCompatch(context: vscode.ExtensionContext, getCfg: () => PxConfig): void {
+  new CompatchView(context, getCfg);
+}

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -48,6 +48,7 @@ import { createTranslationCommand } from "./translation";
 import { createTranslationModCommand } from "./translationMod";
 import { openInfoDocsCommand, openVanillaExamplesCommand, updateInfoDocContext } from "./infoDocs";
 import { FocusMod, registerPxViews } from "./views";
+import { registerCompatch } from "./compatch/view";
 import { addDependencyModCommand } from "./dependencyMods";
 import { registerDashboardView, hiddenRows } from "./webviews/dashboard/view";
 import { actionGroups } from "./webviews/dashboard/actions";
@@ -346,6 +347,11 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     void vscode.commands.executeCommand("setContext", "px.isCk3Workspace", cfg.isCk3Workspace);
     // Context keys for anything a `when` clause may want to gate on later.
     void vscode.commands.executeCommand("setContext", "px.hasTiger", metaFor(cfg.gameId).tiger !== undefined);
+    void vscode.commands.executeCommand(
+      "setContext",
+      "px.compatchSemanticSupported",
+      metaFor(cfg.gameId).compatch !== null
+    );
     void vscode.commands.executeCommand(
       "setContext",
       "px.guiEditorSupported",
@@ -763,6 +769,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   context.subscriptions.push(errorLog);
   const focus = new FocusMod(context.workspaceState, () => cfg);
   const views = registerPxViews(context, lc, () => cfg, focus);
+  registerCompatch(context, () => cfg);
   // Hoisted: the Wiki commands above are registered before `views` exists, but
   // they only call this once the user opens the panel.
   function wikiDeps(): WikiDeps {

--- a/packages/vscode/src/webviews/dashboard/actions.ts
+++ b/packages/vscode/src/webviews/dashboard/actions.ts
@@ -66,6 +66,12 @@ export function actionGroups(meta: GameMeta, gameProblems: number): ActionGroup[
       label: "View",
       items: [
         {
+          label: "Compatch Workspace",
+          command: "px.openCompatch",
+          icon: "listTree",
+          tip: "Compare two mods or game versions, then edit a separate result mod.",
+        },
+        {
           label: "Event Graph",
           command: "px.showEventGraph",
           icon: "waypoints",

--- a/packages/vscode/test/compatch.test.ts
+++ b/packages/vscode/test/compatch.test.ts
@@ -1,0 +1,279 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import * as os from "node:os";
+import { ck3Meta } from "@px-lsp/server/games/ck3/meta";
+import { vic3Meta } from "@px-lsp/server/games/vic3/meta";
+import { eu5Meta } from "@px-lsp/server/games/eu5/meta";
+import { parseScript, parseLoc } from "@px-lsp/server/parser";
+import {
+  addFile,
+  emptyInventory,
+  fingerprint,
+  status,
+  scan,
+  validateRoots,
+  createResult,
+  resultPath,
+  seedFile,
+  hasVanillaLoc,
+  localizationSeed,
+  type Session,
+} from "../src/compatch/core";
+
+const support = ck3Meta.compatch;
+const event = (gold: number) =>
+  `namespace = demo\n@amount = 2\ndemo.1 = {\n immediate = { add_gold = ${gold} }\n}\n`;
+
+describe("compatch identities", () => {
+  it("matches an event across renamed files and keeps its file context", () => {
+    const inventory = emptyInventory();
+    addFile(inventory, "A", "events/original.txt", event(1), support);
+    addFile(inventory, "B", "events/overrides/new.txt", event(2), support);
+    const entry = [...inventory.entries.values()].find((e) => e.kind === "event")!;
+    expect(entry.sites.A[0].path).toBe("events/original.txt");
+    expect(entry.sites.B[0].path).toBe("events/overrides/new.txt");
+    expect(entry.sites.A[0].text).toContain("@amount = 2");
+    expect(status(entry)).toBe("different");
+    expect([...inventory.entries.values()].filter((e) => e.kind === "file")).toHaveLength(2);
+  });
+
+  it("preserves duplicates in one file and across files without choosing a winner", () => {
+    const inventory = emptyInventory();
+    addFile(inventory, "A", "events/a.txt", `${event(1)}\ndemo.1 = { hidden = yes }`, support);
+    addFile(inventory, "A", "events/b.txt", event(3), support);
+    const entry = [...inventory.entries.values()].find((e) => e.kind === "event")!;
+    expect(entry.sites.A).toHaveLength(3);
+    expect(status(entry)).toBe("multiple definitions");
+  });
+
+  it("matches localization across replace and ordinary folders, with separate languages", () => {
+    const inventory = emptyInventory();
+    addFile(
+      inventory,
+      "A",
+      "localization/replace/a_l_english.yml",
+      '\uFEFFl_english:\n key:0 "A"\n',
+      support
+    );
+    addFile(inventory, "B", "localization/english/b_l_english.yml", 'l_english:\n key:0 "B"\n', support);
+    addFile(inventory, "B", "localization/french/b_l_french.yml", 'l_french:\n key:0 "B"\n', support);
+    const entries = [...inventory.entries.values()].filter((e) => e.kind === "localization");
+    expect(entries).toHaveLength(2);
+    expect(entries.find((e) => e.name === "english:key")!.sites.B[0].path).toContain("english/b_");
+    expect(status(entries.find((e) => e.name === "french:key")!)).toBe("B only");
+  });
+
+  it("compares raw GUI files and gates semantic matching per game profile", () => {
+    for (const meta of [vic3Meta, eu5Meta]) {
+      expect(meta.compatch).toBeNull();
+      const inventory = emptyInventory();
+      addFile(inventory, "A", "events/a.txt", event(1), meta.compatch);
+      addFile(inventory, "B", "gui/window.gui", "types = {}", meta.compatch);
+      expect([...inventory.entries.values()].map((e) => e.kind)).toEqual(["file", "file"]);
+    }
+  });
+
+  it("ignores BOM and line endings for equality but retains exact review snapshots", () => {
+    const inventory = emptyInventory();
+    addFile(inventory, "A", "common/a.txt", "\uFEFFx = 1\r\n", support);
+    addFile(inventory, "B", "common/a.txt", "x = 1\n", support);
+    const entry = [...inventory.entries.values()][0];
+    expect(status(entry)).toBe("same");
+    const review = {
+      status: "skipped" as const,
+      fingerprint: fingerprint(entry),
+      sites: structuredClone(entry.sites),
+    };
+    expect(status(entry, review)).toBe("skipped");
+    entry.sites.B[0].text = "x = 2\n";
+    expect(status(entry, review)).toBe("sources changed");
+    expect(review.sites.B[0].text).toBe("x = 1\n");
+  });
+
+  it("reports malformed source text while preserving the full file for manual comparison", () => {
+    const inventory = emptyInventory();
+    addFile(inventory, "A", "events/bad.txt", "namespace = bad\nbad.1 = {", support);
+    addFile(inventory, "B", "localization/bad_l_english.yml", "broken", support);
+    expect(inventory.issues).toHaveLength(2);
+    expect(inventory.files.A.get("events/bad.txt")).toContain("bad.1");
+  });
+});
+
+describe("compatch filesystem and output", () => {
+  let root: string;
+  let session: Session;
+  beforeEach(async () => {
+    root = await fs.mkdtemp(path.join(os.tmpdir(), "px-compatch-"));
+    for (const dir of ["a", "b", "base", "output", "game"]) await fs.mkdir(path.join(root, dir));
+    session = {
+      version: 1,
+      gameId: "ck3",
+      localizationLanguage: "english",
+      roots: { A: path.join(root, "a"), B: path.join(root, "b"), base: null },
+      output: path.join(root, "output"),
+      protectedRoots: [path.join(root, "game")],
+      reviews: {},
+      results: {},
+    };
+  });
+  afterEach(async () => {
+    // mkdtemp returns an absolute task-owned directory, never a computed parent.
+    expect(path.dirname(root)).toBe(os.tmpdir());
+    expect(path.basename(root)).toMatch(/^px-compatch-/);
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  async function file(relative: string, text: string | Uint8Array) {
+    const target = path.join(root, relative);
+    await fs.mkdir(path.dirname(target), { recursive: true });
+    await fs.writeFile(target, text);
+  }
+
+  it("protects sources, game files, ancestors, and paths escaping the result", async () => {
+    await expect(validateRoots(session)).resolves.toBeUndefined();
+    await expect(validateRoots({ ...session, output: session.roots.A! })).rejects.toThrow("separate");
+    await expect(validateRoots({ ...session, output: root })).rejects.toThrow("separate");
+    await expect(validateRoots({ ...session, output: path.join(root, "game") })).rejects.toThrow("separate");
+    await expect(resultPath(session, "../a/stolen.txt")).rejects.toThrow("relative");
+    await expect(resultPath(session, session.roots.A!)).rejects.toThrow("relative");
+  });
+
+  it("rejects output junctions into a source and does not follow source links", async () => {
+    await fs.symlink(session.roots.A!, path.join(session.output, "linked"), "junction");
+    await expect(createResult(session, "linked/file.txt", "changed")).rejects.toThrow("link");
+    await file("b/common/original.txt", "original");
+    await fs.symlink(session.roots.B!, path.join(session.roots.A!, "linked"), "junction");
+    const inventory = await scan(
+      session,
+      support,
+      () => {},
+      () => false
+    );
+    expect(inventory.issues.join("\n")).toContain("symbolic link skipped");
+    expect(inventory.files.A.size).toBe(0);
+  });
+
+  it("never overwrites an edited result or a source", async () => {
+    const target = await createResult(
+      session,
+      "events/demo.txt",
+      seedFile("events/demo.txt", event(1), support)
+    );
+    await fs.writeFile(target, "manual work");
+    await expect(createResult(session, "events/demo.txt", "replacement")).rejects.toMatchObject({
+      code: "EEXIST",
+    });
+    expect(await fs.readFile(target, "utf8")).toBe("manual work");
+    expect(await fs.readdir(session.roots.A!)).toEqual([]);
+  });
+
+  it("retains removed reviews and optional base content without treating absence as deletion", async () => {
+    await file("a/events/a.txt", event(1));
+    await file("base/events/old.txt", event(0));
+    session.roots.base = path.join(root, "base");
+    const first = await scan(
+      session,
+      support,
+      () => {},
+      () => false
+    );
+    const entry = [...first.entries.values()].find((e) => e.kind === "event")!;
+    session.reviews[entry.id] = {
+      status: "reviewed",
+      fingerprint: fingerprint(entry),
+      sites: structuredClone(entry.sites),
+    };
+    await fs.unlink(path.join(root, "a/events/a.txt"));
+    await fs.unlink(path.join(root, "base/events/old.txt"));
+    const second = await scan(
+      session,
+      support,
+      () => {},
+      () => false
+    );
+    expect(second.entries.get(entry.id)!.sites).toEqual({ A: [], B: [], base: [] });
+    expect(status(second.entries.get(entry.id)!, session.reviews[entry.id])).toBe("sources changed");
+    expect(session.reviews[entry.id].sites.base[0].text).toContain("add_gold = 0");
+  });
+
+  it("cancels scans and reports binary/invalid UTF-8 text instead of decoding replacement characters", async () => {
+    await file("a/common/bad.txt", Uint8Array.from([255, 254, 1]));
+    await file("b/common/nul.txt", "a\0b");
+    const inventory = await scan(
+      session,
+      support,
+      () => {},
+      () => false
+    );
+    expect(inventory.issues).toHaveLength(2);
+    expect(inventory.entries.size).toBe(0);
+    await expect(
+      scan(
+        session,
+        support,
+        () => {},
+        () => true
+      )
+    ).rejects.toThrow("cancelled");
+  });
+
+  it("scans one localization language without reopening reviews for omitted languages", async () => {
+    await file("a/localization/english/a_l_english.yml", 'l_english:\n key:0 "English"\n');
+    await file("a/localization/french/a_l_french.yml", 'l_french:\n key:0 "French"\n');
+    const english = await scan(
+      session,
+      support,
+      () => {},
+      () => false
+    );
+    const entry = [...english.entries.values()].find((e) => e.kind === "localization")!;
+    expect(entry.name).toBe("english:key");
+    expect(english.files.A.size).toBe(1);
+    session.reviews[entry.id] = { status: "reviewed", fingerprint: fingerprint(entry), sites: entry.sites };
+    session.localizationLanguage = "french";
+    const french = await scan(
+      session,
+      support,
+      () => {},
+      () => false
+    );
+    expect(french.entries.has(entry.id)).toBe(false);
+    expect([...french.entries.values()].find((e) => e.kind === "localization")!.name).toBe("french:key");
+    session.localizationLanguage = "english";
+    const restored = await scan(
+      session,
+      support,
+      () => {},
+      () => false
+    );
+    expect(status(restored.entries.get(entry.id)!, session.reviews[entry.id])).toBe("reviewed");
+  });
+
+  it("writes full event files with BOM, namespace first, and every original event intact", () => {
+    const original = `# comment\n${event(1)}\ndemo.2 = { hidden = yes }\n`;
+    const seeded = seedFile("events/a.txt", original, support);
+    expect(seeded.startsWith("\uFEFFnamespace = demo\n")).toBe(true);
+    expect(seeded).toContain("# comment");
+    expect(seeded).toContain("demo.2");
+    expect(parseScript(seeded).errors).toEqual([]);
+    expect(() => seedFile("events/a.txt", "demo.1 = {}", support)).toThrow("namespace");
+    expect(() => seedFile("events/a.txt", "namespace = demo\ndemo.1 = {", support)).toThrow("errors");
+  });
+
+  it("routes selected localization using actual vanilla ownership and keeps the language/BOM", async () => {
+    await file("game/localization/english/base_l_english.yml", '\uFEFFl_english:\n vanilla_key:0 "Base"\n');
+    const directory = path.join(root, "game/localization");
+    expect(await hasVanillaLoc(directory, "english", "vanilla_key")).toBe(true);
+    expect(await hasVanillaLoc(directory, "english", "new_key")).toBe(false);
+    expect(await hasVanillaLoc(directory, "french", "vanilla_key")).toBe(false);
+    for (const vanilla of [true, false]) {
+      const seed = localizationSeed('l_english:\n vanilla_key:0 "Edited"\n', "localization", vanilla);
+      expect(seed.relative).toBe(`localization/${vanilla ? "replace" : "english"}/px_compatch_l_english.yml`);
+      const target = await createResult(session, seed.relative, seed.text);
+      const bytes = await fs.readFile(target);
+      expect([...bytes.subarray(0, 3)]).toEqual([239, 187, 191]);
+      expect(parseLoc(bytes.toString("utf8")).errors).toEqual([]);
+    }
+  });
+});

--- a/packages/vscode/test/compatchView.test.ts
+++ b/packages/vscode/test/compatchView.test.ts
@@ -1,0 +1,238 @@
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import * as os from "node:os";
+import type * as VSCode from "vscode";
+import { URI } from "vscode-uri";
+import type { Entry, Kind } from "../src/compatch/core";
+import type { PxConfig } from "../src/config";
+
+type Row = { group: Kind } | { entry: Entry } | { page: Kind; direction: number };
+interface Provider {
+  getChildren(row?: Row): Row[];
+  getTreeItem(row: Row): VSCode.TreeItem;
+}
+const ui = vi.hoisted(() => ({
+  commands: new Map<string, (row?: Row) => Promise<void>>(),
+  provider: undefined as Provider | undefined,
+  content: undefined as VSCode.TextDocumentContentProvider | undefined,
+  pick: vi.fn(),
+  folders: vi.fn(),
+  input: vi.fn(),
+  error: vi.fn(),
+  diff: vi.fn(),
+}));
+
+vi.mock("vscode", async () => {
+  const { URI } = await import("vscode-uri");
+  const disposable = { dispose() {} };
+  return {
+    Uri: URI,
+    EventEmitter: class {
+      event = () => disposable;
+      fire() {}
+      dispose() {}
+    },
+    ThemeIcon: class {
+      constructor(public id: string) {}
+    },
+    TreeItem: class {
+      constructor(public label: string) {}
+    },
+    TreeItemCollapsibleState: { Collapsed: 1 },
+    ProgressLocation: { Notification: 15 },
+    commands: {
+      registerCommand: (name: string, callback: (row?: Row) => Promise<void>) => {
+        ui.commands.set(name, callback);
+        return disposable;
+      },
+      executeCommand: async (command: string, ...args: unknown[]) => {
+        if (command === "vscode.diff") ui.diff(...args);
+      },
+    },
+    workspace: {
+      textDocuments: [],
+      registerTextDocumentContentProvider: (
+        _scheme: string,
+        provider: VSCode.TextDocumentContentProvider
+      ) => {
+        ui.content = provider;
+        return disposable;
+      },
+      onDidCloseTextDocument: () => disposable,
+      openTextDocument: async (uri: URI) => ({ uri }),
+    },
+    languages: { setTextDocumentLanguage: async () => {} },
+    window: {
+      createTreeView: (_id: string, options: { treeDataProvider: Provider }) => {
+        ui.provider = options.treeDataProvider;
+        return disposable;
+      },
+      createOutputChannel: () => ({ ...disposable, appendLine() {}, clear() {}, show() {} }),
+      showOpenDialog: ui.folders,
+      showQuickPick: ui.pick,
+      showInputBox: ui.input,
+      showErrorMessage: ui.error,
+      showWarningMessage: async () => undefined,
+      showTextDocument: async () => ({}),
+      withProgress: async (
+        _options: unknown,
+        run: (progress: { report(): void }, token: { isCancellationRequested: boolean }) => Promise<unknown>
+      ) => run({ report() {} }, { isCancellationRequested: false }),
+    },
+  };
+});
+
+import { registerCompatch } from "../src/compatch/view";
+
+let root: string;
+let context: VSCode.ExtensionContext;
+let cfg: PxConfig;
+beforeEach(async () => {
+  cfg = { gameId: "ck3", gamePath: null, locLanguage: "english" } as PxConfig;
+  vi.clearAllMocks();
+  ui.commands.clear();
+  root = await fs.mkdtemp(path.join(os.tmpdir(), "px-compatch-ui-"));
+  for (const folder of ["a/events", "b/events/override", "result", "storage"])
+    await fs.mkdir(path.join(root, folder), { recursive: true });
+  await fs.writeFile(
+    path.join(root, "a/events/original.txt"),
+    "namespace = demo\ndemo.1 = { hidden = yes }\n"
+  );
+  await fs.writeFile(
+    path.join(root, "b/events/override/other.txt"),
+    "namespace = demo\ndemo.1 = { hidden = no }\n"
+  );
+  context = {
+    subscriptions: [],
+    storageUri: URI.file(path.join(root, "storage")),
+  } as unknown as VSCode.ExtensionContext;
+  registerCompatch(context, () => cfg);
+});
+afterEach(async () => {
+  for (const disposable of context.subscriptions) disposable.dispose();
+  expect(path.dirname(root)).toBe(os.tmpdir());
+  expect(path.basename(root)).toMatch(/^px-compatch-ui-/);
+  await fs.rm(root, { recursive: true, force: true });
+});
+
+const run = (command: string, row?: Row) => ui.commands.get(command)!(row);
+function choose(label: string) {
+  ui.pick.mockImplementationOnce(async (items: { label: string }[]) =>
+    items.find((item) => item.label === label)
+  );
+}
+function eventRow(): Row {
+  return ui.provider!.getChildren({ group: "event" })[0];
+}
+async function setup() {
+  for (const folder of ["a", "b", "result"])
+    ui.folders.mockResolvedValueOnce([URI.file(path.join(root, folder))]);
+  ui.pick.mockResolvedValueOnce("Compare without a base");
+  await run("px.openCompatch");
+  expect(ui.error).not.toHaveBeenCalled();
+}
+
+it("drives cross-file diff, editable result, persisted review, source update and reload through registered commands", async () => {
+  await setup();
+  const row = eventRow();
+  await run("px.compareCompatch", row);
+  const [left, right] = ui.diff.mock.lastCall! as [VSCode.Uri, VSCode.Uri];
+  expect(left.scheme).toBe("px-compatch");
+  expect(right.scheme).toBe("px-compatch");
+  expect(await ui.content!.provideTextDocumentContent(left, {} as VSCode.CancellationToken)).toContain(
+    "hidden = yes"
+  );
+  expect(await ui.content!.provideTextDocumentContent(right, {} as VSCode.CancellationToken)).toContain(
+    "hidden = no"
+  );
+
+  choose("Create result from full A file");
+  await run("px.compatchActions", row);
+  const result = path.join(root, "result/events/original.txt");
+  expect(await fs.readFile(result, "utf8")).toContain("demo.1");
+  choose("Compare B → result");
+  await run("px.compatchActions", row);
+  expect((ui.diff.mock.lastCall![1] as VSCode.Uri).scheme).toBe("file");
+
+  choose("Mark reviewed");
+  await run("px.compatchActions", row);
+  expect(ui.provider!.getTreeItem(row).description).toBe("reviewed");
+  await fs.writeFile(result, "my manual result");
+  await fs.writeFile(
+    path.join(root, "b/events/override/other.txt"),
+    "namespace = demo\ndemo.1 = { hidden = yes immediate = { add_gold = 1 } }\n"
+  );
+  await run("px.refreshCompatch");
+  expect(ui.provider!.getTreeItem(eventRow()).description).toBe("sources changed");
+  expect(await fs.readFile(result, "utf8")).toBe("my manual result");
+  choose("Compare last reviewed B → current B");
+  await run("px.compatchActions", eventRow());
+  const old = ui.diff.mock.lastCall![0] as VSCode.Uri;
+  expect(await ui.content!.provideTextDocumentContent(old, {} as VSCode.CancellationToken)).toContain(
+    "hidden = no"
+  );
+
+  for (const disposable of context.subscriptions) disposable.dispose();
+  context.subscriptions.length = 0;
+  registerCompatch(context, () => cfg);
+  await run("px.openCompatch");
+  expect(ui.provider!.getTreeItem(eventRow()).description).toBe("sources changed");
+  expect(ui.error).not.toHaveBeenCalled();
+});
+
+it("does not start or persist a partial session when folder selection is cancelled", async () => {
+  ui.folders.mockResolvedValueOnce(undefined);
+  await run("px.openCompatch");
+  expect(ui.provider!.getChildren()).toEqual([]);
+  expect(await fs.readdir(path.join(root, "storage"))).toEqual([]);
+  expect(ui.error).not.toHaveBeenCalled();
+});
+
+it("pages large lists and resets the page when a filter narrows the results", async () => {
+  await fs.writeFile(
+    path.join(root, "a/events/many.txt"),
+    "namespace = many\n" + Array.from({ length: 250 }, (_, i) => `many.${i} = { hidden = yes }`).join("\n")
+  );
+  await setup();
+  const first = ui.provider!.getChildren({ group: "event" });
+  expect(first.filter((row) => "entry" in row)).toHaveLength(200);
+  const next = first.find((row) => "page" in row)!;
+  await run("px.compatchPage", next);
+  expect(ui.provider!.getChildren({ group: "event" }).filter((row) => "entry" in row)).toHaveLength(51);
+  ui.input.mockResolvedValueOnce("demo.1");
+  await run("px.filterCompatch");
+  const filtered = ui.provider!.getChildren({ group: "event" });
+  expect(filtered).toHaveLength(1);
+  expect("entry" in filtered[0] && filtered[0].entry.name).toBe("demo.1");
+  expect(ui.error).not.toHaveBeenCalled();
+});
+
+it("creates routed localization results and preserves an existing edited result", async () => {
+  cfg.gamePath = path.join(root, "game");
+  for (const directory of ["game/localization/english", "a/localization/replace"])
+    await fs.mkdir(path.join(root, directory), { recursive: true });
+  await fs.writeFile(
+    path.join(root, "game/localization/english/base_l_english.yml"),
+    'l_english:\n existing:0 "Vanilla"\n'
+  );
+  await fs.writeFile(
+    path.join(root, "a/localization/replace/mod_l_english.yml"),
+    'l_english:\n existing:0 "Modified"\n new_key:0 "New"\n'
+  );
+  await setup();
+  const rows = ui.provider!.getChildren({ group: "localization" });
+  for (const row of rows) {
+    choose("Create localization result from A");
+    await run("px.compatchActions", row);
+  }
+  const replacement = path.join(root, "result/localization/replace/px_compatch_l_english.yml");
+  const ordinary = path.join(root, "result/localization/english/result_l_english.yml");
+  expect(await fs.readFile(replacement, "utf8")).toContain('existing:0 "Modified"');
+  expect(await fs.readFile(ordinary, "utf8")).toContain('new_key:0 "New"');
+  await fs.writeFile(replacement, "manual localization");
+  choose("Create localization result from A");
+  await run("px.compatchActions", rows[0]);
+  expect(await fs.readFile(replacement, "utf8")).toBe("manual localization");
+  expect(ui.error).not.toHaveBeenCalled();
+});


### PR DESCRIPTION
WIP: tracked by #66. Completion requires the Vanilla / New Game Version / Mod update workflow, file filtering and routine upstream carry-over described there. This PR currently provides the manual comparison foundation.

CK3 overrides can define the same event or localization key in different files, which file-path diffs alone cannot match. Add a Compatch Workspace that compares events by ID and localization by language and key, with ordinary file diffs for other content and games.

Sources open as read-only snapshots. Users can compare an optional base, edit a separate result mod, and save reviews that reopen after source changes. Event output copies full files; localization output checks vanilla ownership and uses the existing sibling-file selection for new keys. Single-event priority export and GUI template matching remain deferred.

Validation:
- 57 focused tests pass, including command workflows, persistence, duplicate definitions, pagination, language switching and output protection.
- Typecheck, lint and game-boundary checks pass.
- Generated event and localization files pass installed CK3 Tiger with zero reports.
- Full installed CK3 scan with English selected: about 14 seconds, 9,823 event IDs and 287,906 localization keys. Lists page at 200 entries.
- Test VSIX packaged and installed successfully.

## Summary by Sourcery

Add a safe Compatch Workspace for reviewing cross-file CK3 event and localization differences and producing changes in a separate result mod.

New Features:
- Add a Compatch Workspace for comparing CK3 events by ID, localization by language and key, and other content by file path.
- Support optional base sources, read-only source snapshots, separate editable result mods, saved reviews, source-change detection, filtering, pagination, scan notes, and localization language switching.
- Provide safe result creation for full event files and vanilla-aware localization routing, while preserving existing result files.

Bug Fixes:
- Prevent source files, protected game data, and linked paths from being overwritten through result operations.
- Preserve duplicate definitions and removed reviewed entries without assuming winners or treating missing content as deletion instructions.

Enhancements:
- Gate semantic Compatch comparisons by game profile, with Victoria 3 and EU5 remaining file-comparison-only.
- Expose Compatch commands, sidebar view, walkthrough guidance, dashboard access, and CK3 metadata configuration.

Documentation:
- Document Compatch Workspace workflows, review persistence, localization handling, scan behavior, limitations, and safety expectations.

Tests:
- Add focused coverage for cross-file identity matching, duplicate definitions, persistence, pagination, language switching, malformed and binary inputs, output protection, result seeding, and localization routing.