### PR TITLE
Add configurable completions, snippet exports and preview backgrounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ default amount of configuration is none. Full walkthrough:
 
 ## What you get
 
+Choose minimal completion templates, full examples or names only, with insertion previews and expected-value hints. Export the generated snippets to a searchable, printable catalogue. The flag, coat-of-arms and DDS tools also offer dark, light and custom preview backgrounds.
+
 ![The Project panel](packages/vscode/media/screenshots/project-panel-compact.png)
 
 *The Project panel: the game is auto-detected, and every workspace mod carries

--- a/docs/EMBEDDING.md
+++ b/docs/EMBEDDING.md
@@ -168,6 +168,8 @@ concrete:
 
 Set `indexAssets: false` to skip graphics `.asset` definition and reference indexing in all roots. It defaults to `true` for profiles that support `.asset` files. Send the changed settings through `paradox/configChanged` to rebuild the index without a restart. This does not disable open-file syntax features or on-demand texture previews.
 
+Set `completionMode` to `minimal` (the default), `examples`, or `names` to control ordinary script keyword insertion. Minimal adds the documented operator and blank values and the fields from valid documented examples or scripted parameters, omitting fields marked optional. Examples restores the documented example values and scripted-call parameters. Names inserts only the keyword. Explicit definition templates and the `paradox/snippets` catalogue retain their full templates in every mode. The standard `snippetSupport` capability still decides whether inserts carry tabstops or plain text. This setting applies through `paradox/configChanged` without an index rebuild. Resolving a completion adds an insertion preview and expected-value descriptions from the token documentation or the definition's `@param` tags. Example values are not treated as confirmed datatypes. These hints are documentation only; `insertText` is unchanged.
+
 The remaining settings (`parentPaths`, `scopeInlayHints`, `diagnosticsIgnore`,
 `diagnosticsIgnorePatterns`, `diagnosticsVanilla`) are documented in
 `docs/PROTOCOL.md`. Push the whole settings object again as
@@ -678,3 +680,7 @@ license as `NODE-LICENSE`, the bundled CK3 wiki token lists are CC BY-SA 3.0
 (`data/ck3/wikidocs/ATTRIBUTION.md`) and the EU5 schema table derives from
 MIT-licensed community CWT rules. `THIRD-PARTY-NOTICES.md` ships in both
 archives with the full texts.
+
+### Exporting generated snippets
+
+Call `paradox/snippetCatalogue` with `{}` for the full active-game catalogue, without requiring an open document or applying the cursor picker's cap. The response includes engine templates, definition and child-block skeletons, and effective indexed scripted calls. Every available variant includes snippet syntax, plain insertion text and completion-preview Markdown. An `indexing: true` response has no entries; request again after indexing finishes. VS Code uses this request for `px.exportSnippets`, which saves a self-contained, searchable HTML file with copy and print controls. See the Protocol Reference for the response fields.

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -81,6 +81,7 @@ interface ParadoxSettings {
   parentPaths: string[];       // dependency mods, load order, base first
   workspaceMods?: string[];    // mods being EDITED (reference indexing + diagnostics)
   locLanguage: string;         // "english", ...
+  completionMode?: "minimal" | "examples" | "names"; // default minimal
   scopeInlayHints: boolean;
   indexAssets?: boolean;      // default true; index .asset definitions and references
   hoverDetail?: "compact" | "standard" | "full"; // how much a hover shows; default "standard"
@@ -98,6 +99,8 @@ interface ParadoxSettings {
 ```
 
 `indexAssets` defaults to `true`. Set it to `false` to skip `.asset` definition and reference indexing across workspace mods, dependency mods and vanilla, including on-demand reference searches. Changing it through `paradox/configChanged` rebuilds the index without a restart. Open-file syntax features and on-demand texture previews remain available. Support for `.asset` indexing comes from the active game profile.
+
+`completionMode` controls ordinary script keyword insertion. `minimal` (the default) inserts the documented operator and blank values and the fields from valid documented examples or scripted parameters, omitting fields marked optional, with no example values. `examples` restores full documented blocks and scripted-call parameter snippets. `names` inserts only keyword names. Unknown syntax stays a name in Minimal mode. Explicit definition/child-block snippet items and `paradox/snippets` keep their full templates. Snippet-capable clients receive `CompletionItemKind.Snippet` for generated templates, so the editor shows its snippet icon. Reference/value completions are unchanged. Clients without standard LSP snippet support receive the same punctuation as plain text. Send `paradox/configChanged` to change the mode without restarting or rebuilding the index. Resolving a completion adds an insertion preview and expected-value descriptions from the token documentation or the definition's `@param` tags. Example values are not treated as confirmed datatypes. These hints are documentation only; `insertText` is unchanged.
 
 Every capability in `client` is independent and defaults to **off**, so a
 client declares exactly what it implements and the server tailors its output
@@ -797,3 +800,11 @@ capability at a time. A client declaring nothing (every field off) gets:
 - index health is mirrored to `window/logMessage` regardless: a startup line
   naming the resolved bundled-data folders (or their absence) and `status:`
   lines with token/definition counts on indexing transitions.
+
+### `paradox/snippetCatalogue`
+
+Request with `{}` to export every generated script template for the active game. No open document, cursor filter or item cap applies. The response is `{ gameId, gameName, generatedAt, indexing, entries }`; `generatedAt` is an ISO timestamp. While indexing, `indexing` is true and `entries` is empty; request again after the index finishes.
+
+Each entry has `id`, `label`, `category`, `detail`, and `variants`. Categories are `Engine`, `Definitions`, `Child blocks`, and `Scripted calls`. Each variant carries `label` (`Minimal`, `Examples`, `All fields`, or `Template`), `snippet`, `plain`, and `preview` (completion-details Markdown). Engine templates use loaded documentation, skeletons use the active profile, and scripted calls use effective indexed definitions. Unknown syntax contributes no template. Fixed JSON snippets and GUI completions are outside this script catalogue.
+
+This request is independent of `completionMode` and client snippet support: every available variant includes both insertion formats. Hosts can build searchable or printable exports from the response. The VS Code command is `px.exportSnippets` (Paradox: Export Generated Snippets).

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -76,6 +76,81 @@ For testers who should try a build before it is released, send them the vsix
 file directly; they install it via Extensions panel → `…` menu →
 "Install from VSIX".
 
+## Major game update checklist
+
+Use a fresh copy of this checklist for each major CK3, Victoria 3 or EU5 update. Record the game, previous and new game versions, enabled DLC, toolkit commit and test workspace in the update PR. Keep local paths in `dev-paths.json` or environment variables. Leave tasks unchecked until verified; record a reason for anything that does not apply.
+
+Reloading game documentation updates runtime language knowledge and generated snippets. It does not rebuild bundled harvests or update fixed snippets and file templates. Check all three sources below.
+
+### Establish the baseline
+
+- [ ] Create an update branch and save the previous game documentation and generated snippet export before replacing them. Use `Paradox: Export Generated Snippets (HTML / Print)` for the catalogue.
+- [ ] Read the game's official patch notes for script, GUI, localization, asset, save-format and mod-loading changes. Record the changes that could affect the toolkit, with source links.
+- [ ] Confirm the selected game install and logs belong to the new version. Update the ignored development paths, and use a scratch mod for writer and game tests.
+- [ ] Capture completion ranking and index performance before changing toolkit code or bundled data. Keep the workspace and corpus consistent for the comparison; record any unavoidable game-file changes.
+
+### Refresh game documentation
+
+- [ ] Generate fresh `script_docs` from the updated game in debug mode. Check timestamps, nonempty output and parser coverage for effects, triggers, event targets and modifiers, plus on-actions where available.
+- [ ] Generate fresh `DumpDataTypes` output where supported. Check that the loader finds the game's output location and format, including a sibling logs directory when script docs are in a docs directory.
+- [ ] Run `Paradox: Reload Game Data (script_docs)`. Confirm added, changed and removed names match the fresh dumps, and that fallback wiki data does not restore removed names in a covered category.
+- [ ] Check documentation format changes against the parsers. Add focused fixtures for changed syntax, parameter descriptions and optional-field markers.
+- [ ] Review bundled documentation used without local dumps. Refresh the relevant source snapshots and attribution deliberately; check fallback behavior with local logs unavailable.
+
+### Update profiles and bundled data
+
+- [ ] Audit new, renamed and moved vanilla folders with `audit-schema-coverage.ts --game <id>`. Resolve or document every gap before harvesting definition skeletons.
+- [ ] Check the affected GameProfile's definition kinds, root keys and scopes, references, value vocabularies and supported tools against the updated game sources. Keep game-specific rules inside the profile boundary.
+- [ ] Regenerate completion frequencies, definition skeletons, GUI schema and asset vocabulary for the affected game. Confirm its game path exists first: the skeleton generator can write an empty table without it.
+- [ ] For CK3, regenerate structure documentation from `_*.info`. If refreshing bundled datatype documentation, update its source snapshot before running `build-data-types-json.ts`.
+- [ ] For EU5, decide whether the pinned CWT schema needs updating. If it does, inspect the importer's uncovered types and update the source pin and notices together.
+- [ ] Review harvest counts and diffs for missing folders, empty output, removed entries and changed common fields. Repeat generation against unchanged inputs and confirm deterministic output apart from timestamps.
+
+### Check snippets and file templates
+
+- [ ] Export the refreshed generated snippet catalogue after indexing finishes. Compare it with the baseline for added, changed and removed commands and definitions.
+- [ ] Spot-check minimal insertion for changed commands: braces and assignment signs, documented required fields, optional fields omitted, useful cursor positions and tab order. Do not treat a field's common occurrence in vanilla as proof that it is required.
+- [ ] Check example and all-fields variants against fresh sources. Confirm nested blocks, alternatives, defaults and optional fields produce useful code rather than pasted explanatory prose.
+- [ ] Check completion previews and datatype hints against the new docs. Keep unknown types explicit; do not invent a type or default when the source does not establish one.
+- [ ] Audit fixed VS Code snippets in `packages/vscode/snippets/` and GameProfile scaffolds against the updated game. They need manual review even when generated snippets have refreshed.
+- [ ] Check Minimal, Examples and Names completion modes, snippet icons in VS Code, and plain-text insertion for clients without snippet support. Check any aliases or migrated templates for missing or duplicate suggestions.
+- [ ] Generate representative files in the scratch mod. Validate their syntax with the supported tiger tool and load them in the game where needed; check BOM, localization naming and event namespace requirements.
+
+### Check editor and tool behavior
+
+- [ ] Try completion, hover, navigation, references and structural diagnostics on representative updated vanilla definitions and mod overrides. Keep vanilla read-only and free of diagnostics; scope inference must annotate rather than hide candidates.
+- [ ] Check localization lookup, new-key writing and vanilla-key replacement, including language headers, filenames, BOM and override order.
+- [ ] Check changed GUI widget properties, datafunctions and layout behavior with real game examples. Verify GUI editing and previews against the updated game.
+- [ ] Open representative DDS textures and check format decoding, alpha and export. Check flag and coat-of-arms assets and editors for games whose profiles support them.
+- [ ] Check event graphs, file creators and other tools affected by changed definitions. Review save schemas, descriptors, launch options and log discovery when the patch changes them.
+- [ ] Reindex an existing mod workspace and check cache refresh, game selection and multi-mod override order. Confirm changed vanilla content is visible without stale entries.
+- [ ] Check tiger compatibility and diagnostics integration for each supported profile. Record any tool or feature that does not yet support the new game version.
+
+### Verify and prepare the toolkit release
+
+- [ ] Run focused tests for changed parsers and features, typecheck, lint and the full suite for the major update. Compile first when tests exercise a bundled server; run `node scripts/check-game-boundary.mjs` for server changes.
+- [ ] Compare before/after `fuzzy-diag` and `rank-eval` results for completion or frequency changes. Review intended ranking shifts and investigate regressions.
+- [ ] Record before/after index and completion performance for affected server work, following `docs/PERFORMANCE.md`. Add the release performance-history row and keep machine paths out of tracked results.
+- [ ] Check VS Code and bare LSP behavior, including clients without snippets, file links or client commands. Check the Studio-facing contract where affected, and run representative checks for the other game profiles.
+- [ ] Run `pnpm run package:test`, reload VS Code with `Developer: Reload Window`, and try the installed build. Smoke-test the standalone server artifacts and confirm each ships its required per-game data.
+- [ ] Write changelog entries for changed packages. In the release PR, record tested game versions, DLC coverage and known limitations, refresh source notices, and update protocol/embedding docs plus their wiki mirrors if contracts changed.
+- [ ] Hand the verified release PR to the maintainer for merge and release. Treat support for the new game version as verified only after the required checks pass; document any remaining unsupported features.
+
+### Working commands
+
+Run the relevant checks from the repository root. These commands verify an update; they do not fetch new game documentation or regenerate the harvests for you.
+
+```bash
+pnpm run typecheck
+pnpm run lint
+pnpm run compile
+pnpm exec vitest run
+node scripts/check-game-boundary.mjs
+pnpm run package:test
+```
+
+Use the per-game regeneration commands below for bundled data, and the measurement recipes in `docs/PERFORMANCE.md` for performance comparisons.
+
 ## Regenerating bundled data (per game patch)
 
 The per-game generators take `--game <id>` and default to `ck3`; each reads its
@@ -83,7 +158,7 @@ paths from that game's `dev-paths.json` slots. Build and run them the usual
 way:
 
 ```bash
-npx esbuild scripts/build-freqs.ts --bundle --platform=node --outfile=dist/build-freqs.cjs
+pnpm exec esbuild scripts/build-freqs.ts --bundle --platform=node --outfile=dist/build-freqs.cjs
 node dist/build-freqs.cjs                # ck3
 node dist/build-freqs.cjs --game vic3    # vic3
 ```
@@ -93,6 +168,9 @@ node dist/build-freqs.cjs --game vic3    # vic3
 | CK3 structure docs | `build-structures-json.ts` | `packages/server/data/ck3/structures.json` (CK3 only: no other game ships `_*.info` docs) |
 | GUI widget schema | `build-gui-schema.ts [--game <id>]` | `packages/server/data/<id>/guiSchema.json` |
 | Completion frequencies | `build-freqs.ts [--game <id>]` | `packages/server/data/<id>/freqs.json` |
+| Definition skeletons | `build-skeletons.ts [--game <id>]` | `packages/server/data/<id>/skeletons.json` |
+| Asset vocabulary | `build-asset-vocabulary.ts [--game <id>]` | `packages/server/data/<id>/assetVocabulary.json` |
+| CK3 bundled datatypes | `build-data-types-json.ts` | `packages/server/data/ck3/dataTypes.json`, from bundled `wikidocs/Data_types.md`, not live dumps |
 | Schema coverage audit | `audit-schema-coverage.ts [--game <id>]` | stdout; gaps should be 0 or documented |
 | EU5 schema table | `import-cwt-types.ts <path-to-cwtools-eu5-config-clone>` | `packages/server/src/games/eu5/schema.generated.ts` |
 

--- a/docs/release/0.4.3.md
+++ b/docs/release/0.4.3.md
@@ -1,0 +1,9 @@
+# Paradox Modding Toolkit 0.4.3 (beta)
+
+- Choose dark, light or custom backgrounds in the Flag Builder, Coat of Arms Designer and DDS viewer. Controls sit at the bottom left, with reset to default and saved workspace preferences.
+- Completions now insert minimal templates with documented fields and Tab stops. Use `px.completion.mode` to switch to full examples or names only.
+- See insertion previews and expected-value hints in completion details. Generated templates use the snippet icon.
+- Export all generated snippets to a searchable HTML catalogue with variants, copy controls and printing. Run **Paradox: Export Generated Snippets (HTML / Print)**.
+- Add a major-game-update maintenance checklist and refresh the GitHub and Marketplace presentation.
+
+Includes `@px-lsp/server` 0.3.4 and `@px-lsp/protocol` 0.2.4. Requires VS Code 1.91 or newer.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "px-lsp",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "private": true,
   "license": "GPL-3.0-or-later",
   "engines": {

--- a/packages/protocol/CHANGELOG.md
+++ b/packages/protocol/CHANGELOG.md
@@ -6,7 +6,13 @@ the shared helpers change. Before the split it moved inside the extension's
 version (up to 0.3.2); that history is in the extension changelog
 (`packages/vscode/CHANGELOG.md`).
 
-## Unreleased
+## 0.2.4
+
+Ships with the toolkit's 0.4.3 release.
+
+- Add `paradox/snippetCatalogue` for uncapped exports of engine templates, definition skeletons and effective scripted calls, including every variant and its preview.
+
+- Add optional `ParadoxSettings.completionMode` (`minimal`, `examples`, `names`), applied on initialization and configuration changes; the default is `minimal`.
 
 ## 0.2.3
 

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@px-lsp/protocol",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "license": "GPL-3.0-or-later",
   "description": "Wire contract (custom LSP requests/notifications, settings types) and shared helpers for the px-lsp language server and its clients.",
   "keywords": [

--- a/packages/protocol/src/protocol.ts
+++ b/packages/protocol/src/protocol.ts
@@ -39,6 +39,8 @@ export interface ParadoxSettings {
    * every distinct meaning.
    */
   hoverDetail?: "compact" | "standard" | "full";
+  /** Keyword completion inserts punctuation, documented examples, or names only. Default minimal. */
+  completionMode?: "minimal" | "examples" | "names";
   /** Custom era calendar (total-conversion mods): how script dates display in
    * game. Absent = no calendar features. Shape: calendar.ts `CalendarSetting`;
    * the server sanitizes it on intake, so clients may pass raw JSON. */
@@ -1750,6 +1752,30 @@ export interface SnippetItem {
 export interface SnippetsResult {
   /** Skeletons first (definition, then its child blocks), then engine tokens. */
   snippets: SnippetItem[];
+}
+
+/** Complete generated script-template catalogue for the active game; no cursor or cap. */
+export const snippetCatalogueRequest = "paradox/snippetCatalogue";
+export interface SnippetCatalogueEntry {
+  id: string;
+  label: string;
+  category: "Engine" | "Definitions" | "Child blocks" | "Scripted calls";
+  detail: string;
+  variants: Array<{
+    label: "Minimal" | "Examples" | "All fields" | "Template";
+    snippet: string;
+    plain: string;
+    /** Completion-details markdown, including insertion preview and value hints. */
+    preview: string;
+  }>;
+}
+export interface SnippetCatalogueResult {
+  gameId: string;
+  gameName: string;
+  generatedAt: string;
+  /** True if the snapshot was requested before the index finished. */
+  indexing: boolean;
+  entries: SnippetCatalogueEntry[];
 }
 
 /**

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -6,7 +6,15 @@ changes. Before the split it moved inside the extension's version (up to
 0.3.2); that history is in the extension changelog
 (`packages/vscode/CHANGELOG.md`).
 
-## Unreleased
+## 0.3.4
+
+Ships with the toolkit's 0.4.3 release.
+
+- Add `paradox/snippetCatalogue` for uncapped exports of engine templates, definition skeletons and effective scripted calls, including every variant and its preview.
+
+- Show insertion previews and expected-value descriptions in completion details, using game documentation and scripted-effect `@param` comments. Keep preview hints out of inserted code and label undocumented types explicitly.
+
+- Add selectable keyword insertion modes: Minimal (the default), Examples and Names. Minimal keeps documented fields with blank values and Tab stops, omitting fields marked optional. Generated templates use the snippet icon; clients without snippet support receive plain text.
 
 ## 0.3.3
 

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@px-lsp/server",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "license": "GPL-3.0-or-later",
   "description": "Language server for Paradox script (Crusader Kings III first), usable over node-ipc or stdio from any LSP client.",
   "keywords": [

--- a/packages/server/src/features/blockSnippets.ts
+++ b/packages/server/src/features/blockSnippets.ts
@@ -96,7 +96,11 @@ interface Body {
 }
 
 /** Pure extractor (exported for the accept/reject table in the tests). */
-export function extractBlockTemplate(name: string, usage: string | undefined): BlockTemplate | null {
+export function extractBlockTemplate(
+  name: string,
+  usage: string | undefined,
+  minimal?: { optionalFields: ReadonlySet<string> }
+): BlockTemplate | null {
   if (!usage) return null;
   const stripped = stripOptionalComments(usage.replace(/\r/g, ""));
   if (!stripped) return null;
@@ -120,9 +124,9 @@ export function extractBlockTemplate(name: string, usage: string | undefined): B
   const open = text.indexOf("{");
   const close = matchingBrace(text, open);
   // Unbalanced, or something follows the block: not a template we can trust.
-  if (close < 0 || text.slice(close + 1).trim() !== "") return null;
+  if (close < 0 || (!minimal && text.slice(close + 1).trim() !== "")) return null;
 
-  const parser = new BodyParser(text, open + 1, optionalLines);
+  const parser = new BodyParser(text, open + 1, optionalLines, Boolean(minimal));
   const body = parser.parseBody();
   if (body === null) return null;
   // Every accepted "optional" comment must have landed on an item. One that did
@@ -130,10 +134,19 @@ export function extractBlockTemplate(name: string, usage: string | undefined): B
   // OPENS a nested block) says something about the example we cannot express.
   for (const line of optionalLines) if (!parser.markedLines.has(line)) return null;
 
-  const minimal = { snippet: render(name, body, true, false), plain: render(name, body, false, false) };
-  if (!hasOptional(body)) return minimal;
+  if (minimal) {
+    for (const item of body.items) {
+      if (item.key && (item.key.alts ?? [item.key.text]).some((key) => minimal.optionalFields.has(key))) {
+        item.optional = true;
+      }
+    }
+    return { snippet: render(name, body, true, false, true), plain: render(name, body, false, false, true) };
+  }
+
+  const standard = { snippet: render(name, body, true, false), plain: render(name, body, false, false) };
+  if (!hasOptional(body)) return standard;
   return {
-    ...minimal,
+    ...standard,
     full: { snippet: render(name, body, true, true), plain: render(name, body, false, true) },
   };
 }
@@ -212,7 +225,8 @@ class BodyParser {
   constructor(
     private readonly text: string,
     private i: number,
-    private readonly optionalLines: Set<number> = new Set()
+    private readonly optionalLines: Set<number> = new Set(),
+    private readonly omitParenthesizedOptional = false
   ) {
     this.lineAt = new Array<number>(text.length);
     let line = 0;
@@ -241,6 +255,9 @@ class BodyParser {
         return { items, truncated: false };
       }
       if (TRUNCATE.some((m) => this.text.startsWith(m, this.i))) {
+        if (this.omitParenthesizedOptional && this.text.startsWith("(optional)", this.i) && items.length) {
+          items[items.length - 1].optional = true;
+        }
         const close = matchingBrace(this.text, this.blockStart());
         if (close < 0) return null;
         this.i = close + 1;
@@ -307,8 +324,8 @@ class BodyParser {
 // ---- rendering -------------------------------------------------------------
 
 /** `all` = the "all fields" form; false drops what the example called optional. */
-function render(name: string, body: Body, snippet: boolean, all: boolean): string {
-  return `${name} = {\n${renderBody(body, "\t", snippet, { n: 0 }, all).join("")}}`;
+function render(name: string, body: Body, snippet: boolean, all: boolean, blank = false): string {
+  return `${name} = {\n${renderBody(body, "\t", snippet, { n: 0 }, all, blank).join("")}}`;
 }
 
 function renderBody(
@@ -316,24 +333,29 @@ function renderBody(
   indent: string,
   snippet: boolean,
   counter: { n: number },
-  all: boolean
+  all: boolean,
+  blank: boolean
 ): string[] {
   const lines: string[] = [];
   for (const item of body.items) {
     if (item.optional && !all) continue;
     if (item.key === null) {
-      lines.push(`${indent}${leaf(item.value, snippet, counter)}\n`);
+      lines.push(
+        `${indent}${blank ? (snippet ? `$${++counter.n}` : "") : leaf(item.value, snippet, counter)}\n`
+      );
       continue;
     }
     // A key is known text, not a hole — only an `a/b/c` key is a choice.
     const key = item.key.alts ? leaf(item.key, snippet, counter) : item.key.text;
     if ("items" in item.value) {
       lines.push(`${indent}${key} = {\n`);
-      lines.push(...renderBody(item.value, indent + "\t", snippet, counter, all));
+      lines.push(...renderBody(item.value, indent + "\t", snippet, counter, all, blank));
       lines.push(`${indent}}\n`);
       continue;
     }
-    lines.push(`${indent}${key} = ${leaf(item.value, snippet, counter)}\n`);
+    lines.push(
+      `${indent}${key} = ${blank ? (snippet ? `$${++counter.n}` : "") : leaf(item.value, snippet, counter)}\n`
+    );
   }
   // An empty or cut-short body leaves the cursor a place to land; in plain mode
   // there is nothing meaningful to write there.

--- a/packages/server/src/features/completion.ts
+++ b/packages/server/src/features/completion.ts
@@ -73,6 +73,8 @@ import { assetDirContext, provideAssetDirCompletion, provideBareNameCompletion }
 import { assetCompletion } from "./assetLanguage";
 import { snippetSupport } from "../clientMode";
 import { blockTemplateFor } from "./blockSnippets";
+import { minimalTokenInsert, scriptedCallTemplate, syntaxInsert } from "./completionInsert";
+import { withCompletionPreview } from "./completionPreview";
 import { skeletonsAt } from "./definitionSkeletons";
 
 /** Cap on items per response; the client re-queries per keystroke (isIncomplete). */
@@ -128,7 +130,13 @@ const STRUCTURE_VALUE_HINT: Record<string, string> = {
   block: "{ … }",
 };
 
-function structureItem(spec: KeySpec, kind: string, rank: number, allowSnippet: boolean): CompletionItem {
+function structureItem(
+  spec: KeySpec,
+  kind: string,
+  rank: number,
+  allowSnippet: boolean,
+  minimal: boolean
+): CompletionItem {
   const item: CompletionItem = { label: spec.key, kind: CompletionItemKind.Keyword };
   const hint = spec.values
     ? spec.values.startsWith("enum:")
@@ -141,8 +149,9 @@ function structureItem(spec: KeySpec, kind: string, rank: number, allowSnippet: 
   item.sortText = TIER_STRUCTURE + rankBucket(rank) + SRC_MOD + spec.key;
   // A key the schema says opens a block inserts the block: zero inference, the
   // KeySpec already carries the fact.
-  if (allowSnippet && spec.values === "block") {
-    setInsert(item, `${spec.key} = {\n\t$0\n}`, `${spec.key} = {\n\t\n}`);
+  if (allowSnippet && (spec.values === "block" || minimal)) {
+    const insert = syntaxInsert(spec.key, spec.values === "block");
+    setInsert(item, insert.snippet, insert.plain);
   }
   return item;
 }
@@ -155,6 +164,7 @@ function structureItem(spec: KeySpec, kind: string, rank: number, allowSnippet: 
  */
 function setInsert(item: CompletionItem, snippet: string, plain: string): void {
   if (snippetSupport()) {
+    item.kind = CompletionItemKind.Snippet;
     item.insertText = snippet;
     item.insertTextFormat = InsertTextFormat.Snippet;
   } else {
@@ -312,6 +322,11 @@ export class CompletionFeature {
     this.settings = settings;
   }
 
+  private get insertMode(): "minimal" | "examples" | "names" {
+    const mode = this.settings?.completionMode;
+    return mode === "examples" || mode === "names" ? mode : "minimal";
+  }
+
   /**
    * Merged frequency count for `name` (§C2): MAX of the bundled per-context count
    * and the live workspace usage count. O(1) — two map hits, no scan. `fctx` is
@@ -383,7 +398,7 @@ export class CompletionFeature {
       start: pos,
       end: { line: pos.line + 1, character: 0 },
     });
-    const allowSnippet = !lineSuffix.includes("=");
+    const allowSnippet = this.insertMode !== "names" && !/[=<>]/.test(lineSuffix);
 
     // Inside a list-form ref block (`on_actions = { | }`) → the target kinds.
     const listRef = this.listRefItems(result, offset, entry);
@@ -480,7 +495,7 @@ export class CompletionFeature {
       // An engine token whose dumped `usage:` example qualifies completes as the
       // block that example shows (blockSnippets.ts); most tokens have none.
       if (allowSnippet) {
-        const tmpl = blockTemplateFor(token);
+        const tmpl = this.insertMode === "minimal" ? minimalTokenInsert(token) : blockTemplateFor(token);
         if (tmpl) setInsert(out, tmpl.snippet, tmpl.plain);
       }
       ranked.push(out);
@@ -535,15 +550,9 @@ export class CompletionFeature {
     if (!data || data.t !== "def" || !data.k || !data.n || !SNIPPET_KINDS.has(data.k)) return;
     const def = this.data.index.lookup(data.n).find((d) => d.kind === data.k);
     if (!def) return;
-    if (def.params && def.params.length > 0) {
-      const snippet = def.params.map((p, i) => `\t${p} = \${${i + 1}:${p}}`).join("\n");
-      const plain = def.params.map((p) => `\t${p} = ${p}`).join("\n");
-      setInsert(item, `${data.n} = {\n${snippet}\n}`, `${data.n} = {\n${plain}\n}`);
-      item.detail = `${item.detail} · params: ${def.params.join(", ")}`;
-    } else if (data.k !== "scripted_modifier") {
-      // Bare scripted modifiers are referenced by name, not assigned yes/no.
-      setInsert(item, `${data.n} = \${1|yes,no|}`, `${data.n} = yes`);
-    }
+    const template = scriptedCallTemplate(def, this.insertMode === "examples" ? "examples" : "minimal");
+    if (template) setInsert(item, template.snippet, template.plain);
+    if (def.params?.length) item.detail = `${item.detail} · params: ${def.params.join(", ")}`;
   }
 
   /**
@@ -552,11 +561,11 @@ export class CompletionFeature {
    */
   resolve(item: CompletionItem): CompletionItem {
     const data = item.data as { t?: string; k?: string; n?: string } | undefined;
-    if (!data || !data.n) return item;
+    if (!data || !data.n) return withCompletionPreview(item);
     if (data.t === "tok") {
       const token = this.data.tokenMap.get(data.n)?.find((t) => t.kind === data.k);
       if (token?.doc) item.documentation = token.doc;
-      return item;
+      return withCompletionPreview(item, token);
     }
     if (data.t === "tmpl") {
       const m = matchTemplatedModifier(data.n, this.data.modifierTemplates, (n) => this.data.index.lookup(n));
@@ -568,6 +577,7 @@ export class CompletionFeature {
       if (def) {
         const doc = defDocMarkdown(def);
         if (doc) item.documentation = { kind: MarkupKind.Markdown, value: doc };
+        return withCompletionPreview(item, undefined, def);
       }
     }
     return item;
@@ -600,7 +610,9 @@ export class CompletionFeature {
         if (fa !== fb) return fb - fa;
         return a.key < b.key ? -1 : a.key > b.key ? 1 : 0;
       });
-    return [...curated, ...harvested].map((spec, i) => structureItem(spec, ctx.kind, i, allowSnippet));
+    return [...curated, ...harvested].map((spec, i) =>
+      structureItem(spec, ctx.kind, i, allowSnippet, this.insertMode === "minimal")
+    );
   }
 
   /**

--- a/packages/server/src/features/completionInsert.ts
+++ b/packages/server/src/features/completionInsert.ts
@@ -1,0 +1,110 @@
+import type { Definition, TokenData } from "@px-lsp/protocol/types";
+import { blockTemplateFor, extractBlockTemplate, type BlockTemplate } from "./blockSnippets";
+import { parseScript } from "../parser/parser";
+
+interface RequiredField {
+  name: string;
+  block?: boolean;
+}
+
+/** Shared by keyword completion and the full catalogue export. */
+export function scriptedCallTemplate(def: Definition, mode: "minimal" | "examples"): BlockTemplate | null {
+  if (!["scripted_effect", "scripted_trigger", "scripted_modifier"].includes(def.kind)) return null;
+  if (def.params?.length) {
+    if (mode === "minimal")
+      return syntaxInsert(
+        def.name,
+        true,
+        "=",
+        def.params.map((name) => ({ name }))
+      );
+    const snippet = def.params.map((p, i) => `\t${p} = \${${i + 1}:${p}}`).join("\n");
+    const plain = def.params.map((p) => `\t${p} = ${p}`).join("\n");
+    return { snippet: `${def.name} = {\n${snippet}\n}`, plain: `${def.name} = {\n${plain}\n}` };
+  }
+  if (def.kind === "scripted_modifier") return null;
+  return mode === "minimal"
+    ? syntaxInsert(def.name, false)
+    : {
+        snippet: `${def.name} = \${1|yes,no|}`,
+        plain: `${def.name} = yes`,
+      };
+}
+
+/** Punctuation only, with no example values inserted into the document. */
+export function syntaxInsert(
+  name: string,
+  block: boolean,
+  operator = "=",
+  fields: RequiredField[] = []
+): BlockTemplate {
+  if (block && fields.length) {
+    const render = (snippet: boolean) =>
+      fields
+        .map((field, i) => {
+          const value = snippet ? `$${i + 1}` : "";
+          return field.block ? `\t${field.name} = {\n\t\t${value}\n\t}` : `\t${field.name} = ${value}`;
+        })
+        .join("\n");
+    return { snippet: `${name} = {\n${render(true)}\n}`, plain: `${name} = {\n${render(false)}\n}` };
+  }
+  return block
+    ? { snippet: `${name} = {\n\t$0\n}`, plain: `${name} = {\n\t\n}` }
+    : { snippet: `${name} ${operator} $0`, plain: `${name} ${operator} ` };
+}
+
+const memo = new WeakMap<TokenData, BlockTemplate | null>();
+
+/** The example's outer syntax is usable even when its body contains prose. */
+export function minimalTokenInsert(token: TokenData): BlockTemplate | null {
+  const hit = memo.get(token);
+  if (hit !== undefined) return hit;
+  const built = buildMinimalTokenInsert(token);
+  memo.set(token, built);
+  return built;
+}
+
+function buildMinimalTokenInsert(token: TokenData): BlockTemplate | null {
+  // Keep the documented fields, omitting optional fields named in prose as well
+  // as those the example marks inline. Example values remain empty tabstops.
+  const prose = `${token.doc}\n${token.usage ?? ""}`;
+  const optionalFields = new Set<string>();
+  for (const pattern of [
+    /\boptional\s+['"`]?([a-z_][a-z0-9_]*)/gi,
+    /\b['"`]?([a-z_][a-z0-9_]*)['"`]?\s+(?:field\s+)?is\s+optional\b/gi,
+  ]) {
+    for (const match of prose.matchAll(pattern)) optionalFields.add(match[1]);
+  }
+  // Only an explicit, unconditional field declaration establishes a requirement.
+  // Example presence and corpus frequency do not. This wording occurs in script_docs.
+  const required = new Set(
+    [...token.doc.matchAll(/\bthe ([a-z_][a-z0-9_]*) field is (?:mandatory|required)(?=\.| and\b)/gi)].map(
+      (m) => m[1]
+    )
+  );
+  if (required.size && token.usage) {
+    const root = parseScript(token.usage).root;
+    const outer = root.statements[0];
+    if (outer?.kind === "assignment" && outer.value?.kind === "block") {
+      const inner = outer.key.text === token.name ? outer : outer.value.statements[0];
+      if (inner?.kind === "assignment" && inner.key.text === token.name && inner.value?.kind === "block") {
+        const fields = inner.value.statements.flatMap((s) =>
+          s.kind === "assignment" && s.op === "=" && required.has(s.key.text) && s.value
+            ? [{ name: s.key.text, block: s.value.kind === "block" }]
+            : []
+        );
+        if (fields.length) return syntaxInsert(token.name, true, "=", fields);
+      }
+    }
+  }
+  const template = extractBlockTemplate(token.name, token.usage, { optionalFields });
+  if (template) return template;
+
+  const head = /^\s*([A-Za-z_][A-Za-z0-9_]*)\s*(>=|<=|!=|=|>|<)\s*(\{)?/.exec(token.usage ?? "");
+  if (head?.[1] === token.name) {
+    if (head[3] && head[2] !== "=") return null;
+    return syntaxInsert(token.name, Boolean(head[3]), head[2]);
+  }
+  // The full extractor also understands examples wrapped in a scope block.
+  return blockTemplateFor(token) ? syntaxInsert(token.name, true) : null;
+}

--- a/packages/server/src/features/completionPreview.ts
+++ b/packages/server/src/features/completionPreview.ts
@@ -1,0 +1,111 @@
+import { InsertTextFormat, MarkupKind, type CompletionItem } from "vscode-languageserver/node";
+import type { Definition, TokenData } from "@px-lsp/protocol/types";
+import { parseScript } from "../parser/parser";
+import type { Statement } from "../parser/cst";
+
+/** Decode the numbered stops and choices emitted by our snippet renderers. */
+function previewText(item: CompletionItem): string | undefined {
+  if (!item.insertText) return undefined;
+  const text =
+    item.insertTextFormat === InsertTextFormat.Snippet
+      ? item.insertText.replace(
+          /\\([\\$}])|\$\{\d+\|((?:\\.|[^}])*?)\|\}|\$\{\d+:((?:\\.|[^}])*)\}|\$\{\d+\}|\$\d+/g,
+          (_match, escaped: string, choices: string, value: string) =>
+            escaped ?? (choices?.split(/(?<!\\),/)[0] ?? value ?? "").replace(/\\([\\$},|])/g, "$1")
+        )
+      : item.insertText;
+  // These labels only appear in documentation, never in insertText.
+  return text
+    .replace(/^([ \t]+)$/gm, "$1<value>")
+    .replace(
+      /(\b([A-Za-z_][A-Za-z0-9_]*)\s*(?:>=|<=|!=|=|>|<))[ \t]*$/gm,
+      (_match, assignment: string, key: string) => `${assignment} <${key === item.label ? "value" : key}>`
+    );
+}
+
+/** Scalar fields by their full path, so nested keys with the same name stay distinct. */
+function fields(text: string, name?: string): Map<string, string> {
+  const root = parseScript(
+    text.replace(/"(?:\\.|[^"\\])*"|<[^<>\n]+>/g, (match) =>
+      match.startsWith('"') ? match : JSON.stringify(match)
+    )
+  ).root;
+  let statements = root.statements;
+  if (name) {
+    const outer = statements[0];
+    if (outer?.kind !== "assignment") return new Map();
+    if (outer.key.text !== name) {
+      if (outer.value?.kind !== "block") return new Map();
+      statements = outer.value.statements;
+    }
+    if (statements[0]?.kind !== "assignment" || statements[0].key.text !== name) return new Map();
+    statements = [statements[0]];
+  }
+  const result = new Map<string, string>();
+  const visit = (nodes: Statement[], prefix = "") => {
+    for (const node of nodes) {
+      if (node.kind === "value" && node.value.kind === "scalar") {
+        result.set(`${prefix}[]`, node.value.text);
+        continue;
+      }
+      if (node.kind !== "assignment" || !node.value) continue;
+      const path = prefix ? `${prefix}.${node.key.text}` : node.key.text;
+      if (node.value.kind === "block") visit(node.value.statements, path);
+      else if (node.value.kind === "scalar") result.set(path, node.value.text);
+    }
+  };
+  visit(statements);
+  return result;
+}
+
+function cell(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/([\\`*_[\]])/g, "\\$1")
+    .replace(/\|/g, "&#124;")
+    .replace(/\r?\n/g, " ");
+}
+
+/** Resolve-time only: selecting an item builds its preview without inflating the completion list. */
+export function withCompletionPreview(
+  item: CompletionItem,
+  token?: TokenData,
+  definition?: Definition
+): CompletionItem {
+  const preview = previewText(item);
+  if (!preview) return item;
+  const existing = typeof item.documentation === "string" ? item.documentation : item.documentation?.value;
+  if (existing?.startsWith("**Insertion preview**\n")) return item;
+  const descriptions = new Map<string, string>();
+  // script_docs describes example placeholders as "Where X is ..." / "Y can be ...".
+  for (const match of (token?.doc ?? "").matchAll(
+    /\b([A-Z][A-Z0-9_]*)\s+(?:is|can be)\s+([^\n]+?)(?=\.\s+[A-Z]\s+(?:is|can be)\b|\n|$)/g
+  )) {
+    descriptions.set(match[1], match[2]);
+  }
+  for (const tag of definition?.tags ?? []) {
+    if (tag.tag !== "param") continue;
+    const match = /^(\S+)\s+(.+)$/.exec(tag.text);
+    if (match) descriptions.set(match[1], match[2]);
+  }
+  const source = token?.usage ? fields(token.usage, token.name) : new Map<string, string>();
+  const rows: string[] = [];
+  for (const path of token || definition ? fields(preview).keys() : []) {
+    const field = path.includes(".") ? path.slice(path.indexOf(".") + 1) : path;
+    const example = source.get(path);
+    let hint = definition ? descriptions.get(field) : example ? descriptions.get(example) : undefined;
+    if (!hint && token && path === token.name) hint = /^Traits:\s*(.+)$/im.exec(token.traits ?? "")?.[1];
+    if (!hint && example?.startsWith("<") && example.endsWith(">")) hint = example.slice(1, -1);
+    if (!hint) hint = example ? `Type not documented. Example: ${example}` : "Type not documented.";
+    rows.push(`| ${cell(field.replace(/\[\]$/, " (contents)"))} | ${cell(hint)} |`);
+  }
+  const fence = "`".repeat(Math.max(3, ...[...preview.matchAll(/`+/g)].map((m) => m[0].length + 1)));
+  const parts = [`**Insertion preview**\n\n${fence}paradox\n${preview}\n${fence}`];
+  if (rows.length)
+    parts.push(`**Expected values**\n\n| Field | From documentation |\n| --- | --- |\n${rows.join("\n")}`);
+  if (existing) parts.push(existing);
+  item.documentation = { kind: MarkupKind.Markdown, value: parts.join("\n\n") };
+  return item;
+}

--- a/packages/server/src/features/snippetCatalogue.ts
+++ b/packages/server/src/features/snippetCatalogue.ts
@@ -1,0 +1,91 @@
+import type { SnippetCatalogueEntry } from "@px-lsp/protocol/protocol";
+import type { Definition, TokenData } from "@px-lsp/protocol/types";
+import type { KindSkeleton } from "../schema/skeletons";
+import { renderDefinitionSkeleton, renderBlockSkeleton } from "../schema/skeletons";
+import { blockTemplateFor, type BlockTemplate } from "./blockSnippets";
+import { minimalTokenInsert, scriptedCallTemplate } from "./completionInsert";
+import { withCompletionPreview } from "./completionPreview";
+
+export function buildSnippetCatalogue(
+  tokens: TokenData[],
+  skeletons: Record<string, KindSkeleton> | undefined,
+  definitions: Definition[]
+): SnippetCatalogueEntry[] {
+  const entries: SnippetCatalogueEntry[] = [];
+  const variant = (
+    label: SnippetCatalogueEntry["variants"][number]["label"],
+    name: string,
+    template: BlockTemplate,
+    token?: TokenData,
+    definition?: Definition
+  ) => {
+    const item = withCompletionPreview(
+      { label: name, insertText: template.snippet, insertTextFormat: 2 },
+      token,
+      definition
+    );
+    const preview =
+      typeof item.documentation === "string" ? item.documentation : (item.documentation?.value ?? "");
+    return { label, snippet: template.snippet, plain: template.plain, preview };
+  };
+  const seen = new Set<string>();
+  for (const token of tokens) {
+    const id = `engine:${token.kind}:${token.name}`;
+    if (seen.has(id)) continue;
+    seen.add(id);
+    const variants: SnippetCatalogueEntry["variants"] = [];
+    const minimal = minimalTokenInsert(token);
+    const example = blockTemplateFor(token);
+    if (minimal) variants.push(variant("Minimal", token.name, minimal, token));
+    if (example) variants.push(variant("Examples", token.name, example, token));
+    if (example?.full) variants.push(variant("All fields", token.name, example.full, token));
+    if (variants.length)
+      entries.push({
+        id,
+        label: token.name,
+        category: "Engine",
+        detail: `${token.kind}; loaded game documentation`,
+        variants,
+      });
+  }
+  for (const [kind, skeleton] of Object.entries(skeletons ?? {})) {
+    const template = renderDefinitionSkeleton(kind, skeleton, {
+      withHeader: skeleton.nameFromHeader !== undefined,
+    });
+    entries.push({
+      id: `definition:${kind}`,
+      label: `new ${kind}`,
+      category: "Definitions",
+      detail: `${skeleton.sampled} sampled vanilla definitions`,
+      variants: [variant("Template", `new ${kind}`, template)],
+    });
+    for (const [name, block] of Object.entries(skeleton.blocks ?? {})) {
+      entries.push({
+        id: `block:${kind}:${name}`,
+        label: `${kind} / ${name}`,
+        category: "Child blocks",
+        detail: `${block.sampled} sampled vanilla blocks`,
+        variants: [variant("Template", name, renderBlockSkeleton(name, block))],
+      });
+    }
+  }
+  // Definitions are effective definitions supplied in the index's lookup order.
+  for (const def of definitions) {
+    const id = `scripted:${def.kind}:${def.name}`;
+    if (seen.has(id)) continue;
+    seen.add(id);
+    const minimal = scriptedCallTemplate(def, "minimal");
+    if (!minimal) continue;
+    entries.push({
+      id,
+      label: def.name,
+      category: "Scripted calls",
+      detail: `${def.kind}; ${def.source}`,
+      variants: [
+        variant("Minimal", def.name, minimal, undefined, def),
+        variant("Examples", def.name, scriptedCallTemplate(def, "examples")!, undefined, def),
+      ],
+    });
+  }
+  return entries.sort((a, b) => a.label.localeCompare(b.label) || a.id.localeCompare(b.id));
+}

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -100,6 +100,8 @@ import {
   scopeAtRequest,
   type ScopeAtParams,
   snippetsRequest,
+  snippetCatalogueRequest,
+  type SnippetCatalogueResult,
   type SnippetsParams,
   type SnippetsResult,
   type ScopeAtResult,
@@ -203,6 +205,7 @@ import { prepareRename, provideRename } from "./features/rename";
 import { provideWorkspaceSymbols } from "./features/workspaceSymbols";
 import { evictParse, getLocParse, getParse } from "./parseCache";
 import { buildSnippetList } from "./features/snippetList";
+import { buildSnippetCatalogue } from "./features/snippetCatalogue";
 import { resolveClientCapabilities, setClientCapabilities } from "./clientMode";
 import { isIgnoredByConfig, isSuppressedInline, scanInlineSuppressions } from "@px-lsp/protocol/suppression";
 import { computeModOverview } from "./overview/modOverview";
@@ -301,6 +304,7 @@ function defaultSettings(): ParadoxSettings {
     scopeInlayHints: false,
     indexAssets: true,
     hoverDetail: "standard",
+    completionMode: "minimal",
     diagnosticsIgnore: [],
     diagnosticsIgnorePatterns: [],
     diagnosticsVanilla: false,
@@ -1866,6 +1870,29 @@ connection.onRequest(scopeAtRequest, (params: ScopeAtParams): ScopeAtResult | nu
     entry?.rootScopes?.length ? new Set(entry.rootScopes.map((s) => s.toLowerCase())) : null,
     entry
   );
+});
+
+connection.onRequest(snippetCatalogueRequest, (): SnippetCatalogueResult => {
+  flushModFileChanges();
+  const names = new Set(
+    data.index
+      .allDefinitions()
+      .filter((def) => ["scripted_effect", "scripted_trigger", "scripted_modifier"].includes(def.kind))
+      .map((def) => def.name)
+  );
+  return {
+    gameId: activeProfile().id,
+    gameName: activeProfile().name,
+    generatedAt: new Date().toISOString(),
+    indexing,
+    entries: indexing
+      ? []
+      : buildSnippetCatalogue(
+          data.tokens,
+          activeProfile().skeletons,
+          [...names].flatMap((name) => data.index.lookup(name))
+        ),
+  };
 });
 
 connection.onRequest(snippetsRequest, (params: SnippetsParams): SnippetsResult => {

--- a/packages/server/test/completionInsert.test.ts
+++ b/packages/server/test/completionInsert.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import { minimalTokenInsert, syntaxInsert } from "../src/features/completionInsert";
+import type { TokenData } from "@px-lsp/protocol/types";
+
+const token = (name: string, usage?: string, doc = ""): TokenData => ({
+  name,
+  usage,
+  doc,
+  kind: "effect",
+  scopes: [],
+});
+
+describe("minimal completion syntax", () => {
+  it("keeps set_variable name and value, without the optional days", () => {
+    // CK3 script_docs effects.log; days is optional in the prose, not in the example.
+    expect(
+      minimalTokenInsert(
+        token(
+          "set_variable",
+          "set_variable = { name = X value = Y days = Z }",
+          "An optional days where Z is the number of days or script value"
+        )
+      )
+    ).toEqual({
+      snippet: "set_variable = {\n\tname = $1\n\tvalue = $2\n}",
+      plain: "set_variable = {\n\tname = \n\tvalue = \n}",
+    });
+  });
+
+  it("uses explicitly mandatory fields from the docs, including a scope wrapper", () => {
+    // CK3 script_docs: record_situation_special_event.
+    const example = token(
+      "record_situation_special_event",
+      "scope:situation = { record_situation_special_event = { key = special_event_key actor = scope:character (optional) } }",
+      "The key field is mandatory and enables special entry localization."
+    );
+    expect(minimalTokenInsert(example)?.snippet).toBe("record_situation_special_event = {\n\tkey = $1\n}");
+  });
+
+  it("keeps example fields even without an unconditional required declaration", () => {
+    expect(
+      minimalTokenInsert(
+        token(
+          "sample",
+          "sample = { key = X value = Y }",
+          "The key field is required if another field is set."
+        )
+      )?.snippet
+    ).toBe("sample = {\n\tkey = $1\n\tvalue = $2\n}");
+  });
+
+  it("keeps nested control-flow fields without placeholder text", () => {
+    expect(minimalTokenInsert(token("if", "if = { limit = { <triggers> } <effects> }"))?.snippet).toBe(
+      "if = {\n\tlimit = {\n\t\t$1\n\t}\n\t$2\n}"
+    );
+  });
+
+  it("keeps fields from Victoria 3 examples without concrete values", () => {
+    expect(
+      minimalTokenInsert(token("add_acceptance", "add_acceptance = { culture = cu:romanian value = -10 }"))
+        ?.snippet
+    ).toBe("add_acceptance = {\n\tculture = $1\n\tvalue = $2\n}");
+  });
+
+  it("omits fields marked optional inline and in prose", () => {
+    expect(
+      minimalTokenInsert(
+        token(
+          "sample",
+          "sample = {\n key = X\n other = Y # optional\n last = Z\n}",
+          "The last field is optional."
+        )
+      )?.snippet
+    ).toBe("sample = {\n\tkey = $1\n}");
+  });
+
+  it("uses the first complete example when wiki usage includes trailing prose", () => {
+    expect(
+      minimalTokenInsert(
+        token("set_variable", "set_variable = { name = X value = Y }\nUse the variable later.")
+      )?.snippet
+    ).toBe("set_variable = {\n\tname = $1\n\tvalue = $2\n}");
+  });
+
+  it("omits a field followed by a parenthesized optional marker", () => {
+    expect(minimalTokenInsert(token("sample", "sample = { key = X actor = Y (optional) }"))?.snippet).toBe(
+      "sample = {\n\tkey = $1\n\t$2\n}"
+    );
+  });
+
+  it("leaves required parameter values blank and gives each a tabstop", () => {
+    expect(syntaxInsert("sample", true, "=", [{ name: "TARGET" }, { name: "AMOUNT" }])).toEqual({
+      snippet: "sample = {\n\tTARGET = $1\n\tAMOUNT = $2\n}",
+      plain: "sample = {\n\tTARGET = \n\tAMOUNT = \n}",
+    });
+  });
+
+  it("uses the documented operator without its example value", () => {
+    expect(minimalTokenInsert(token("sample", "sample >= 10"))?.snippet).toBe("sample >= $0");
+  });
+
+  it("uses an empty block even when the example body is not executable", () => {
+    expect(
+      minimalTokenInsert(token("random_list", "random_list = { X1 = { effect1 } X2 = { effect2 } ... }"))
+        ?.snippet
+    ).toBe("random_list = {\n\t$0\n}");
+  });
+
+  it("keeps unknown syntax and copied sibling examples as names", () => {
+    expect(minimalTokenInsert(token("sample"))).toBeNull();
+    expect(minimalTokenInsert(token("sample", "sibling = { key = X }"))).toBeNull();
+  });
+});

--- a/packages/server/test/completionPreview.test.ts
+++ b/packages/server/test/completionPreview.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from "vitest";
+import type { CompletionItem } from "vscode-languageserver/node";
+import type { TokenData } from "@px-lsp/protocol/types";
+import { withCompletionPreview } from "../src/features/completionPreview";
+import { minimalTokenInsert } from "../src/features/completionInsert";
+
+function markdown(item: CompletionItem): string {
+  return typeof item.documentation === "string" ? item.documentation : (item.documentation?.value ?? "");
+}
+
+const variable: TokenData = {
+  name: "set_variable",
+  kind: "effect",
+  scopes: [],
+  usage: "set_variable = { name = X value = Y days = Z }",
+  doc: "Where X is the name of the variable used to then access it\nWhere Y is any event target, bool, value, script value or flag (flag:W)\nAn optional days where Z is the number of days or script value",
+};
+
+describe("completion previews", () => {
+  it("maps game-documented placeholder descriptions to the inserted fields", () => {
+    const item: CompletionItem = {
+      label: variable.name,
+      insertText: minimalTokenInsert(variable)!.snippet,
+      insertTextFormat: 2,
+      documentation: variable.doc,
+    };
+    const insert = item.insertText;
+    const preview = markdown(withCompletionPreview(item, variable));
+    expect(preview).toContain("name = <name>");
+    expect(preview).toContain("| name | the name of the variable");
+    expect(preview).toContain("| value | any event target, bool, value, script value or flag (flag:W) |");
+    expect(preview).not.toContain("| days |");
+    expect(preview).not.toContain("$1");
+    expect(item.insertText).toBe(insert);
+  });
+
+  it("gives plain LSP inserts the same preview", () => {
+    const template = minimalTokenInsert(variable)!;
+    const rich = withCompletionPreview(
+      { label: variable.name, insertText: template.snippet, insertTextFormat: 2 },
+      variable
+    );
+    const plain = withCompletionPreview({ label: variable.name, insertText: template.plain }, variable);
+    expect(markdown(plain)).toBe(markdown(rich));
+    expect(plain.insertText).toBe(template.plain);
+  });
+
+  it("labels concrete examples honestly instead of inferring an accepted datatype", () => {
+    const token: TokenData = {
+      name: "add_acceptance",
+      kind: "effect",
+      scopes: [],
+      doc: "",
+      usage: "add_acceptance = { culture = cu:romanian value = -10 }",
+    };
+    const preview = markdown(
+      withCompletionPreview(
+        { label: token.name, insertText: minimalTokenInsert(token)!.snippet, insertTextFormat: 2 },
+        token
+      )
+    );
+    expect(preview).toContain("Type not documented. Example: cu:romanian");
+    expect(preview).toContain("Type not documented. Example: -10");
+  });
+
+  it("shows angle-bracket type hints and keeps nested paths distinct", () => {
+    const token: TokenData = {
+      name: "sample",
+      kind: "effect",
+      scopes: [],
+      doc: "",
+      usage: "sample = { first = { target = <character> } second = { target = <title> } }",
+    };
+    const preview = markdown(
+      withCompletionPreview(
+        { label: token.name, insertText: minimalTokenInsert(token)!.snippet, insertTextFormat: 2 },
+        token
+      )
+    );
+    expect(preview).toContain("| first.target | character |");
+    expect(preview).toContain("| second.target | title |");
+  });
+
+  it("uses user-written @param descriptions without guessing from parameter names", () => {
+    const item = withCompletionPreview(
+      {
+        label: "my_effect",
+        insertText: "my_effect = {\n\tTARGET = $1\n\tAMOUNT = $2\n}",
+        insertTextFormat: 2,
+      },
+      undefined,
+      {
+        name: "my_effect",
+        kind: "scripted_effect",
+        file: "mod.txt",
+        line: 0,
+        source: "mod",
+        params: ["TARGET", "AMOUNT"],
+        tags: [{ tag: "param", text: "TARGET character scope" }],
+      }
+    );
+    expect(markdown(item)).toContain("| TARGET | character scope |");
+    expect(markdown(item)).toContain("| AMOUNT | Type not documented. |");
+  });
+
+  it("decodes choices and escaped placeholder text in full examples", () => {
+    const item = withCompletionPreview({
+      label: "sample",
+      insertText: "sample = {\n\tdays = ${1|10,20|}\n\ttext = ${2:a\\}b} $0\n}",
+      insertTextFormat: 2,
+    });
+    expect(markdown(item)).toContain("days = 10");
+    expect(markdown(item)).toContain("text = a}b");
+    const once = markdown(item);
+    expect(markdown(withCompletionPreview(item))).toBe(once);
+  });
+
+  it("does not attach an insertion preview to names-only completions", () => {
+    const item = withCompletionPreview({ label: variable.name, documentation: variable.doc }, variable);
+    expect(item.documentation).toBe(variable.doc);
+  });
+
+  it("uses the documented traits for a scalar value", () => {
+    const token: TokenData = {
+      name: "sample",
+      kind: "trigger",
+      scopes: [],
+      doc: "",
+      usage: "sample = yes",
+      traits: "Traits: yes/no",
+    };
+    const preview = markdown(
+      withCompletionPreview({ label: "sample", insertText: "sample = $0", insertTextFormat: 2 }, token)
+    );
+    expect(preview).toContain("sample = <value>");
+    expect(preview).toContain("| sample | yes/no |");
+  });
+
+  it("describes block contents from the documented placeholders", () => {
+    const token: TokenData = {
+      name: "if",
+      kind: "effect",
+      scopes: [],
+      doc: "",
+      usage: "if = { limit = { <triggers> } <effects> }",
+    };
+    const template = minimalTokenInsert(token)!;
+    const rich = markdown(
+      withCompletionPreview({ label: "if", insertText: template.snippet, insertTextFormat: 2 }, token)
+    );
+    const plain = markdown(withCompletionPreview({ label: "if", insertText: template.plain }, token));
+    expect(rich).toBe(plain);
+    expect(rich).toContain("| limit (contents) | triggers |");
+    expect(rich).toContain("| if (contents) | effects |");
+  });
+});

--- a/packages/server/test/completionV3.test.ts
+++ b/packages/server/test/completionV3.test.ts
@@ -9,7 +9,7 @@ import { TextDocument } from "vscode-languageserver-textdocument";
 import { CompletionFeature, matchesTypedWord, MAX_ITEMS } from "../src/features/completion";
 import { ServerData } from "../src/serverData";
 import { loadSchema } from "../src/schema/loader";
-import type { ParadoxInitOptions } from "@px-lsp/protocol/protocol";
+import type { ParadoxInitOptions, ParadoxSettings } from "@px-lsp/protocol/protocol";
 import type { Definition, TokenData } from "@px-lsp/protocol/types";
 import { resolveClientCapabilities, setClientCapabilities } from "../src/clientMode";
 import { fuzzyScore, FuzzyScoreOptionsDefault } from "./vscodeFuzzy";
@@ -33,7 +33,22 @@ function def(name: string, kind: string, extra: Partial<Definition> = {}): Defin
   return { name, kind, file: `F:/mod/common/${kind}/x.txt`, line: 1, source: "mod", ...extra };
 }
 
-function makeEnv() {
+function setMode(completion: CompletionFeature, completionMode: ParadoxSettings["completionMode"]) {
+  completion.setSettings({
+    gamePath: null,
+    logsPath: null,
+    modPath: null,
+    parentPaths: [],
+    locLanguage: "english",
+    scopeInlayHints: false,
+    diagnosticsIgnore: [],
+    diagnosticsIgnorePatterns: [],
+    diagnosticsVanilla: false,
+    completionMode,
+  });
+}
+
+function makeEnv(mode: ParadoxSettings["completionMode"] | null = "examples") {
   const schema = loadSchema(null);
   const data = new ServerData();
   data.setTokens([
@@ -63,6 +78,7 @@ function makeEnv() {
     def("my_loc_key", "loc_key"),
   ]);
   const completion = new CompletionFeature(data, () => schema);
+  if (mode !== null) setMode(completion, mode);
   return { data, schema, completion };
 }
 
@@ -316,7 +332,9 @@ describe("completion — engine block templates from usage examples", () => {
       { ...tok("random_list", "effect"), usage: "random_list = { X1 = { effect1 } X2 = { effect2 } ... }" },
       tok("add_gold", "effect", ["character"]),
     ]);
-    return { data, schema, completion: new CompletionFeature(data, () => schema) };
+    const completion = new CompletionFeature(data, () => schema);
+    setMode(completion, "examples");
+    return { data, schema, completion };
   }
 
   it("a token whose example qualifies completes as that block", () => {
@@ -372,6 +390,72 @@ describe("completion — a client that did not declare snippetSupport", () => {
     const items = allItems();
     expect(items.find((i) => i.label === "immediate")!.insertText).toBe("immediate = {\n\t$0\n}");
     expect(items.find((i) => i.label === "immediate")!.insertTextFormat).toBe(2);
+  });
+});
+
+describe("completion insertion modes", () => {
+  const text = "e.1 = {\n\timmediate = {\n\t\tmy_eff|\n\t}\n}";
+
+  it("defaults to minimal and applies mode changes to cached completion items", () => {
+    const env = makeEnv(null);
+    const effect = () => provideAt(env, text).items.find((i) => i.label === "my_effect")!;
+    expect(effect().insertText).toBe("my_effect = $0");
+    expect(effect().kind).toBe(15); // CompletionItemKind.Snippet, including the icon.
+    setMode(env.completion, "examples");
+    expect(effect().insertText).toBe("my_effect = ${1|yes,no|}");
+    expect(effect().kind).toBe(15);
+    setMode(env.completion, "names");
+    expect(effect().insertText).toBeUndefined();
+    expect(effect().kind).not.toBe(15);
+    setMode(env.completion, "minimal");
+    expect(effect().insertText).toBe("my_effect = $0");
+  });
+
+  it("places the cursor after the first required scripted parameter", () => {
+    const env = makeEnv("minimal");
+    env.data.index.addAll([def("my_effect_params", "scripted_effect", { params: ["TARGET"] })]);
+    env.data.notifyIndexChanged();
+    expect(provideAt(env, text).items.find((i) => i.label === "my_effect_params")!.insertText).toBe(
+      "my_effect_params = {\n\tTARGET = $1\n}"
+    );
+  });
+
+  it("emits plain punctuation for clients without snippet support", () => {
+    asClient({ client: {} });
+    const item = provideAt(makeEnv("minimal"), text).items.find((i) => i.label === "my_effect")!;
+    expect(item.insertText).toBe("my_effect = ");
+    expect(item.insertTextFormat).toBeUndefined();
+    expect(item.kind).not.toBe(15);
+  });
+
+  it("marks generated engine field templates as snippets", () => {
+    const env = makeEnv("minimal");
+    env.data.setTokens([
+      {
+        ...tok("set_variable", "effect"),
+        usage: "set_variable = { name = X value = Y days = Z }",
+        doc: "An optional days where Z is the number of days or script value",
+      },
+    ]);
+    const item = provideAt(env, text.replace("my_eff|", "set_var|")).items.find(
+      (i) => i.label === "set_variable"
+    )!;
+    expect(item.kind).toBe(15);
+    expect(item.insertText).toBe("set_variable = {\n\tname = $1\n\tvalue = $2\n}");
+    expect(item.documentation).toBeUndefined();
+    const resolved = env.completion.resolve(item);
+    expect(resolved.documentation).toMatchObject({
+      kind: "markdown",
+      value: expect.stringContaining("name = <name>"),
+    });
+    expect(resolved.insertText).toBe("set_variable = {\n\tname = $1\n\tvalue = $2\n}");
+  });
+
+  it("does not duplicate a comparison operator already after the cursor", () => {
+    const item = provideAt(makeEnv("minimal"), text.replace("my_eff|", "my_eff| > 10")).items.find(
+      (i) => i.label === "my_effect"
+    )!;
+    expect(item.insertText).toBeUndefined();
   });
 });
 

--- a/packages/server/test/lspSmoke.test.ts
+++ b/packages/server/test/lspSmoke.test.ts
@@ -47,6 +47,8 @@ import {
   guiWidgetInfoRequest,
   scopeAtRequest,
   snippetsRequest,
+  snippetCatalogueRequest,
+  type SnippetCatalogueResult,
   type SnippetsResult,
   statusNotification,
   type DependenciesResult,
@@ -587,14 +589,71 @@ describe.skipIf(!hasServer)("LSP smoke over node IPC (the client's transport)", 
       position: { line: 5, character: 2 },
     })) as { items: Array<{ label: string; insertText?: string; insertTextFormat?: number }> };
     const effect = result.items.find((i) => i.label === "my_smoke_effect")!;
-    expect(effect.insertText).toBe("my_smoke_effect = ${1|yes,no|}");
+    expect(effect.insertText).toBe("my_smoke_effect = $0");
     expect(effect.insertTextFormat).toBe(2); // InsertTextFormat.Snippet
+    expect(effect).toHaveProperty("kind", 15); // CompletionItemKind.Snippet
+    const resolved = (await conn.sendRequest("completionItem/resolve", effect)) as {
+      insertText: string;
+      documentation: { kind: string; value: string };
+    };
+    expect(resolved.documentation.kind).toBe("markdown");
+    expect(resolved.documentation.value).toContain("**Insertion preview**");
+    expect(resolved.documentation.value).toContain("my_smoke_effect = <value>");
+    expect(resolved.documentation.value).toContain("Gives gold");
+    expect(resolved.insertText).toBe(effect.insertText);
 
     const hover = (await conn.sendRequest("textDocument/hover", {
       textDocument: { uri: eventsUri },
       position: { line: 6, character: 4 },
     })) as { contents: { value: string } };
     expect(hover.contents.value).toContain("](file:");
+  });
+
+  it("exports the full generated catalogue without a cursor or open document", async () => {
+    const catalogue = await conn.sendRequest<SnippetCatalogueResult>(snippetCatalogueRequest, {});
+    expect(catalogue.indexing).toBe(false);
+    expect(catalogue.gameId).toBe("ck3");
+    expect(catalogue.entries.filter((entry) => entry.category === "Engine").length).toBeGreaterThan(60);
+    expect(catalogue.entries.some((entry) => entry.category === "Definitions")).toBe(true);
+    const effect = catalogue.entries.find(
+      (entry) => entry.id === "scripted:scripted_effect:my_smoke_effect"
+    )!;
+    expect(effect.variants[0].snippet).toBe("my_smoke_effect = $0");
+    expect(effect.variants[0].preview).toContain("Insertion preview");
+    expect(new Set(catalogue.entries.map((entry) => entry.id)).size).toBe(catalogue.entries.length);
+  });
+
+  it("changes completion mode over the wire without rebuilding the index", async () => {
+    const uri = toUri(path.join(modDir, "events", "smoke_completion_mode.txt"));
+    await conn.sendNotification("textDocument/didOpen", {
+      textDocument: { uri, languageId: "paradox", version: 1, text: "e.1 = { immediate = { my_smoke_ } }" },
+    });
+    const start = statuses.length;
+    for (const [completionMode, expected] of [
+      ["examples", "my_smoke_effect = ${1|yes,no|}"],
+      ["names", undefined],
+      ["minimal", "my_smoke_effect = $0"],
+    ] as const) {
+      await conn.sendNotification(configChangedNotification, {
+        gamePath: null,
+        logsPath: null,
+        modPath: modDir,
+        parentPaths: [parentDir, depDir],
+        workspaceMods: [parentDir],
+        locLanguage: "english",
+        scopeInlayHints: false,
+        diagnosticsIgnore: [],
+        diagnosticsIgnorePatterns: [],
+        diagnosticsVanilla: false,
+        completionMode,
+      });
+      const result = (await conn.sendRequest("textDocument/completion", {
+        textDocument: { uri },
+        position: { line: 0, character: 29 },
+      })) as { items: Array<{ label: string; insertText?: string }> };
+      expect(result.items.find((item) => item.label === "my_smoke_effect")?.insertText).toBe(expected);
+    }
+    expect(statuses.slice(start).some((status) => status.indexing)).toBe(false);
   });
 
   it("hover on the scripted effect shows its card with a references link", async () => {
@@ -1517,7 +1576,7 @@ describe.skipIf(!hasServer)("LSP smoke: client capability object", () => {
       textDocument: { uri },
       position: { line: 5, character: 2 },
     })) as { items: Array<{ label: string; insertText?: string; insertTextFormat?: number }> };
-    expect(result.items.find((i) => i.label === "my_smoke_effect")!.insertText).toBe("my_smoke_effect = yes");
+    expect(result.items.find((i) => i.label === "my_smoke_effect")!.insertText).toBe("my_smoke_effect = ");
     for (const item of result.items) {
       expect(item.insertTextFormat, item.label).toBeUndefined();
       expect(item.insertText ?? "", item.label).not.toContain("${");

--- a/packages/server/test/perf/history.json
+++ b/packages/server/test/perf/history.json
@@ -759,6 +759,286 @@
         "peakRssMb": 787,
         "rssSamples": 17
       }
+    },
+    {
+      "version": "minimal-completion-before",
+      "recordedAt": "2026-09-09",
+      "workspace": "cultivation.code-workspace",
+      "roots": 6,
+      "build": "worktree packages/server/dist/server.js",
+      "machine": {
+        "cpu": "AMD Ryzen 7 5800X 8-Core Processor             ",
+        "totalMemGb": 32,
+        "node": "v24.12.0"
+      },
+      "results": {
+        "timeToIndexedMs": 11505,
+        "definitions": 481510,
+        "completionCold": 230,
+        "completionWarm": 7,
+        "semanticTokens": 1,
+        "hover": 3,
+        "documentSymbol": 1,
+        "completionAfterSave": 175,
+        "tokensAfterSave": 1,
+        "heapMb": 271,
+        "rssAtBuildMb": 711,
+        "internedIdentifiers": 559699,
+        "peakRssMb": 847,
+        "rssSamples": 24
+      }
+    },
+    {
+      "version": "minimal-completion-after",
+      "recordedAt": "2026-09-09",
+      "workspace": "cultivation.code-workspace",
+      "roots": 6,
+      "build": "worktree packages/server/dist/server.js",
+      "machine": {
+        "cpu": "AMD Ryzen 7 5800X 8-Core Processor             ",
+        "totalMemGb": 32,
+        "node": "v24.12.0"
+      },
+      "results": {
+        "timeToIndexedMs": 7067,
+        "definitions": 481510,
+        "completionCold": 168,
+        "completionWarm": 6,
+        "semanticTokens": 1,
+        "hover": 3,
+        "documentSymbol": 1,
+        "completionAfterSave": 126,
+        "tokensAfterSave": 1,
+        "heapMb": 271,
+        "rssAtBuildMb": 703,
+        "internedIdentifiers": 559699,
+        "peakRssMb": 856,
+        "rssSamples": 17
+      }
+    },
+    {
+      "version": "completion-fields-before",
+      "recordedAt": "2026-09-09",
+      "workspace": "cultivation.code-workspace",
+      "roots": 6,
+      "build": "worktree packages/server/dist/server.js",
+      "machine": {
+        "cpu": "AMD Ryzen 7 5800X 8-Core Processor             ",
+        "totalMemGb": 32,
+        "node": "v24.12.0"
+      },
+      "results": {
+        "timeToIndexedMs": 6241,
+        "definitions": 481510,
+        "completionCold": 154,
+        "completionWarm": 7,
+        "semanticTokens": 1,
+        "hover": 3,
+        "documentSymbol": 1,
+        "completionAfterSave": 152,
+        "tokensAfterSave": 1,
+        "heapMb": 271,
+        "rssAtBuildMb": 703,
+        "internedIdentifiers": 559699,
+        "peakRssMb": 849,
+        "rssSamples": 16
+      }
+    },
+    {
+      "version": "completion-fields-after",
+      "recordedAt": "2026-09-09",
+      "workspace": "cultivation.code-workspace",
+      "roots": 6,
+      "build": "worktree packages/server/dist/server.js",
+      "machine": {
+        "cpu": "AMD Ryzen 7 5800X 8-Core Processor             ",
+        "totalMemGb": 32,
+        "node": "v24.12.0"
+      },
+      "results": {
+        "timeToIndexedMs": 6036,
+        "definitions": 481510,
+        "completionCold": 176,
+        "completionWarm": 6,
+        "semanticTokens": 1,
+        "hover": 3,
+        "documentSymbol": 1,
+        "completionAfterSave": 126,
+        "tokensAfterSave": 1,
+        "heapMb": 271,
+        "rssAtBuildMb": 705,
+        "internedIdentifiers": 559699,
+        "peakRssMb": 851,
+        "rssSamples": 16
+      }
+    },
+    {
+      "version": "completion-preview-before",
+      "recordedAt": "2026-09-09",
+      "workspace": "cultivation.code-workspace",
+      "roots": 6,
+      "build": "worktree packages/server/dist/server.js",
+      "machine": {
+        "cpu": "AMD Ryzen 7 5800X 8-Core Processor             ",
+        "totalMemGb": 32,
+        "node": "v24.12.0"
+      },
+      "results": {
+        "timeToIndexedMs": 9632,
+        "definitions": 481510,
+        "completionCold": 391,
+        "completionWarm": 12,
+        "semanticTokens": 2,
+        "hover": 5,
+        "documentSymbol": 1,
+        "completionAfterSave": 184,
+        "tokensAfterSave": 1,
+        "heapMb": 271,
+        "rssAtBuildMb": 701,
+        "internedIdentifiers": 559699,
+        "peakRssMb": 833,
+        "rssSamples": 19
+      }
+    },
+    {
+      "version": "completion-preview-after",
+      "recordedAt": "2026-09-09",
+      "workspace": "cultivation.code-workspace",
+      "roots": 6,
+      "build": "worktree packages/server/dist/server.js",
+      "machine": {
+        "cpu": "AMD Ryzen 7 5800X 8-Core Processor             ",
+        "totalMemGb": 32,
+        "node": "v24.12.0"
+      },
+      "results": {
+        "timeToIndexedMs": 7613,
+        "definitions": 481510,
+        "completionCold": 165,
+        "completionWarm": 6,
+        "semanticTokens": 1,
+        "hover": 4,
+        "documentSymbol": 1,
+        "completionAfterSave": 149,
+        "tokensAfterSave": 0,
+        "heapMb": 271,
+        "rssAtBuildMb": 712,
+        "internedIdentifiers": 559699,
+        "peakRssMb": 851,
+        "rssSamples": 17
+      }
+    },
+    {
+      "version": "snippet-catalogue-before",
+      "recordedAt": "2026-09-09",
+      "workspace": "cultivation.code-workspace",
+      "roots": 6,
+      "build": "worktree packages/server/dist/server.js",
+      "machine": {
+        "cpu": "AMD Ryzen 7 5800X 8-Core Processor             ",
+        "totalMemGb": 32,
+        "node": "v24.12.0"
+      },
+      "results": {
+        "timeToIndexedMs": 6798,
+        "definitions": 481510,
+        "completionCold": 195,
+        "completionWarm": 8,
+        "semanticTokens": 1,
+        "hover": 3,
+        "documentSymbol": 1,
+        "completionAfterSave": 139,
+        "tokensAfterSave": 1,
+        "heapMb": 271,
+        "rssAtBuildMb": 746,
+        "internedIdentifiers": 559699,
+        "peakRssMb": 878,
+        "rssSamples": 15
+      }
+    },
+    {
+      "version": "snippet-catalogue-after",
+      "recordedAt": "2026-09-09",
+      "workspace": "cultivation.code-workspace",
+      "roots": 6,
+      "build": "worktree packages/server/dist/server.js",
+      "machine": {
+        "cpu": "AMD Ryzen 7 5800X 8-Core Processor             ",
+        "totalMemGb": 32,
+        "node": "v24.12.0"
+      },
+      "results": {
+        "timeToIndexedMs": 7031,
+        "definitions": 481510,
+        "completionCold": 196,
+        "completionWarm": 7,
+        "semanticTokens": 2,
+        "hover": 3,
+        "documentSymbol": 1,
+        "completionAfterSave": 126,
+        "tokensAfterSave": 0,
+        "heapMb": 271,
+        "rssAtBuildMb": 731,
+        "internedIdentifiers": 559699,
+        "peakRssMb": 869,
+        "rssSamples": 15
+      }
+    },
+    {
+      "version": "0.4.3",
+      "recordedAt": "2026-09-09",
+      "workspace": "cultivation.code-workspace",
+      "roots": 6,
+      "build": "worktree packages/server/dist/server.js",
+      "machine": {
+        "cpu": "AMD Ryzen 7 5800X 8-Core Processor             ",
+        "totalMemGb": 32,
+        "node": "v24.12.0"
+      },
+      "results": {
+        "timeToIndexedMs": 8340,
+        "definitions": 481510,
+        "completionCold": 319,
+        "completionWarm": 12,
+        "semanticTokens": 2,
+        "hover": 5,
+        "documentSymbol": 1,
+        "completionAfterSave": 232,
+        "tokensAfterSave": 1,
+        "heapMb": 271,
+        "rssAtBuildMb": 704,
+        "internedIdentifiers": 559699,
+        "peakRssMb": 844,
+        "rssSamples": 17
+      }
+    },
+    {
+      "version": "0.4.3",
+      "recordedAt": "2026-09-09",
+      "workspace": "cultivation.code-workspace",
+      "roots": 6,
+      "build": "worktree packages/server/dist/server.js",
+      "machine": {
+        "cpu": "AMD Ryzen 7 5800X 8-Core Processor             ",
+        "totalMemGb": 32,
+        "node": "v24.12.0"
+      },
+      "results": {
+        "timeToIndexedMs": 7281,
+        "definitions": 481510,
+        "completionCold": 237,
+        "completionWarm": 15,
+        "semanticTokens": 2,
+        "hover": 4,
+        "documentSymbol": 1,
+        "completionAfterSave": 216,
+        "tokensAfterSave": 1,
+        "heapMb": 271,
+        "rssAtBuildMb": 748,
+        "internedIdentifiers": 559699,
+        "peakRssMb": 885,
+        "rssSamples": 16
+      }
     }
   ]
 }

--- a/packages/server/test/snippetCatalogue.test.ts
+++ b/packages/server/test/snippetCatalogue.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { buildSnippetCatalogue } from "../src/features/snippetCatalogue";
+import type { TokenData } from "@px-lsp/protocol/types";
+import { minimalTokenInsert, scriptedCallTemplate } from "../src/features/completionInsert";
+import { resolveProfile } from "../src/games/registry";
+
+describe("generated snippet catalogue", () => {
+  it("exports all tokens without the cursor picker's cap and keeps both kinds of a name", () => {
+    const tokens: TokenData[] = Array.from({ length: 80 }, (_, i) => ({
+      name: `sample_${i}`,
+      kind: "effect",
+      scopes: [],
+      doc: "",
+      usage: `sample_${i} = { key = X }`,
+    }));
+    tokens.push({ ...tokens[0], kind: "trigger" });
+    const entries = buildSnippetCatalogue(tokens, undefined, []);
+    expect(entries).toHaveLength(81);
+    expect(new Set(entries.map((entry) => entry.id)).size).toBe(81);
+    expect(entries.every((entry) => entry.variants.length === 2)).toBe(true);
+  });
+
+  it("uses the same insertion and preview rules as completion", () => {
+    const token: TokenData = {
+      name: "set_variable",
+      kind: "effect",
+      scopes: [],
+      usage: "set_variable = { name = X value = Y days = Z }",
+      doc: "Where X is the name of the variable\nWhere Y is any event target, bool, value, script value or flag\nAn optional days where Z is the number of days",
+    };
+    const [entry] = buildSnippetCatalogue([token], undefined, []);
+    expect(entry.variants[0].snippet).toBe(minimalTokenInsert(token)!.snippet);
+    expect(entry.variants[0].preview).toContain("| value | any event target");
+    expect(entry.variants[0].snippet).not.toContain("days");
+    expect(entry.variants[1].snippet).toContain("days");
+  });
+
+  it("includes all-fields variants and effective scripted calls", () => {
+    const token: TokenData = {
+      name: "sample",
+      kind: "effect",
+      scopes: [],
+      doc: "",
+      usage: "sample = {\n key = X\n other = Y # optional\n}",
+    };
+    const def = {
+      name: "my_effect",
+      kind: "scripted_effect",
+      source: "mod" as const,
+      file: "mod.txt",
+      line: 0,
+      params: ["TARGET"],
+    };
+    const entries = buildSnippetCatalogue([token], undefined, [def, def]);
+    expect(entries[1].variants.map((v) => v.label)).toEqual(["Minimal", "Examples", "All fields"]);
+    expect(entries[0].variants[0].snippet).toBe(scriptedCallTemplate(def, "minimal")!.snippet);
+    expect(entries[0].category).toBe("Scripted calls");
+  });
+
+  it.each(["ck3", "vic3", "eu5"])("exports every bundled definition and child block for %s", (game) => {
+    const profile = resolveProfile(game);
+    const entries = buildSnippetCatalogue([], profile.skeletons, []);
+    const expected = Object.values(profile.skeletons ?? {}).reduce(
+      (sum, kind) => sum + 1 + Object.keys(kind.blocks ?? {}).length,
+      0
+    );
+    expect(entries).toHaveLength(expected);
+    expect(entries.every((entry) => entry.variants[0].snippet.length > 0)).toBe(true);
+  });
+});

--- a/packages/server/test/structure.test.ts
+++ b/packages/server/test/structure.test.ts
@@ -5,7 +5,6 @@
  * character_interaction document.
  */
 import { describe, expect, it } from "vitest";
-import { CompletionItemKind } from "vscode-languageserver/node";
 import { TextDocument } from "vscode-languageserver-textdocument";
 import { parseScript } from "../src/parser";
 import { ScopeModel } from "../src/scopes/model";
@@ -242,7 +241,7 @@ describe("completion wiring (§B2/§B3)", () => {
     // ahead of every non-structure item.
     const sorted = [...items].sort((a, b) => (a.sortText ?? a.label).localeCompare(b.sortText ?? b.label));
     const structLabels = new Set(
-      items.filter((i) => i.kind === CompletionItemKind.Keyword).map((i) => i.label)
+      schema.structures.keysByKindBlock.get("character_interaction")!.get("")!.keys()
     );
     const firstNonStruct = sorted.findIndex((i) => !structLabels.has(i.label));
     const isShownRank = sorted.findIndex((i) => i.label === "is_shown");

--- a/packages/vscode/CHANGELOG.md
+++ b/packages/vscode/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
-## Unreleased
+## 0.4.3 (beta) - completion templates and viewer backgrounds
+
+- Add Export Generated Snippets: save and open a searchable HTML catalogue with all available variants, value hints, copy controls and printing.
+
+- Show insertion previews and expected-value descriptions in completion details, using game documentation and scripted-effect `@param` comments. Keep preview hints out of inserted code and label undocumented types explicitly.
+
+- Add `px.completion.mode`: Minimal (the default) keeps documented fields with blank values and Tab stops, omitting fields marked optional. Examples restores full keyword snippets, and Names inserts only the keyword. Generated templates use the snippet icon. Explicit definition templates and Insert Snippet stay available.
+
+- Add a bottom-left background control to the Flag Builder, Coat of Arms Designer and DDS viewer, with dark and light presets, a custom color picker and reset to default. Each tool remembers its background in the workspace.
 
 - Use the same banner in the GitHub and Marketplace READMEs, remove the repeated title and vague LSP badge, and link directly to server installation, embedding and protocol guides.
 

--- a/packages/vscode/README.md
+++ b/packages/vscode/README.md
@@ -27,6 +27,8 @@ This is a beta. Check generated content in the game before publishing it. After 
 
 ## At the cursor
 
+- **Completion templates:** choose Minimal, Examples or Names with `px.completion.mode`. Preview inserted code and expected values, or run **Paradox: Export Generated Snippets (HTML / Print)** to browse, copy and print the full catalogue.
+
 - **Completion and navigation:** scope-aware ranking, definitions, references, rename, symbols and block skeletons. Items outside the inferred scope are annotated rather than hidden.
 - **Documentation from the game:** hover descriptions, scope information, localized text and texture previews, plus searchable vanilla examples.
 - **Graphics assets:** CK3 and Victoria 3 `.asset` indexing, context-specific completion, reference navigation and DDS previews. Use `px.indexAssets` to toggle scanning.
@@ -35,6 +37,8 @@ This is a beta. Check generated content in the game before publishing it. After 
 - **Localization:** coverage, inlay hints, quick fixes and workflows for adding languages or making a translation mod.
 
 ## Build and inspect content
+
+The Flag Builder, Coat of Arms Designer and DDS viewer have bottom-left background controls: dark, light, custom color and reset. Each tool remembers its choice in the workspace.
 
 The **Event Simulator** walks an event and its options beside the source. The **Event Graph** follows firing chains and lets you edit event content. Both are static tools; they do not execute the game.
 

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "px-toolkit",
   "displayName": "Paradox Modding Toolkit",
   "description": "Modding toolkit for Paradox games (Crusader Kings III, Victoria 3, Europa Universalis V): completion, go-to-definition, hover docs, tiger diagnostics, inline localization, event graph and a visual GUI editor.",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "publisher": "JDeffner",
   "author": {
     "name": "Joël Deffner"
@@ -553,6 +553,11 @@
         "title": "Insert Snippet (definition skeleton, block)"
       },
       {
+        "command": "px.exportSnippets",
+        "category": "Paradox",
+        "title": "Export Generated Snippets (HTML / Print)"
+      },
+      {
         "command": "px.createMod",
         "category": "Paradox",
         "title": "New Mod (project folder + launcher link)"
@@ -789,7 +794,7 @@
           {
             "id": "px.step.explore",
             "title": "Try it",
-            "description": "Open an event file: hover an effect, F12 a scripted effect, check the inline localization.\n[Insert Snippet](command:px.insertSnippet)",
+            "description": "Open an event file: hover an effect, F12 a scripted effect, check the inline localization.\n[Insert Snippet](command:px.insertSnippet)\n[Export all generated snippets](command:px.exportSnippets) as searchable HTML with previews and printing.",
             "media": {
               "markdown": "media/walkthrough/explore.md"
             },
@@ -959,6 +964,22 @@
         "title": "Editor",
         "order": 4,
         "properties": {
+          "px.completion.mode": {
+            "type": "string",
+            "enum": [
+              "minimal",
+              "examples",
+              "names"
+            ],
+            "enumDescriptions": [
+              "Insert documented fields with blank values and Tab stops. Fields marked optional are omitted.",
+              "Insert documented example blocks and scripted-call parameters.",
+              "Insert only the keyword name."
+            ],
+            "default": "minimal",
+            "order": 0,
+            "markdownDescription": "What accepting a script keyword completion inserts. Minimal keeps the fields from valid documented examples and leaves their values blank; unknown syntax stays a name. Explicit definition templates and **Paradox: Insert Snippet** still insert their full templates. Changes apply immediately."
+          },
           "px.hover.detail": {
             "type": "string",
             "enum": [
@@ -1466,6 +1487,10 @@
         {
           "command": "px.openSettings",
           "when": "px.isCk3Workspace"
+        },
+        {
+          "command": "px.exportSnippets",
+          "when": "px.isCk3Workspace"
         }
       ],
       "view/title": [
@@ -1900,6 +1925,11 @@
         "command": "px.insertSnippet",
         "key": "ctrl+alt+i",
         "when": "editorTextFocus && editorLangId =~ /^paradox(-(ck3|vic3|eu5))?$/"
+      },
+      {
+        "command": "px.exportSnippets",
+        "key": "ctrl+alt+shift+i",
+        "when": "px.isCk3Workspace"
       }
     ]
   },

--- a/packages/vscode/src/config.ts
+++ b/packages/vscode/src/config.ts
@@ -39,6 +39,7 @@ export interface PxConfig {
   indexAssets: boolean;
   scopeInlayHints: boolean;
   hoverDetail: "compact" | "standard" | "full";
+  completionMode: "minimal" | "examples" | "names";
   /** `px.calendar`: custom era calendar for date display, or undefined. */
   calendar: CalendarSetting | undefined;
   tigerRunOn: "save" | "manual";
@@ -313,6 +314,7 @@ export function readConfig(): PxConfig {
     scopeInlayHints: cfg.get<boolean>("scopeInlayHints") ?? false,
     indexAssets: cfg.get<boolean>("indexAssets") ?? true,
     hoverDetail: cfg.get<"compact" | "standard" | "full">("hover.detail") ?? "standard",
+    completionMode: cfg.get<"minimal" | "examples" | "names">("completion.mode") ?? "minimal",
     calendar: sanitizeCalendar(cfg.get("calendar")),
     tigerRunOn,
     enableForWorkspace,

--- a/packages/vscode/src/ddsEditor.ts
+++ b/packages/vscode/src/ddsEditor.ts
@@ -11,8 +11,12 @@
 import * as vscode from "vscode";
 import { decodeDds, ddsFormatInfo, encodePng } from "@px-lsp/server/dds";
 import { makeNonce } from "./webviews/nonce";
-import uiCss from "./webviews/shared/ui.css";
-import { icon } from "./webviews/shared/icons";
+import { ddsPreviewHtml } from "./webviews/ddsPreview/html";
+import { bundleUri, watchBundle, webviewSource } from "./webviews/devReload";
+import { readViewerBackground } from "./webviews/shared/viewerBackground";
+import type { AppToHost } from "./webviews/ddsPreview/messages";
+
+const BACKGROUND_KEY = "px.ddsPreview.background";
 
 class DdsDocument implements vscode.CustomDocument {
   constructor(
@@ -71,9 +75,9 @@ export class DdsPreviewProvider implements vscode.CustomReadonlyEditorProvider<D
 
   async resolveCustomEditor(document: DdsDocument, panel: vscode.WebviewPanel): Promise<void> {
     void this.maybePromptForDefault();
-    panel.webview.options = { enableScripts: true, localResourceRoots: [] };
+    const source = webviewSource(this.context);
+    panel.webview.options = { enableScripts: true, localResourceRoots: [source.root] };
     const name = document.uri.path.split("/").pop() ?? "texture.dds";
-    const nonce = makeNonce();
     const info = ddsFormatInfo(document.bytes);
     let png: Uint8Array | null = null;
     let dataUri: string | null = null;
@@ -91,11 +95,29 @@ export class DdsPreviewProvider implements vscode.CustomReadonlyEditorProvider<D
         error = `Preview failed: ${err instanceof Error ? err.message : String(err)}`;
       }
     }
-    panel.webview.html = pageHtml({ name, meta, dataUri, error, nonce });
+    const render = (): void => {
+      panel.webview.html = ddsPreviewHtml({
+        name,
+        meta,
+        dataUri,
+        error,
+        nonce: makeNonce(),
+        scriptSrc: bundleUri(panel.webview, source, "ddsPreview"),
+      });
+    };
 
-    const messages = panel.webview.onDidReceiveMessage(async (msg: { type?: string }) => {
+    const messages = panel.webview.onDidReceiveMessage(async (msg: AppToHost) => {
       try {
         switch (msg?.type) {
+          case "ready":
+            await panel.webview.postMessage({
+              type: "background",
+              value: readViewerBackground(this.context.workspaceState.get(BACKGROUND_KEY)),
+            });
+            break;
+          case "background":
+            await this.context.workspaceState.update(BACKGROUND_KEY, readViewerBackground(msg.value));
+            break;
           case "copyPath":
             await vscode.env.clipboard.writeText(scriptPath(document.uri.fsPath));
             break;
@@ -121,7 +143,12 @@ export class DdsPreviewProvider implements vscode.CustomReadonlyEditorProvider<D
         );
       }
     });
-    panel.onDidDispose(() => messages.dispose());
+    const watcher = watchBundle(source, "ddsPreview", render);
+    panel.onDidDispose(() => {
+      messages.dispose();
+      watcher.dispose();
+    });
+    render();
   }
 }
 
@@ -137,211 +164,4 @@ function scriptPath(fsPath: string): string {
 
 function formatBytes(n: number): string {
   return n >= 1024 * 1024 ? `${(n / (1024 * 1024)).toFixed(1)} MB` : `${(n / 1024).toFixed(1)} KB`;
-}
-
-function pageHtml(opts: {
-  name: string;
-  meta: string;
-  dataUri: string | null;
-  error: string | null;
-  nonce: string;
-}): string {
-  const { name, meta, dataUri, error, nonce } = opts;
-  const barButton = (id: string, name_: Parameters<typeof icon>[0], label: string, tip: string): string =>
-    `<button id="${id}" class="px-btn" data-variant="ghost" data-size="sm" data-tip="${tip}" data-tip-wrap>${icon(name_)}${label}</button>`;
-  const toolButton = (id: string, name_: Parameters<typeof icon>[0], tip: string): string =>
-    `<button id="${id}" class="px-btn" data-variant="ghost" data-size="icon-sm" data-tip="${tip}" data-tip-side="top" data-tip-wrap>${icon(name_)}</button>`;
-
-  const stageInfo = meta ? `<div id="stageInfo">${escapeHtml(meta)}</div>` : "";
-  const stage = error
-    ? `<div class="err">${escapeHtml(error)}</div>${stageInfo}`
-    : /* html */ `
-  <img id="img" src="${dataUri}" />
-  <div id="stageTools">
-    ${toolButton("zout", "zoomOut", "Zoom out")}
-    <span id="zoomLabel" class="px-muted px-xs" data-tip="Wheel zooms, drag pans" data-tip-side="top" data-tip-wrap>100%</span>
-    ${toolButton("zin", "zoomIn", "Zoom in")}
-    <div class="px-separator" data-orientation="vertical"></div>
-    ${toolButton("zfit", "maximize", "Fit the image to the window")}
-    ${toolButton("recenter", "locate", "Recenter at the current zoom")}
-    <div class="px-separator" data-orientation="vertical"></div>
-    <label class="px-toggle" data-size="sm" data-tip="Pixelated: nearest-neighbour scaling to inspect single pixels. Off matches how the game samples the texture (smooth)" data-tip-side="top" data-tip-wrap><input id="pix" type="checkbox" />${icon("grid")}</label>
-  </div>
-  ${stageInfo}`;
-
-  return /* html */ `<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="UTF-8" />
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src data:; style-src 'unsafe-inline'; script-src 'nonce-${nonce}'" />
-<title>DDS Preview</title>
-<style>
-${uiCss}
-  body { overflow: hidden; }
-  #app { display: flex; flex-direction: column; height: 100vh; }
-  #bar {
-    display: flex; align-items: center; gap: 6px; flex: 0 0 auto;
-    padding: 6px 8px; border-bottom: 1px solid var(--px-border);
-  }
-  #bar .px-separator { height: 20px; align-self: center; }
-  /* The name has its own padding-free text edge; the buttons carry inner padding.
-     Extra margin around this divider keeps the visual gaps equal. */
-  #fileNameWrap + .px-separator { margin: 0 4px; }
-  #fileNameWrap { position: relative; display: flex; min-width: 0; }
-  #fileName { font-weight: 600; max-width: 260px; cursor: pointer; }
-  #copyToast {
-    position: absolute; left: 50%; top: calc(100% + 6px); transform: translateX(-50%);
-    padding: 3px 8px; border-radius: var(--px-radius-md); z-index: 61;
-    font-size: var(--px-text-xs); color: var(--px-bg); background: var(--px-fg);
-    opacity: 0; transition: opacity var(--px-ease); pointer-events: none; white-space: nowrap;
-  }
-  #copyToast.show { opacity: 1; }
-  /* The toast owns the spot below the name; mute the hover tooltip while it shows. */
-  #fileNameWrap:has(> #copyToast.show)::after { opacity: 0 !important; }
-  /* A checkbox inside a toggle: hidden, its state shown on the label (the px-switch pattern). */
-  .px-toggle > input[type="checkbox"] { position: absolute; opacity: 0; width: 0; height: 0; }
-  .px-toggle:has(> input:checked) { background: var(--px-muted); }
-  .px-toggle:has(> input:focus-visible) { border-color: var(--px-ring); box-shadow: 0 0 0 3px var(--px-ring-soft); }
-  /* Panning moves the image outside the stage, so clip rather than scroll. */
-  #stage { flex: 1 1 auto; position: relative; overflow: hidden; background: #101010; }
-  #stage.panning, #stage.panning #img { cursor: grabbing; }
-  #img {
-    position: absolute; top: 0; left: 0; transform-origin: 0 0;
-    image-rendering: auto; cursor: grab;
-    /* checkerboard so alpha is visible */
-    background: repeating-conic-gradient(rgba(128,128,128,0.25) 0% 25%, transparent 0% 50%) 0 0 / 16px 16px;
-  }
-  #img.pixelated { image-rendering: pixelated; }
-  #stageTools {
-    position: absolute; left: 8px; bottom: 8px; display: flex; align-items: center; gap: 2px;
-    padding: 2px; border-radius: var(--px-radius);
-    background: color-mix(in oklch, var(--px-bg) 75%, transparent);
-  }
-  #zoomLabel { min-width: 44px; height: var(--px-h-sm); line-height: var(--px-h-sm); padding: 0 6px; text-align: center; font-variant-numeric: tabular-nums; cursor: default; }
-  #stageInfo {
-    position: absolute; right: 8px; bottom: 8px;
-    padding: 4px 10px; border-radius: var(--px-radius);
-    color: var(--px-muted-fg); font-size: var(--px-text-xs); font-variant-numeric: tabular-nums;
-    background: color-mix(in oklch, var(--px-bg) 75%, transparent);
-    pointer-events: none;
-  }
-  .err { padding: 24px; color: var(--px-destructive); }
-</style>
-</head>
-<body>
-<div id="app">
-  <div id="bar">
-    <span id="fileNameWrap" data-tip="Click to copy the file name"><span id="fileName" class="px-truncate">${escapeHtml(name)}</span><span id="copyToast">Copied!</span></span>
-    <div class="px-separator" data-orientation="vertical"></div>
-    ${barButton("copyPath", "copy", "Copy path", "Copy the path from the gfx/ root, as script references it")}
-    ${barButton("reveal", "folderOpen", "Reveal", "Show the file in the system file explorer")}
-    ${dataUri ? barButton("savePng", "imageDown", "Save PNG", "Decode the texture and save it as a .png") : ""}
-  </div>
-  <div id="stage">${stage}</div>
-</div>
-<script nonce="${nonce}">
-  const vscode = acquireVsCodeApi();
-  for (const id of ["copyPath", "reveal", "savePng"]) {
-    const el = document.getElementById(id);
-    if (el) el.addEventListener("click", () => vscode.postMessage({ type: id }));
-  }
-  const copyToast = document.getElementById("copyToast");
-  let toastTimer = 0;
-  document.getElementById("fileName").addEventListener("click", () => {
-    vscode.postMessage({ type: "copyName" });
-    copyToast.classList.add("show");
-    clearTimeout(toastTimer);
-    toastTimer = setTimeout(() => copyToast.classList.remove("show"), 1200);
-  });
-
-  const stage = document.getElementById("stage");
-  const img = document.getElementById("img");
-  if (img) {
-    // Zoom clamps: 5% to 3200%.
-    const MIN = 0.05, MAX = 32;
-    let scale = 1, tx = 0, ty = 0;
-    const zoomLabel = document.getElementById("zoomLabel");
-
-    function apply() {
-      img.style.transform = "translate(" + tx + "px," + ty + "px) scale(" + scale + ")";
-      zoomLabel.textContent = Math.round(scale * 100) + "%";
-    }
-    function fitScale() {
-      return Math.min(1, stage.clientWidth / img.naturalWidth, stage.clientHeight / img.naturalHeight);
-    }
-    function center(s) {
-      scale = Math.max(MIN, Math.min(MAX, s));
-      tx = (stage.clientWidth - img.naturalWidth * scale) / 2;
-      ty = (stage.clientHeight - img.naturalHeight * scale) / 2;
-      apply();
-    }
-    // Zoom about a stage-relative point, keeping the image pixel under it fixed.
-    function zoomAt(cx, cy, factor) {
-      const next = Math.max(MIN, Math.min(MAX, scale * factor));
-      const ix = (cx - tx) / scale, iy = (cy - ty) / scale;
-      scale = next;
-      tx = cx - ix * scale;
-      ty = cy - iy * scale;
-      apply();
-    }
-
-    const fit = () => center(fitScale() > 0 ? fitScale() : 1);
-    img.addEventListener("load", fit);
-    if (img.complete && img.naturalWidth > 0) fit();
-
-    // The webview often lays out at a provisional size before the editor pane
-    // settles, so a load-time fit is wrong minutes later. Keep the image
-    // fitted on every stage resize until the user zooms or pans themselves.
-    let touched = false;
-    new ResizeObserver(() => { if (!touched) fit(); }).observe(stage);
-
-    stage.addEventListener("wheel", (e) => {
-      e.preventDefault();
-      touched = true;
-      const r = stage.getBoundingClientRect();
-      zoomAt(e.clientX - r.left, e.clientY - r.top, e.deltaY < 0 ? 1.15 : 1 / 1.15);
-    }, { passive: false });
-
-    // Left- or middle-button drag pans; preventDefault suppresses image drag / autoscroll.
-    let panX = 0, panY = 0, panning = false;
-    stage.addEventListener("mousedown", (e) => {
-      // Clicks on the floating tools interact with them, never pan.
-      if (e.target instanceof Element && e.target.closest("#stageTools")) return;
-      if (e.button !== 0 && e.button !== 1) return;
-      e.preventDefault();
-      touched = true;
-      panning = true; panX = e.clientX; panY = e.clientY;
-      stage.classList.add("panning");
-    });
-    window.addEventListener("mousemove", (e) => {
-      if (!panning) return;
-      tx += e.clientX - panX; ty += e.clientY - panY;
-      panX = e.clientX; panY = e.clientY;
-      apply();
-    });
-    window.addEventListener("mouseup", () => {
-      if (!panning) return;
-      panning = false; stage.classList.remove("panning");
-    });
-    stage.addEventListener("auxclick", (e) => { if (e.button === 1) e.preventDefault(); });
-    img.addEventListener("dragstart", (e) => e.preventDefault());
-
-    const cx = () => stage.clientWidth / 2, cy = () => stage.clientHeight / 2;
-    document.getElementById("zin").addEventListener("click", () => { touched = true; zoomAt(cx(), cy(), 1.25); });
-    document.getElementById("zout").addEventListener("click", () => { touched = true; zoomAt(cx(), cy(), 1 / 1.25); });
-    // Fit re-arms the auto-fit: the view should stay fitted through resizes again.
-    document.getElementById("zfit").addEventListener("click", () => { touched = false; fit(); });
-    document.getElementById("recenter").addEventListener("click", () => { touched = true; center(scale); });
-    document.getElementById("pix").addEventListener("change", (e) => img.classList.toggle("pixelated", e.target.checked));
-  }
-</script>
-</body>
-</html>`;
-}
-
-function escapeHtml(s: string): string {
-  return s.replace(
-    /[&<>"']/g,
-    (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[c]!
-  );
 }

--- a/packages/vscode/src/exportSnippets.ts
+++ b/packages/vscode/src/exportSnippets.ts
@@ -1,0 +1,43 @@
+import * as vscode from "vscode";
+import { randomUUID } from "node:crypto";
+import { snippetCatalogueRequest, type SnippetCatalogueResult } from "@px-lsp/protocol/protocol";
+import { snippetCatalogueHtml } from "./snippetCatalogueHtml";
+
+export async function exportSnippetsCommand(
+  storage: vscode.Uri,
+  send: <R>(method: string, params: unknown) => Promise<R>
+): Promise<void> {
+  try {
+    const uri = await vscode.window.withProgress(
+      { location: vscode.ProgressLocation.Notification, title: "Exporting generated snippets" },
+      async () => {
+        const result = await send<SnippetCatalogueResult>(snippetCatalogueRequest, {});
+        if (result.indexing) {
+          void vscode.window.showInformationMessage(
+            "The toolkit is still indexing. Run Export Generated Snippets when indexing finishes."
+          );
+          return undefined;
+        }
+        const folder = vscode.Uri.joinPath(storage, "snippet-exports");
+        await vscode.workspace.fs.createDirectory(folder);
+        const file = vscode.Uri.joinPath(
+          folder,
+          `generated-snippets-${result.gameId.replace(/[^a-z0-9-]/gi, "_")}-${Date.now()}-${randomUUID().slice(0, 8)}.html`
+        );
+        await vscode.workspace.fs.writeFile(file, Buffer.from(snippetCatalogueHtml(result), "utf8"));
+        return file;
+      }
+    );
+    if (!uri) return;
+    const opened = await vscode.env.openExternal(uri);
+    const action = await vscode.window.showInformationMessage(
+      `${opened ? "Exported generated snippets." : "Exported generated snippets; the browser could not be opened."} Saved to ${uri.fsPath}`,
+      "Show File"
+    );
+    if (action === "Show File") await vscode.commands.executeCommand("revealFileInOS", uri);
+  } catch (error) {
+    void vscode.window.showErrorMessage(
+      `Could not export snippets: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
+}

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -85,6 +85,7 @@ import { reduceEditorLoadCommand } from "./reduceEditorLoad";
 import { translateNextCommand } from "./translationLoop";
 import { newContentCommand } from "./scaffold/command";
 import { insertSnippetCommand } from "./insertSnippet";
+import { exportSnippetsCommand } from "./exportSnippets";
 import { createModCommand, moveModCommand } from "./modProjects/command";
 import { registerDescriptorMod } from "./descriptorMod";
 import { registerWorkshop } from "./steam/workshop";
@@ -192,6 +193,7 @@ function toSettings(c: PxConfig): ParadoxSettings {
     locLanguage: c.locLanguage,
     indexAssets: c.indexAssets,
     scopeInlayHints: c.scopeInlayHints,
+    completionMode: c.completionMode,
     calendar: c.calendar,
     diagnosticsIgnore: c.diagnosticsIgnore,
     diagnosticsIgnorePatterns: c.diagnosticsIgnorePatterns,
@@ -709,6 +711,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     vscode.commands.registerCommand("px.runTiger", () => tiger.run(true)),
     vscode.commands.registerCommand("px.insertSnippet", () =>
       insertSnippetCommand((method, params) => lc.sendRequest(method, params))
+    ),
+    vscode.commands.registerCommand("px.exportSnippets", () =>
+      exportSnippetsCommand(context.globalStorageUri, (method, params) => lc.sendRequest(method, params))
     ),
     // Target of the "N references" hover link: open the references peek for
     // the hovered site (the LSP reference provider supplies the locations).

--- a/packages/vscode/src/snippetCatalogueHtml.ts
+++ b/packages/vscode/src/snippetCatalogueHtml.ts
@@ -1,0 +1,69 @@
+import type { SnippetCatalogueResult } from "@px-lsp/protocol/protocol";
+
+const escape = (text: string) =>
+  text.replace(
+    /[&<>"']/g,
+    (char) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[char]!
+  );
+
+/** Only the code fence and table emitted by completionPreview; no arbitrary HTML or links. */
+function previewHtml(markdown: string): string {
+  const code = /^(`{3,})[^\n]*\n([\s\S]*?)\n\1/m.exec(markdown)?.[2] ?? "";
+  const decode = (text: string) =>
+    text
+      .trim()
+      .replace(/&#124;/g, "|")
+      .replace(/&lt;/g, "<")
+      .replace(/&gt;/g, ">")
+      .replace(/&amp;/g, "&")
+      .replace(/\\([\\`*_[\]])/g, "$1");
+  const rows = markdown
+    .split("\n")
+    .filter((line) => line.startsWith("| "))
+    .slice(2);
+  const table = rows.length
+    ? "<table><thead><tr><th>Field</th><th>Expected value / documentation</th></tr></thead><tbody>" +
+      rows
+        .map(
+          (row) =>
+            "<tr>" +
+            row
+              .slice(1, -1)
+              .split("|")
+              .map((cell) => `<td>${escape(decode(cell))}</td>`)
+              .join("") +
+            "</tr>"
+        )
+        .join("") +
+      "</tbody></table>"
+    : "";
+  return `<pre>${escape(code)}</pre>${table}`;
+}
+
+export function snippetCatalogueHtml(result: SnippetCatalogueResult): string {
+  const entries = result.entries.map((entry) => ({
+    ...entry,
+    variants: entry.variants.map((variant) => ({ ...variant, html: previewHtml(variant.preview) })),
+  }));
+  const data = JSON.stringify(entries).replace(/</g, "\\u003c");
+  return `<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Generated snippets | ${escape(result.gameName)}</title>
+<style>
+:root{color-scheme:dark}*{box-sizing:border-box}body{margin:0;background:#191b1e;color:#eeefed;font:18px/1.65 'Segoe UI',system-ui,sans-serif}main{max-width:1180px;margin:auto;padding:40px 28px}h1{font-size:32px;line-height:1.25;margin:0 0 12px}p{max-width:72ch}.muted{color:#abb0b7;font-size:14px}.controls{position:sticky;top:0;background:#191b1e;padding:16px 0;border-bottom:1px solid #383d43;z-index:1;display:flex;gap:10px;flex-wrap:wrap;align-items:center}input,select,button{font:inherit;font-size:15px;color:inherit;background:#22252a;border:1px solid #555c64;border-radius:6px;padding:8px 12px}input[type=search]{flex:1;min-width:220px}button{cursor:pointer}button:hover{background:#353a42}label{font-size:14px}input[type=checkbox]{margin-right:6px}input:focus-visible,button:focus-visible,select:focus-visible,summary:focus-visible{outline:2px solid #e0c999;outline-offset:3px}details{margin:9px 0;border:1px solid #383d43;border-radius:7px;background:#22252a}summary{padding:12px 16px;cursor:pointer;font-size:16px;overflow-wrap:anywhere}summary span{color:#abb0b7;font-size:13px;margin-left:14px}.content{padding:0 18px 18px}.content button{float:right;margin:0 0 8px 10px}pre{clear:both;white-space:pre-wrap;overflow-wrap:anywhere;tab-size:4;background:#191b1f;padding:16px;border-radius:5px;font:14px/1.65 Consolas,'Cascadia Code',monospace}table{width:100%;border-collapse:collapse;font-size:14px}th,td{text-align:left;vertical-align:top;padding:9px;border-bottom:1px solid #383d43;overflow-wrap:anywhere}th:first-child{width:25%}[hidden]{display:none!important}footer{border-top:1px solid #383d43;margin-top:28px;padding-top:16px}
+@media print{:root{color-scheme:light}body,details,pre,main{background:white;color:black}main{max-width:none;padding:0}.controls,button,footer,#message{display:none!important}details{break-inside:avoid;border-color:#bbb}summary{font-weight:600}pre{border:1px solid #ddd}th,td{border-color:#bbb}.muted,summary span{color:#444}}
+</style></head><body><main><h1>Generated snippets</h1><p>${escape(result.gameName)} · ${entries.length.toLocaleString("en-US")} entries</p><p class="muted">Generated ${escape(result.generatedAt)} from the toolkit’s loaded documentation, bundled definition skeletons and indexed scripted calls. Fixed JSON snippets and GUI completions are separate. Re-run Export Generated Snippets after updating or reloading the game documentation.</p>
+<div class="controls"><input id="search" type="search" aria-label="Search snippets" placeholder="Search names, code or value hints"><select id="category" aria-label="Category"><option>All categories</option><option>Engine</option><option>Definitions</option><option>Child blocks</option><option>Scripted calls</option></select><select id="mode" aria-label="Snippet variant"><option>Minimal</option><option>Examples</option><option>All fields</option><option>All variants</option></select><label><input id="stops" type="checkbox">Show Tab stops</label><button id="print">Print / Save PDF</button></div><p id="count" class="muted" aria-live="polite"></p><p id="message" class="muted" aria-live="polite"></p><section id="entries" aria-label="Snippets"></section><footer class="muted">Minimal keeps documented fields with blank values. Examples retains example values. All fields includes optional fields where that variant exists. All variants shows and prints every available form. Entries without the selected variant show their available template. Printing includes every matching entry in the selected variant; clear the search and select All categories to print the full catalogue. Copy uses plain insertion text, or snippet syntax when Show Tab stops is checked. Type hints are documentation only.</footer></main>
+<script type="application/json" id="data">${data}</script><script>${SCRIPT}</script></body></html>`;
+}
+
+const SCRIPT = String.raw`
+const entries=JSON.parse(document.getElementById('data').textContent);
+const search=document.getElementById('search'),category=document.getElementById('category'),mode=document.getElementById('mode'),stops=document.getElementById('stops'),list=document.getElementById('entries');
+const nodes=entries.map((entry)=>{const node=document.createElement('details'),title=document.createElement('summary'),tag=document.createElement('span'),body=document.createElement('div');title.textContent=entry.label;tag.textContent=entry.category;title.append(tag);body.className='content';node.append(title,body);node.addEventListener('toggle',()=>{if(node.open)fill(node,entry)});list.append(node);return node});
+const searchable=entries.map(e=>(e.label+' '+e.detail+' '+e.variants.map(v=>v.snippet+' '+v.preview).join(' ')).toLowerCase());
+function selected(entry){return entry.variants.find(v=>v.label===mode.value)||entry.variants.find(v=>v.label==='Examples')||entry.variants[0]}
+function fill(node,entry){const body=node.querySelector('.content');body.replaceChildren();for(const variant of mode.value==='All variants'?entry.variants:[selected(entry)]){const section=document.createElement('section');section.innerHTML=variant.html;const meta=document.createElement('p');meta.className='muted';meta.textContent=entry.detail+' / '+variant.label;const copy=document.createElement('button');copy.textContent='Copy '+variant.label;copy.addEventListener('click',async()=>{try{await navigator.clipboard.writeText(stops.checked?variant.snippet:variant.plain);document.getElementById('message').textContent='Copied '+entry.label}catch{document.getElementById('message').textContent='Copy could not access the clipboard. Select and copy the code below.'}});section.prepend(copy,meta);if(stops.checked)section.querySelector('pre').textContent=variant.snippet;body.append(section);}}
+function filter(){const query=search.value.trim().toLowerCase();let count=0;nodes.forEach((node,i)=>{node.hidden=!(searchable[i].includes(query)&&(category.value==='All categories'||entries[i].category===category.value));if(!node.hidden)count++});document.getElementById('count').textContent=count+' of '+entries.length+' entries'+(count===0?' · No matches':'');}
+function update(){nodes.forEach((node,i)=>{if(node.open)fill(node,entries[i])})}
+search.addEventListener('input',filter);category.addEventListener('change',filter);mode.addEventListener('change',update);stops.addEventListener('change',update);document.getElementById('print').addEventListener('click',()=>window.print());
+let openBeforePrint=[];window.addEventListener('beforeprint',()=>{openBeforePrint=nodes.map(node=>node.open);nodes.forEach((node,i)=>{if(!node.hidden){fill(node,entries[i]);node.open=true}})});window.addEventListener('afterprint',()=>{nodes.forEach((node,i)=>{node.open=openBeforePrint[i]})});filter();
+`;

--- a/packages/vscode/src/webviews/coaDesigner/app/main.ts
+++ b/packages/vscode/src/webviews/coaDesigner/app/main.ts
@@ -13,6 +13,7 @@
  * with the Flag Builder: this panel is a different way to reach the same
  * `coat_of_arms` definition, not a second renderer.
  */
+import { viewerBackground } from "../../shared/viewerBackground";
 import {
   COLOR_SLOTS,
   colorToRgb,
@@ -2285,6 +2286,10 @@ function defaultFrame(label: string | undefined): string {
 // ---------------------------------------------------------------------------
 
 const stage = $("stage");
+const background = viewerBackground(stage, $("stageTools"), (value) => {
+  uiState = { ...uiState, background: value };
+  send({ type: "uiState", state: uiState });
+});
 const viewport = $("viewport");
 const view = { x: 0, y: 0, scale: 1 };
 
@@ -2892,6 +2897,7 @@ window.addEventListener("message", (event: MessageEvent<HostToApp>) => {
       if (first) {
         if (m.ui) {
           uiState = { ...uiState, ...m.ui };
+          background.restore(uiState.background);
           right.setWidth(m.ui.panelWidth);
           right.toggle(m.ui.panelCollapsed);
           if (m.ui.leftWidth !== undefined) left.setWidth(m.ui.leftWidth);

--- a/packages/vscode/src/webviews/coaDesigner/messages.ts
+++ b/packages/vscode/src/webviews/coaDesigner/messages.ts
@@ -8,6 +8,7 @@
  * a `frames/<id>` texture drawn over the arms masked by `masks/<id>`, and it
  * is decoration for the preview only, never written into the script.
  */
+import type { ViewerBackground } from "../shared/viewerBackground";
 import type { DesignerFrame, FlagDatabase, FlagEntry, FlagTarget, ModTarget } from "../flagBuilder/messages";
 import type { CoaFlag } from "@px-lsp/server/coa/coa";
 import type { CreatorSaveTarget } from "../shared/creatorMessages";
@@ -32,6 +33,8 @@ export type DesignerTab = "background" | "layout" | "emblems";
 
 /** Per-user layout the host remembers across sessions. */
 export interface DesignerUiState {
+  /** Preview background only; never written into the design. */
+  background?: ViewerBackground;
   /** The RIGHT panel (the Background / Layout / Emblems tabs). */
   panelWidth: number;
   panelCollapsed: boolean;

--- a/packages/vscode/src/webviews/dashboard/actions.ts
+++ b/packages/vscode/src/webviews/dashboard/actions.ts
@@ -141,6 +141,12 @@ export function actionGroups(meta: GameMeta, gameProblems: number): ActionGroup[
           icon: "bookOpen",
           tip: "Search every trigger, effect and datafunction the game has.",
         },
+        {
+          label: "Export Generated Snippets",
+          command: "px.exportSnippets",
+          icon: "download",
+          tip: "Open a searchable HTML catalogue with snippet previews, copying and printing.",
+        },
       ],
     },
     {

--- a/packages/vscode/src/webviews/ddsPreview/app/main.ts
+++ b/packages/vscode/src/webviews/ddsPreview/app/main.ts
@@ -1,0 +1,147 @@
+import { viewerBackground } from "../../shared/viewerBackground";
+import { installTips } from "../../shared/tips";
+import type { AppToHost, HostToApp } from "../messages";
+
+declare function acquireVsCodeApi(): { postMessage(message: AppToHost): void };
+const $ = <T extends HTMLElement = HTMLElement>(id: string): T => document.getElementById(id) as T;
+installTips();
+const vscode = acquireVsCodeApi();
+for (const id of ["copyPath", "reveal", "savePng"] as const) {
+  const el = $(id);
+  if (el) el.addEventListener("click", () => vscode.postMessage({ type: id }));
+}
+const copyToast = $("copyToast");
+let toastTimer = 0;
+$("fileName").addEventListener("click", () => {
+  vscode.postMessage({ type: "copyName" });
+  copyToast.classList.add("show");
+  clearTimeout(toastTimer);
+  toastTimer = window.setTimeout(() => copyToast.classList.remove("show"), 1200);
+});
+
+const stage = $("stage");
+const img = $<HTMLImageElement>("img");
+const background = viewerBackground(
+  stage,
+  $("stageTools"),
+  (value) => {
+    vscode.postMessage({ type: "background", value });
+  },
+  img
+);
+window.addEventListener("message", (event: MessageEvent<HostToApp>) => {
+  if (event.data.type === "background") background.restore(event.data.value);
+});
+vscode.postMessage({ type: "ready" });
+if (img) {
+  // Zoom clamps: 5% to 3200%.
+  const MIN = 0.05,
+    MAX = 32;
+  let scale = 1,
+    tx = 0,
+    ty = 0;
+  const zoomLabel = $("zoomLabel");
+
+  function apply() {
+    img.style.transform = "translate(" + tx + "px," + ty + "px) scale(" + scale + ")";
+    zoomLabel.textContent = Math.round(scale * 100) + "%";
+  }
+  function fitScale() {
+    return Math.min(1, stage.clientWidth / img.naturalWidth, stage.clientHeight / img.naturalHeight);
+  }
+  function center(s: number) {
+    scale = Math.max(MIN, Math.min(MAX, s));
+    tx = (stage.clientWidth - img.naturalWidth * scale) / 2;
+    ty = (stage.clientHeight - img.naturalHeight * scale) / 2;
+    apply();
+  }
+  // Zoom about a stage-relative point, keeping the image pixel under it fixed.
+  function zoomAt(cx: number, cy: number, factor: number) {
+    const next = Math.max(MIN, Math.min(MAX, scale * factor));
+    const ix = (cx - tx) / scale,
+      iy = (cy - ty) / scale;
+    scale = next;
+    tx = cx - ix * scale;
+    ty = cy - iy * scale;
+    apply();
+  }
+
+  const fit = () => center(fitScale() > 0 ? fitScale() : 1);
+  img.addEventListener("load", fit);
+  if (img.complete && img.naturalWidth > 0) fit();
+
+  // The webview often lays out at a provisional size before the editor pane
+  // settles, so a load-time fit is wrong minutes later. Keep the image
+  // fitted on every stage resize until the user zooms or pans themselves.
+  let touched = false;
+  new ResizeObserver(() => {
+    if (!touched) fit();
+  }).observe(stage);
+
+  stage.addEventListener(
+    "wheel",
+    (e) => {
+      e.preventDefault();
+      touched = true;
+      const r = stage.getBoundingClientRect();
+      zoomAt(e.clientX - r.left, e.clientY - r.top, e.deltaY < 0 ? 1.15 : 1 / 1.15);
+    },
+    { passive: false }
+  );
+
+  // Left- or middle-button drag pans; preventDefault suppresses image drag / autoscroll.
+  let panX = 0,
+    panY = 0,
+    panning = false;
+  stage.addEventListener("mousedown", (e) => {
+    // Clicks on the floating tools interact with them, never pan.
+    if (e.target instanceof Element && e.target.closest("#stageTools")) return;
+    if (e.button !== 0 && e.button !== 1) return;
+    e.preventDefault();
+    touched = true;
+    panning = true;
+    panX = e.clientX;
+    panY = e.clientY;
+    stage.classList.add("panning");
+  });
+  window.addEventListener("mousemove", (e) => {
+    if (!panning) return;
+    tx += e.clientX - panX;
+    ty += e.clientY - panY;
+    panX = e.clientX;
+    panY = e.clientY;
+    apply();
+  });
+  window.addEventListener("mouseup", () => {
+    if (!panning) return;
+    panning = false;
+    stage.classList.remove("panning");
+  });
+  stage.addEventListener("auxclick", (e) => {
+    if (e.button === 1) e.preventDefault();
+  });
+  img.addEventListener("dragstart", (e) => e.preventDefault());
+
+  const cx = () => stage.clientWidth / 2,
+    cy = () => stage.clientHeight / 2;
+  $("zin").addEventListener("click", () => {
+    touched = true;
+    zoomAt(cx(), cy(), 1.25);
+  });
+  $("zout").addEventListener("click", () => {
+    touched = true;
+    zoomAt(cx(), cy(), 1 / 1.25);
+  });
+  // Fit re-arms the auto-fit: the view should stay fitted through resizes again.
+  $("zfit").addEventListener("click", () => {
+    touched = false;
+    fit();
+  });
+  $("recenter").addEventListener("click", () => {
+    touched = true;
+    center(scale);
+  });
+  $("pix").addEventListener("change", (e) =>
+    img.classList.toggle("pixelated", (e.target as HTMLInputElement).checked)
+  );
+}

--- a/packages/vscode/src/webviews/ddsPreview/app/tsconfig.json
+++ b/packages/vscode/src/webviews/ddsPreview/app/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  // The DDS viewer app is browser code, not extension-host code: it gets the DOM
+  // and NOTHING else. `types: []` is the point — no node, no vscode — so a
+  // host API can only reach app/ through messages.ts. The root tsconfig
+  // excludes this folder and typecheck runs this project on top of it.
+  "extends": "../../../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "lib": ["ES2022", "DOM"],
+    "types": [],
+    "paths": {
+      "@px-lsp/protocol/*": ["../../../../../protocol/src/*"],
+      "@px-lsp/server/*": ["../../../../../server/src/*"]
+    }
+  },
+  "include": ["."]
+}

--- a/packages/vscode/src/webviews/ddsPreview/html.ts
+++ b/packages/vscode/src/webviews/ddsPreview/html.ts
@@ -1,0 +1,115 @@
+import uiCss from "../shared/ui.css";
+import { icon } from "../shared/icons";
+
+export function ddsPreviewHtml(opts: {
+  name: string;
+  meta: string;
+  dataUri: string | null;
+  error: string | null;
+  nonce: string;
+  scriptSrc: string;
+}): string {
+  const { name, meta, dataUri, error, nonce, scriptSrc } = opts;
+  const barButton = (id: string, name_: Parameters<typeof icon>[0], label: string, tip: string): string =>
+    `<button id="${id}" class="px-btn" data-variant="ghost" data-size="sm" data-tip="${tip}" data-tip-wrap>${icon(name_)}${label}</button>`;
+  const toolButton = (id: string, name_: Parameters<typeof icon>[0], tip: string): string =>
+    `<button id="${id}" class="px-btn" data-variant="ghost" data-size="icon-sm" data-tip="${tip}" data-tip-side="top" data-tip-wrap>${icon(name_)}</button>`;
+
+  const stageInfo = meta ? `<div id="stageInfo">${escapeHtml(meta)}</div>` : "";
+  const stage = error
+    ? `<div class="err">${escapeHtml(error)}</div><div id="stageTools"></div>${stageInfo}`
+    : /* html */ `
+  <img id="img" src="${dataUri}" />
+  <div id="stageTools">
+    ${toolButton("zout", "zoomOut", "Zoom out")}
+    <span id="zoomLabel" class="px-muted px-xs" data-tip="Wheel zooms, drag pans" data-tip-side="top" data-tip-wrap>100%</span>
+    ${toolButton("zin", "zoomIn", "Zoom in")}
+    <div class="px-separator" data-orientation="vertical"></div>
+    ${toolButton("zfit", "maximize", "Fit the image to the window")}
+    ${toolButton("recenter", "locate", "Recenter at the current zoom")}
+    <div class="px-separator" data-orientation="vertical"></div>
+    <label class="px-toggle" data-size="sm" data-tip="Pixelated: nearest-neighbour scaling to inspect single pixels. Off matches how the game samples the texture (smooth)" data-tip-side="top" data-tip-wrap><input id="pix" type="checkbox" />${icon("grid")}</label>
+  </div>
+  ${stageInfo}`;
+
+  return /* html */ `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src data:; style-src 'unsafe-inline'; script-src 'nonce-${nonce}'" />
+<title>DDS Preview</title>
+<style>
+${uiCss}
+  body { overflow: hidden; }
+  #app { display: flex; flex-direction: column; height: 100vh; }
+  #bar {
+    display: flex; align-items: center; gap: 6px; flex: 0 0 auto;
+    padding: 6px 8px; border-bottom: 1px solid var(--px-border);
+  }
+  #bar .px-separator { height: 20px; align-self: center; }
+  /* The name has its own padding-free text edge; the buttons carry inner padding.
+     Extra margin around this divider keeps the visual gaps equal. */
+  #fileNameWrap + .px-separator { margin: 0 4px; }
+  #fileNameWrap { position: relative; display: flex; min-width: 0; }
+  #fileName { font-weight: 600; max-width: 260px; cursor: pointer; }
+  #copyToast {
+    position: absolute; left: 50%; top: calc(100% + 6px); transform: translateX(-50%);
+    padding: 3px 8px; border-radius: var(--px-radius-md); z-index: 61;
+    font-size: var(--px-text-xs); color: var(--px-bg); background: var(--px-fg);
+    opacity: 0; transition: opacity var(--px-ease); pointer-events: none; white-space: nowrap;
+  }
+  #copyToast.show { opacity: 1; }
+  /* The toast owns the spot below the name; mute the hover tooltip while it shows. */
+  #fileNameWrap:has(> #copyToast.show)::after { opacity: 0 !important; }
+  /* A checkbox inside a toggle: hidden, its state shown on the label (the px-switch pattern). */
+  .px-toggle > input[type="checkbox"] { position: absolute; opacity: 0; width: 0; height: 0; }
+  .px-toggle:has(> input:checked) { background: var(--px-muted); }
+  .px-toggle:has(> input:focus-visible) { border-color: var(--px-ring); box-shadow: 0 0 0 3px var(--px-ring-soft); }
+  /* Panning moves the image outside the stage, so clip rather than scroll. */
+  #stage { flex: 1 1 auto; position: relative; overflow: hidden; background: #101010; }
+  #stage.panning, #stage.panning #img { cursor: grabbing; }
+  #img {
+    position: absolute; top: 0; left: 0; transform-origin: 0 0;
+    image-rendering: auto; cursor: grab;
+    /* checkerboard so alpha is visible */
+    background: repeating-conic-gradient(rgba(128,128,128,0.25) 0% 25%, transparent 0% 50%) 0 0 / 16px 16px;
+  }
+  #img.pixelated { image-rendering: pixelated; }
+  #stageTools {
+    position: absolute; left: 8px; bottom: 8px; display: flex; align-items: center; gap: 2px;
+    padding: 2px; border-radius: var(--px-radius);
+    background: color-mix(in oklch, var(--px-bg) 75%, transparent);
+  }
+  #zoomLabel { min-width: 44px; height: var(--px-h-sm); line-height: var(--px-h-sm); padding: 0 6px; text-align: center; font-variant-numeric: tabular-nums; cursor: default; }
+  #stageInfo {
+    position: absolute; right: 8px; bottom: 8px;
+    padding: 4px 10px; border-radius: var(--px-radius);
+    color: var(--px-muted-fg); font-size: var(--px-text-xs); font-variant-numeric: tabular-nums;
+    background: color-mix(in oklch, var(--px-bg) 75%, transparent);
+    pointer-events: none;
+  }
+  .err { padding: 24px; color: var(--px-destructive); }
+</style>
+</head>
+<body>
+<div id="app">
+  <div id="bar">
+    <span id="fileNameWrap" data-tip="Click to copy the file name"><span id="fileName" class="px-truncate">${escapeHtml(name)}</span><span id="copyToast">Copied!</span></span>
+    <div class="px-separator" data-orientation="vertical"></div>
+    ${barButton("copyPath", "copy", "Copy path", "Copy the path from the gfx/ root, as script references it")}
+    ${barButton("reveal", "folderOpen", "Reveal", "Show the file in the system file explorer")}
+    ${dataUri ? barButton("savePng", "imageDown", "Save PNG", "Decode the texture and save it as a .png") : ""}
+  </div>
+  <div id="stage">${stage}</div>
+</div>
+<script nonce="${nonce}" src="${scriptSrc}"></script>
+</body>
+</html>`;
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(
+    /[&<>"']/g,
+    (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[c]!
+  );
+}

--- a/packages/vscode/src/webviews/ddsPreview/messages.ts
+++ b/packages/vscode/src/webviews/ddsPreview/messages.ts
@@ -1,0 +1,7 @@
+import type { ViewerBackground } from "../shared/viewerBackground";
+
+export type AppToHost =
+  | { type: "ready" | "copyPath" | "copyName" | "reveal" | "savePng" }
+  | { type: "background"; value: ViewerBackground };
+
+export type HostToApp = { type: "background"; value: ViewerBackground };

--- a/packages/vscode/src/webviews/flagBuilder/app/main.ts
+++ b/packages/vscode/src/webviews/flagBuilder/app/main.ts
@@ -6,6 +6,7 @@
  * edit and every committed field value is one step. Built from the shared
  * px-ui classes; talks to the host only through messages.ts.
  */
+import { viewerBackground } from "../../shared/viewerBackground";
 import {
   COLOR_SLOTS,
   colorToRgb,
@@ -1242,6 +1243,10 @@ function updateModPicker(): void {
 // ---------------------------------------------------------------------------
 
 const stage = $("stage");
+const background = viewerBackground(stage, $("stageTools"), (value) => {
+  uiState = { ...uiState, background: value };
+  send({ type: "uiState", state: uiState });
+});
 const viewport = $("viewport");
 const view = { x: 0, y: 0, scale: 1 };
 
@@ -1622,6 +1627,7 @@ window.addEventListener("message", (event: MessageEvent<HostToApp>) => {
       if (first) {
         if (m.ui) {
           uiState = m.ui;
+          background.restore(uiState.background);
           panel.setWidth(m.ui.panelWidth);
           panel.toggle(m.ui.panelCollapsed);
           applyView();

--- a/packages/vscode/src/webviews/flagBuilder/messages.ts
+++ b/packages/vscode/src/webviews/flagBuilder/messages.ts
@@ -3,6 +3,7 @@
  * Everything the app knows about the game arrives in `init`; textures are
  * fetched on demand as webview URLs because the app cannot read the disk.
  */
+import type { ViewerBackground } from "../shared/viewerBackground";
 import type { CoaFlag, DesignerEntry, Rgb } from "@px-lsp/server/coa/coa";
 
 export type TextureKind = "patterns" | "colored_emblems" | "textured_emblems";
@@ -108,6 +109,8 @@ export interface FlagDatabase {
 
 /** Per-user layout the host remembers across sessions. */
 export interface UiState {
+  /** Preview background only; never written into the design. */
+  background?: ViewerBackground;
   panelWidth: number;
   panelCollapsed: boolean;
   /** The mod flags are saved into (its path), when the workspace has several. */

--- a/packages/vscode/src/webviews/shared/viewerBackground.ts
+++ b/packages/vscode/src/webviews/shared/viewerBackground.ts
@@ -1,0 +1,86 @@
+import { colorPicker, hexToRgb, rgbToHex } from "./colorPicker";
+import { iconEl } from "./icons";
+import { menu } from "./overlay";
+
+export type ViewerBackground = "default" | "dark" | "light" | `#${string}`;
+
+export function readViewerBackground(value: unknown): ViewerBackground {
+  if (value === "dark" || value === "light") return value;
+  if (typeof value === "string" && /^#[0-9a-f]{6}$/i.test(value)) {
+    return value.toLowerCase() as ViewerBackground;
+  }
+  return "default";
+}
+
+// Fixed contrast references, independent of the editor theme.
+const DARK = "#181818";
+const LIGHT = "#f2f2f2";
+
+/** Preview-only paint. Reset releases the page's original CSS background. */
+export function viewerBackground(
+  stage: HTMLElement,
+  tools: HTMLElement,
+  onChange: (value: ViewerBackground) => void,
+  image?: HTMLElement | null
+): { restore: (value: unknown) => void } {
+  let value: ViewerBackground = "default";
+  const button = document.createElement("button");
+  button.className = "px-btn";
+  button.dataset.variant = "ghost";
+  button.dataset.size = "icon-sm";
+  button.dataset.tipSide = "top";
+  button.setAttribute("aria-label", "Viewer background");
+  button.setAttribute("aria-haspopup", "dialog");
+  button.append(iconEl("palette"));
+  tools.append(button);
+
+  const restore = (saved: unknown): void => {
+    value = readViewerBackground(saved);
+    const color = value === "dark" ? DARK : value === "light" ? LIGHT : value;
+    if (value === "default") {
+      stage.style.background = "";
+      if (image) image.style.background = "";
+    } else {
+      stage.style.background = color;
+      // The DDS checkerboard is on the image itself, above the stage.
+      if (image) image.style.background = "none";
+    }
+    const label = value.startsWith("#") ? value : value[0].toUpperCase() + value.slice(1);
+    button.dataset.tip = `Viewer background: ${label}`;
+  };
+  const choose = (next: ViewerBackground): void => {
+    restore(next);
+    onChange(value);
+  };
+  button.onclick = () => {
+    menu(
+      button,
+      [
+        { value: "dark", label: "Dark", swatch: DARK },
+        { value: "light", label: "Light", swatch: LIGHT },
+        { value: "custom", label: "Custom color…", swatch: value.startsWith("#") ? value : undefined },
+        { value: "default", label: "Reset to default" },
+      ],
+      {
+        value: value.startsWith("#") ? "custom" : value,
+        width: 190,
+        onPick: (picked) => {
+          if (picked !== "custom") {
+            choose(readViewerBackground(picked));
+            return;
+          }
+          const initial = hexToRgb(value === "light" ? LIGHT : value === "dark" ? DARK : value);
+          colorPicker(button, initial ?? [128, 128, 128], {
+            onChange: (rgb) => choose(readViewerBackground(rgbToHex(rgb))),
+          });
+          const input = document.querySelector<HTMLInputElement>(".px-picker input");
+          input?.setAttribute("aria-label", "Custom background color (hex)");
+          input?.focus();
+          input?.select();
+        },
+      }
+    );
+  };
+  restore(value);
+  return { restore };
+}

--- a/packages/vscode/test/dashboardActions.test.ts
+++ b/packages/vscode/test/dashboardActions.test.ts
@@ -33,6 +33,7 @@ describe("visibleActionGroups", () => {
       "px.openWiki",
       "px.openCredits",
       "px.showExamplesWiki",
+      "px.exportSnippets",
     ]);
     expect(groups.map((g) => g.label)).toEqual(["View", "Share", "Info", "Create", "Test & Troubleshoot"]);
     // The wiki rows moved out of View, they are not listed twice.

--- a/packages/vscode/test/guiEditorPackaging.test.ts
+++ b/packages/vscode/test/guiEditorPackaging.test.ts
@@ -58,9 +58,14 @@ describe("the webview bundles are built by the compile chain", () => {
     // name), so the guarded invariant is the helper call plus the exact name
     // the build produces.
     for (const name of apps) {
-      const panel = fs.readFileSync(path.join(WEBVIEWS_DIR, name, "panel.ts"), "utf8");
-      expect(panel, `${name}/panel.ts`).toContain("bundleUri(");
-      expect(panel, `${name}/panel.ts`).toContain(`"${name}"`);
+      // DDS uses a custom editor provider rather than a command-created panel.
+      const host =
+        name === "ddsPreview"
+          ? path.join(PKG_ROOT, "src", "ddsEditor.ts")
+          : path.join(WEBVIEWS_DIR, name, "panel.ts");
+      const panel = fs.readFileSync(host, "utf8");
+      expect(panel, host).toContain("bundleUri(");
+      expect(panel, host).toContain(`"${name}"`);
     }
   });
 });

--- a/packages/vscode/test/snippetCatalogueHtml.test.ts
+++ b/packages/vscode/test/snippetCatalogueHtml.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { JSDOM } from "jsdom";
+import { snippetCatalogueHtml } from "../src/snippetCatalogueHtml";
+import type { SnippetCatalogueResult } from "@px-lsp/protocol/protocol";
+
+const result: SnippetCatalogueResult = {
+  gameId: "test",
+  gameName: "Test game",
+  generatedAt: "2026-09-09",
+  indexing: false,
+  entries: [
+    {
+      id: "engine:test",
+      label: "set_variable",
+      category: "Engine",
+      detail: "effect",
+      variants: [
+        {
+          label: "Minimal",
+          snippet: "set_variable = {\n name = $1\n}",
+          plain: "set_variable = {\n name = \n}",
+          preview:
+            "**Insertion preview**\n\n```paradox\nset_variable = {\n name = <name>\n}\n```\n\n**Expected values**\n\n| Field | From documentation |\n| --- | --- |\n| name | Variable name |",
+        },
+        {
+          label: "Examples",
+          snippet: "set_variable = { name = ${1:X} }",
+          plain: "set_variable = { name = X }",
+          preview: "```paradox\nset_variable = { name = X }\n```",
+        },
+      ],
+    },
+    {
+      id: "definition:test",
+      label: "new test",
+      category: "Definitions",
+      detail: "measured",
+      variants: [
+        {
+          label: "Template",
+          snippet: "test = $1",
+          plain: "test = ",
+          preview: "```paradox\ntest = <value>\n```",
+        },
+      ],
+    },
+  ],
+};
+const doms: JSDOM[] = [];
+afterEach(() => doms.splice(0).forEach((dom) => dom.window.close()));
+function boot(data = result) {
+  const dom = new JSDOM(snippetCatalogueHtml(data), { runScripts: "dangerously" });
+  doms.push(dom);
+  return dom;
+}
+
+describe("printable snippet catalogue", () => {
+  it("filters the complete list, shows hints and switches to raw snippet syntax", () => {
+    const dom = boot(),
+      doc = dom.window.document;
+    const search = doc.querySelector<HTMLInputElement>("#search")!;
+    search.value = "variable";
+    search.dispatchEvent(new dom.window.Event("input"));
+    expect(doc.querySelector("#count")!.textContent).toContain("1 of 2");
+    const item = doc.querySelector("details")!;
+    item.open = true;
+    item.dispatchEvent(new dom.window.Event("toggle"));
+    expect(item.querySelector("table")!.textContent).toContain("Variable name");
+    const stops = doc.querySelector<HTMLInputElement>("#stops")!;
+    stops.checked = true;
+    stops.dispatchEvent(new dom.window.Event("change"));
+    expect(item.querySelector("pre")!.textContent).toContain("$1");
+    const mode = doc.querySelector<HTMLSelectElement>("#mode")!;
+    mode.value = "Examples";
+    mode.dispatchEvent(new dom.window.Event("change"));
+    expect(item.querySelector("pre")!.textContent).toContain("${1:X}");
+    mode.value = "All variants";
+    mode.dispatchEvent(new dom.window.Event("change"));
+    expect(item.querySelectorAll("pre")).toHaveLength(2);
+  });
+
+  it("expands every matching entry for printing and restores the open state", () => {
+    const dom = boot(),
+      doc = dom.window.document;
+    const print = vi.fn();
+    dom.window.print = print;
+    doc.querySelector<HTMLButtonElement>("#print")!.click();
+    expect(print).toHaveBeenCalledOnce();
+    dom.window.dispatchEvent(new dom.window.Event("beforeprint"));
+    expect(doc.querySelectorAll("details[open]")).toHaveLength(2);
+    expect(doc.querySelectorAll("pre")).toHaveLength(2);
+    dom.window.dispatchEvent(new dom.window.Event("afterprint"));
+    expect(doc.querySelectorAll("details[open]")).toHaveLength(0);
+  });
+
+  it("copies insertion text and keeps game documentation inert", async () => {
+    const malicious = structuredClone(result);
+    malicious.entries[0].label = '</script><img src=x onerror="window.injected=true">';
+    malicious.entries[0].variants[0].preview += '\n| attack | <img src=x onerror="window.injected=true"> |';
+    const dom = boot(malicious),
+      doc = dom.window.document;
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(dom.window.navigator, "clipboard", { value: { writeText } });
+    const item = doc.querySelector("details")!;
+    item.open = true;
+    item.dispatchEvent(new dom.window.Event("toggle"));
+    item.querySelector<HTMLButtonElement>("button")!.click();
+    await Promise.resolve();
+    expect(writeText).toHaveBeenCalledWith(result.entries[0].variants[0].plain);
+    expect(doc.querySelector("img")).toBeNull();
+    expect(doc.querySelectorAll("script")).toHaveLength(2);
+  });
+});

--- a/packages/vscode/test/viewerBackground.test.ts
+++ b/packages/vscode/test/viewerBackground.test.ts
@@ -1,0 +1,156 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { buildSync } from "esbuild";
+import { JSDOM, VirtualConsole } from "jsdom";
+import * as path from "path";
+import { flagBuilderHtml } from "../src/webviews/flagBuilder/html";
+import { coaDesignerHtml } from "../src/webviews/coaDesigner/html";
+import { ddsPreviewHtml } from "../src/webviews/ddsPreview/html";
+import type { FlagDatabase } from "../src/webviews/flagBuilder/messages";
+
+const db: FlagDatabase = {
+  gameName: "Test",
+  textures: { patterns: [], colored_emblems: [], textured_emblems: [] },
+  namedColors: {},
+  flags: [],
+  definitions: {},
+  gameMissing: true,
+};
+const doms: JSDOM[] = [];
+afterEach(() => doms.splice(0).forEach((dom) => dom.window.close()));
+
+function boot(name: "flagBuilder" | "coaDesigner" | "ddsPreview", error: string | null = null) {
+  const options = { scriptSrc: "app.js", nonce: "test", csp: "" };
+  const html =
+    name === "flagBuilder"
+      ? flagBuilderHtml(options)
+      : name === "coaDesigner"
+        ? coaDesignerHtml(options)
+        : ddsPreviewHtml({
+            ...options,
+            name: "test.dds",
+            meta: "",
+            dataUri: "data:image/png;base64,",
+            error,
+          });
+  const bundle = buildSync({
+    entryPoints: [path.join(__dirname, "../src/webviews", name, "app/main.ts")],
+    bundle: true,
+    write: false,
+    platform: "browser",
+    format: "iife",
+  }).outputFiles[0].text;
+  const posted: { type: string; value?: string; state?: { background?: string }; text?: string }[] = [];
+  const errors: string[] = [];
+  const virtualConsole = new VirtualConsole();
+  virtualConsole.on("jsdomError", (e: Error) => errors.push(e.message));
+  const dom = new JSDOM(
+    html.replace(/<script[^>]+src="app.js"><\/script>/, () => `<script>${bundle}</script>`),
+    {
+      runScripts: "dangerously",
+      url: "http://localhost/",
+      virtualConsole,
+      beforeParse(win) {
+        const w = win as unknown as Record<string, unknown>;
+        w.acquireVsCodeApi = () => ({
+          postMessage: (message: (typeof posted)[number]) => posted.push(message),
+        });
+        // jsdom lacks layout, canvas rendering and observers; the app and its events are real.
+        win.HTMLCanvasElement.prototype.getContext = (() =>
+          new Proxy(
+            {},
+            {
+              get: () => () => undefined,
+            }
+          )) as unknown as HTMLCanvasElement["getContext"];
+        w.IntersectionObserver = w.ResizeObserver = class {
+          observe(): void {}
+          unobserve(): void {}
+          disconnect(): void {}
+        };
+        win.HTMLElement.prototype.scrollIntoView = () => undefined;
+      },
+    }
+  );
+  doms.push(dom);
+  const { document } = dom.window;
+  const push = (data: unknown): void => {
+    dom.window.dispatchEvent(new dom.window.MessageEvent("message", { data }));
+  };
+  push(
+    name === "ddsPreview"
+      ? { type: "background", value: "light" }
+      : {
+          type: "init",
+          db,
+          mods: [],
+          library: { dir: "", chosen: false },
+          ui: { panelWidth: 340, panelCollapsed: false, background: "light" },
+        }
+  );
+  const choose = (label: string): void => {
+    document.querySelector<HTMLButtonElement>('[aria-label="Viewer background"]')!.click();
+    const row = [...document.querySelectorAll<HTMLElement>('[role="option"]')].find(
+      (el) => el.textContent === label
+    );
+    expect(row).toBeDefined();
+    row!.click();
+  };
+  return { dom, document, posted, errors, choose, push };
+}
+
+describe.each(["flagBuilder", "coaDesigner", "ddsPreview"] as const)("%s viewer background", (name) => {
+  it("restores a preference, previews presets and custom colors, and resets without editing the content", async () => {
+    const app = boot(name);
+    const stage = app.document.getElementById("stage")!;
+    const image = app.document.getElementById("img");
+    const pixels = image?.getAttribute("src");
+    const copy = app.document.getElementById("copy");
+    copy?.click();
+    const script = [...app.posted].reverse().find((m) => m.type === "copy")?.text;
+    expect(stage.style.background).toBe("rgb(242, 242, 242)");
+    expect(app.document.querySelector('#stageTools [aria-label="Viewer background"]')).not.toBeNull();
+
+    app.choose("Dark");
+    expect(stage.style.background).toBe("rgb(24, 24, 24)");
+    if (image) expect(image.style.background).toBe("none");
+    app.choose("Light");
+    expect(stage.style.background).toBe("rgb(242, 242, 242)");
+    app.choose("Custom color…");
+    const input = app.document.querySelector<HTMLInputElement>(".px-picker input")!;
+    expect(app.document.activeElement).toBe(input);
+    input.value = "#376694";
+    input.dispatchEvent(new app.dom.window.Event("input", { bubbles: true }));
+    expect(stage.style.background).toBe("rgb(55, 102, 148)");
+    const saved = [...app.posted]
+      .reverse()
+      .find((m) => m.type === (name === "ddsPreview" ? "background" : "uiState"));
+    expect(saved?.state?.background ?? saved?.value).toBe("#376694");
+    input.value = "#nope";
+    input.dispatchEvent(new app.dom.window.Event("input", { bubbles: true }));
+    expect(stage.style.background).toBe("rgb(55, 102, 148)");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    app.dom.window.document.dispatchEvent(
+      new app.dom.window.KeyboardEvent("keydown", { key: "Escape", bubbles: true })
+    );
+    expect(app.document.querySelector(".px-popover")).toBeNull();
+
+    app.choose("Reset to default");
+    expect(stage.style.background).toBe("");
+    if (image) {
+      expect(image.style.background).toBe("");
+      expect(image.getAttribute("src")).toBe(pixels);
+      app.document.getElementById("savePng")!.click();
+      expect(app.posted.at(-1)?.type).toBe("savePng");
+    }
+    copy?.click();
+    expect([...app.posted].reverse().find((m) => m.type === "copy")?.text).toBe(script);
+    expect(app.errors).toEqual([]);
+  });
+});
+
+it("DDS decode errors still show the background tools and accept restored preferences", () => {
+  const app = boot("ddsPreview", "Preview failed");
+  expect(app.document.querySelector(".err")?.textContent).toBe("Preview failed");
+  app.choose("Dark");
+  expect(app.errors).toEqual([]);
+});


### PR DESCRIPTION
## Summary

- Add minimal, example, and names-only completion modes with insertion previews and expected-value hints.
- Export generated snippets to a searchable, printable HTML catalogue.
- Add dark, light, and custom backgrounds to flag, coat-of-arms, and DDS previews.
- Update protocol, embedding, release, changelog, and game-update documentation.

## Testing

- Added focused server tests for completion insertion, previews, snippet catalogues, and LSP smoke coverage.
- Added VS Code tests for catalogue rendering and viewer background preferences.
- Not run in this change request.

## Summary by Sourcery

Expand completion customization and generated snippet exports while adding configurable preview backgrounds across the visual asset tools.

New Features:
- Add configurable minimal, examples, and names-only completion modes with snippet-aware insertion and documentation previews.
- Add an uncapped snippet catalogue protocol request and a VS Code command that exports searchable, printable HTML containing generated variants and value hints.
- Add dark, light, and custom background preferences to flag, coat-of-arms, and DDS previews.

Enhancements:
- Share completion insertion and preview behavior between editor completions and catalogue exports, including plain-text fallback for clients without snippet support.
- Persist viewer background choices per workspace and modernize DDS preview bundling.

Build:
- Bump the toolkit, server, protocol, and VS Code package versions for the 0.4.3 release.

Documentation:
- Document completion modes, snippet catalogue protocol usage, viewer backgrounds, and major game-update maintenance procedures.
- Add 0.4.3 beta release notes and refresh user-facing toolkit guidance.

Tests:
- Add focused server, LSP smoke, HTML catalogue, and viewer background coverage for the new functionality.

Chores:
- Record performance history updates associated with the release.